### PR TITLE
fix: Resolve annotation session loading errors

### DIFF
--- a/app/api/annotations/sessions/route.ts
+++ b/app/api/annotations/sessions/route.ts
@@ -40,6 +40,8 @@ export async function GET(request: NextRequest) {
             id: true,
             weedType: true,
             confidence: true,
+            coordinates: true,
+            notes: true,
             verified: true,
             pushedToTraining: true,
             pushedAt: true,
@@ -96,11 +98,35 @@ export async function POST(request: NextRequest) {
       where: {
         assetId,
         status: 'IN_PROGRESS'
+      },
+      include: {
+        asset: {
+          select: {
+            id: true,
+            fileName: true,
+            storageUrl: true,
+            imageWidth: true,
+            imageHeight: true,
+            gpsLatitude: true,
+            gpsLongitude: true,
+            altitude: true,
+            gimbalPitch: true,
+            gimbalRoll: true,
+            gimbalYaw: true,
+            project: {
+              select: {
+                name: true,
+                location: true,
+              }
+            }
+          }
+        },
+        annotations: true,
       }
     });
-    
+
     if (existingSession) {
-      // Return existing session instead of creating new one
+      // Return existing session with full data
       return NextResponse.json(existingSession);
     }
     


### PR DESCRIPTION
## Summary
Fixes the "Failed to load annotation session" error when trying to annotate images.

## Root Cause
Two bugs were causing the error:

1. **Frontend**: Only checked `response.ok` once after potentially two API calls, missing errors from the GET request
2. **Backend**: When returning an existing IN_PROGRESS session from POST, the response didn't include the `asset` and `annotations` data needed by the frontend

## Changes

### `app/annotate/[assetId]/page.tsx`
- Check `response.ok` for both GET and POST requests separately
- Handle case where GET returns error object instead of array
- Validate session has required `asset` data before setting state
- Add console.error logging for debugging

### `app/api/annotations/sessions/route.ts`
- Include full `asset` and `annotations` data when returning existing session from POST
- Add `coordinates` and `notes` fields to annotation response (needed for canvas rendering)

## Test Plan
- [ ] Navigate to Images page
- [ ] Click "Annotate" on any image
- [ ] Verify annotation session loads without error
- [ ] Verify existing annotations (if any) display on canvas
- [ ] Create new annotation and verify it saves

🤖 Generated with [Claude Code](https://claude.com/claude-code)