### PR TITLE
fix: handle NoSuchUpload error on server-side for listParts and abort

### DIFF
--- a/app/api/s3/multipart/abort/route.ts
+++ b/app/api/s3/multipart/abort/route.ts
@@ -35,6 +35,17 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ success: true });
   } catch (error) {
+    // Handle NoSuchUpload gracefully - upload may already be completed or aborted
+    const err = error as { name?: string; Code?: string; message?: string };
+    if (
+      err?.name === "NoSuchUpload" ||
+      err?.Code === "NoSuchUpload" ||
+      err?.message?.includes("NoSuchUpload")
+    ) {
+      console.debug("abortMultipartUpload: NoSuchUpload - already completed/aborted");
+      return NextResponse.json({ success: true });
+    }
+
     console.error("Failed to abort multipart upload:", error);
     return NextResponse.json(
       {


### PR DESCRIPTION
## Summary
Fixes the persistent "Failed to list multipart upload parts" error that was causing all uploads to fail.

## Root Cause
The previous fix (PR #45) only handled `NoSuchUpload` on the client side, but the server was still returning 500 errors before the client could handle them. This caused Uppy to fail all uploads.

## Fix
Both server-side endpoints now catch `NoSuchUpload` errors and return success responses:

- **`/api/s3/multipart/list-parts`**: Returns `{ parts: [] }` instead of 500 error
- **`/api/s3/multipart/abort`**: Returns `{ success: true }` instead of 500 error

This handles cases where:
1. Upload was already completed (S3 automatically deletes the session)
2. Upload was already aborted
3. Upload ID is invalid/expired

## Test plan
- [ ] Upload 10 images
- [ ] Verify no "Failed to list multipart upload parts" error
- [ ] Verify all uploads complete successfully
- [ ] Verify "Next Steps" UI appears after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)