### PR TITLE
fix: add missing listParts and abortMultipartUpload handlers for Uppy S3 uploads

### DIFF
--- a/app/api/s3/multipart/abort/route.ts
+++ b/app/api/s3/multipart/abort/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth/config";
+import { S3Service } from "@/lib/services/s3";
+import { z } from "zod";
+
+const requestSchema = z.object({
+  key: z.string().min(1, "key is required"),
+  uploadId: z.string().min(1, "uploadId is required"),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const parsed = requestSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: "Invalid request payload",
+          details: parsed.error.flatten(),
+        },
+        { status: 400 },
+      );
+    }
+
+    const { key, uploadId } = parsed.data;
+
+    await S3Service.abortMultipartUpload({ key, uploadId });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Failed to abort multipart upload:", error);
+    return NextResponse.json(
+      {
+        error: "Failed to abort multipart upload",
+        details: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/s3/multipart/list-parts/route.ts
+++ b/app/api/s3/multipart/list-parts/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth/config";
+import { S3Service } from "@/lib/services/s3";
+import { z } from "zod";
+
+const requestSchema = z.object({
+  key: z.string().min(1, "key is required"),
+  uploadId: z.string().min(1, "uploadId is required"),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const parsed = requestSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: "Invalid request payload",
+          details: parsed.error.flatten(),
+        },
+        { status: 400 },
+      );
+    }
+
+    const { key, uploadId } = parsed.data;
+
+    const parts = await S3Service.listParts({ key, uploadId });
+
+    return NextResponse.json({ parts });
+  } catch (error) {
+    console.error("Failed to list multipart upload parts:", error);
+    return NextResponse.json(
+      {
+        error: "Failed to list multipart upload parts",
+        details: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/components/UppyUploader.tsx
+++ b/components/UppyUploader.tsx
@@ -170,6 +170,24 @@ export function UppyUploader({
 
         return (await response.json()) as CreateMultipartResponse;
       },
+      listParts: async (_file, { uploadId, key, signal }) => {
+        const response = await fetch("/api/s3/multipart/list-parts", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          signal,
+          body: JSON.stringify({ uploadId, key }),
+        });
+
+        if (!response.ok) {
+          const errorBody = await response.json().catch(() => ({}));
+          const message =
+            errorBody?.error || "Failed to list multipart upload parts.";
+          throw new Error(message);
+        }
+
+        const data = await response.json();
+        return data.parts || [];
+      },
       signPart: async (_file, { uploadId, key, partNumber, body, signal }) => {
         const response = await fetch("/api/s3/multipart/sign", {
           method: "POST",
@@ -191,6 +209,21 @@ export function UppyUploader({
         }
 
         return response.json();
+      },
+      abortMultipartUpload: async (_file, { uploadId, key, signal }) => {
+        const response = await fetch("/api/s3/multipart/abort", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          signal,
+          body: JSON.stringify({ uploadId, key }),
+        });
+
+        if (!response.ok) {
+          const errorBody = await response.json().catch(() => ({}));
+          const message =
+            errorBody?.error || "Failed to abort multipart upload.";
+          throw new Error(message);
+        }
       },
       completeMultipartUpload: async (_file, { uploadId, key, parts, signal }) => {
         const response = await fetch("/api/s3/multipart/complete", {


### PR DESCRIPTION
## Summary
Fixes the upload error: "Expected a `endpoint` option containing a URL, or if you are not using Companion, a custom `listParts` implementation."

The Uppy `@uppy/aws-s3` plugin requires `listParts` and `abortMultipartUpload` handlers for resumable multipart uploads. When uploads are interrupted or retried, Uppy needs to know which parts have already been uploaded to resume correctly.

## Changes
- **S3 Service**: Added `listParts` method using AWS SDK `ListPartsCommand`
- **New API endpoint**: `/api/s3/multipart/list-parts` - returns uploaded parts for a multipart upload
- **New API endpoint**: `/api/s3/multipart/abort` - aborts a failed multipart upload
- **UppyUploader**: Added `listParts` and `abortMultipartUpload` handlers to the AwsS3 plugin config

## Root Cause
When uploading multiple images, if any upload fails mid-way, Uppy tries to determine which parts have already been uploaded so it can resume. Without the `listParts` handler, this fails with the error message the user reported.

## Test plan
- [ ] Upload multiple images (10+) to verify normal uploads work
- [ ] Simulate a network interruption mid-upload to verify retry/resume works
- [ ] Verify all files process correctly after upload completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)