### PR TITLE
feat: Roboflow-style annotation UI redesign

### DIFF
--- a/components/annotation/AnnotationList.tsx
+++ b/components/annotation/AnnotationList.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { getClassColor } from "./ClassSelector";
+
+interface Annotation {
+  id: string;
+  weedType: string;
+  confidence: string;
+  notes?: string;
+  verified?: boolean;
+  pushedToTraining?: boolean;
+}
+
+interface AnnotationListProps {
+  annotations: Annotation[];
+  selectedId?: string | null;
+  onSelect: (id: string | null) => void;
+  onDelete: (id: string) => void;
+  className?: string;
+}
+
+export function AnnotationList({
+  annotations,
+  selectedId,
+  onSelect,
+  onDelete,
+  className,
+}: AnnotationListProps) {
+  if (annotations.length === 0) {
+    return (
+      <div className={cn("bg-gray-100 rounded-lg p-3", className)}>
+        <div className="text-xs font-medium text-gray-500 mb-2">
+          Annotations
+        </div>
+        <p className="text-xs text-gray-400 text-center py-4">
+          No annotations yet.
+          <br />
+          Click on the image to start.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("bg-gray-100 rounded-lg p-2", className)}>
+      <div className="text-xs font-medium text-gray-500 px-2 pb-2">
+        Annotations
+        <span className="text-gray-400 ml-1">({annotations.length})</span>
+      </div>
+      <div className="space-y-0.5 max-h-64 overflow-y-auto">
+        {annotations.map((annotation, index) => {
+          const isSelected = selectedId === annotation.id;
+          const color = getClassColor(annotation.weedType);
+
+          return (
+            <div
+              key={annotation.id}
+              className={cn(
+                "group flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer transition-all",
+                isSelected
+                  ? "bg-blue-100 ring-1 ring-blue-300"
+                  : "hover:bg-gray-200"
+              )}
+              onClick={() => onSelect(isSelected ? null : annotation.id)}
+            >
+              {/* Index and color */}
+              <div className="flex items-center gap-1.5 flex-shrink-0">
+                <span className="text-[10px] text-gray-400 w-3 text-right">
+                  {index + 1}
+                </span>
+                <div
+                  className="w-2.5 h-2.5 rounded"
+                  style={{ backgroundColor: color }}
+                />
+              </div>
+
+              {/* Class name */}
+              <span className="flex-1 text-sm truncate">
+                {annotation.weedType.replace("Suspected ", "")}
+              </span>
+
+              {/* Confidence badge */}
+              <span className={cn(
+                "text-[10px] px-1 py-0.5 rounded",
+                annotation.confidence === "CERTAIN" && "bg-green-100 text-green-700",
+                annotation.confidence === "LIKELY" && "bg-yellow-100 text-yellow-700",
+                annotation.confidence === "UNCERTAIN" && "bg-gray-200 text-gray-600"
+              )}>
+                {annotation.confidence.slice(0, 1)}
+              </span>
+
+              {/* Status indicators */}
+              {annotation.pushedToTraining && (
+                <span className="text-[9px] bg-purple-100 text-purple-600 px-1 rounded">
+                  T
+                </span>
+              )}
+              {annotation.verified && !annotation.pushedToTraining && (
+                <span className="text-[9px] bg-blue-100 text-blue-600 px-1 rounded">
+                  V
+                </span>
+              )}
+
+              {/* Delete button */}
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-5 w-5 p-0 opacity-0 group-hover:opacity-100 transition-opacity text-red-500 hover:text-red-700 hover:bg-red-50"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete(annotation.id);
+                }}
+              >
+                <Trash2 className="h-3 w-3" />
+              </Button>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Legend */}
+      <div className="mt-2 pt-2 border-t border-gray-200 px-2">
+        <div className="flex items-center gap-3 text-[10px] text-gray-400">
+          <span className="flex items-center gap-1">
+            <span className="px-1 bg-green-100 text-green-700 rounded">C</span>
+            Certain
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="px-1 bg-yellow-100 text-yellow-700 rounded">L</span>
+            Likely
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="px-1 bg-gray-200 text-gray-600 rounded">U</span>
+            Unsure
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/annotation/ClassSelector.tsx
+++ b/components/annotation/ClassSelector.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+export interface WeedClass {
+  id: string;
+  name: string;
+  color: string;
+  hotkey?: number;
+}
+
+// Default classes - can be overridden with Roboflow-synced classes
+export const DEFAULT_WEED_CLASSES: WeedClass[] = [
+  { id: "lantana", name: "Lantana", color: "#22c55e", hotkey: 1 },
+  { id: "wattle", name: "Wattle", color: "#eab308", hotkey: 2 },
+  { id: "bellyache", name: "Bellyache Bush", color: "#ef4444", hotkey: 3 },
+  { id: "calitropis", name: "Calitropis", color: "#3b82f6", hotkey: 4 },
+  { id: "pine", name: "Pine Sapling", color: "#a855f7", hotkey: 5 },
+  { id: "unknown", name: "Unknown Weed", color: "#9ca3af", hotkey: 0 },
+];
+
+interface ClassButtonProps {
+  weedClass: WeedClass;
+  active?: boolean;
+  onClick: () => void;
+}
+
+function ClassButton({ weedClass, active, onClick }: ClassButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "w-full flex items-center gap-2 px-2 py-1.5 rounded text-sm transition-all",
+        "hover:bg-gray-200",
+        active && "bg-gray-200 ring-2 ring-blue-500 ring-offset-1"
+      )}
+      title={`${weedClass.name}${weedClass.hotkey !== undefined ? ` (Press ${weedClass.hotkey})` : ""}`}
+    >
+      {/* Color indicator */}
+      <div
+        className="w-3 h-3 rounded flex-shrink-0"
+        style={{ backgroundColor: weedClass.color }}
+      />
+
+      {/* Class name */}
+      <span className="flex-1 text-left truncate">{weedClass.name}</span>
+
+      {/* Hotkey badge */}
+      {weedClass.hotkey !== undefined && (
+        <kbd className={cn(
+          "px-1.5 py-0.5 text-[10px] font-mono rounded min-w-[18px] text-center",
+          active ? "bg-blue-500 text-white" : "bg-gray-100 text-gray-500"
+        )}>
+          {weedClass.hotkey}
+        </kbd>
+      )}
+    </button>
+  );
+}
+
+interface ClassSelectorProps {
+  classes?: WeedClass[];
+  selectedClass: string;
+  onClassSelect: (classId: string) => void;
+  className?: string;
+}
+
+export function ClassSelector({
+  classes = DEFAULT_WEED_CLASSES,
+  selectedClass,
+  onClassSelect,
+  className,
+}: ClassSelectorProps) {
+  return (
+    <div className={cn("bg-gray-100 rounded-lg p-2", className)}>
+      <div className="text-xs font-medium text-gray-500 px-2 pb-2">
+        Classes
+        <span className="text-gray-400 ml-1">(1-9 to select)</span>
+      </div>
+      <div className="space-y-0.5">
+        {classes.map((weedClass) => (
+          <ClassButton
+            key={weedClass.id}
+            weedClass={weedClass}
+            active={selectedClass === weedClass.id || selectedClass === weedClass.name}
+            onClick={() => onClassSelect(weedClass.name)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Get class by hotkey number
+ */
+export function getClassByHotkey(
+  hotkey: number,
+  classes: WeedClass[] = DEFAULT_WEED_CLASSES
+): WeedClass | undefined {
+  return classes.find((c) => c.hotkey === hotkey);
+}
+
+/**
+ * Get color for a class name
+ */
+export function getClassColor(
+  className: string,
+  classes: WeedClass[] = DEFAULT_WEED_CLASSES
+): string {
+  const found = classes.find(
+    (c) => c.name.toLowerCase() === className.toLowerCase() || c.id === className
+  );
+  return found?.color || "#9ca3af";
+}

--- a/components/annotation/Filmstrip.tsx
+++ b/components/annotation/Filmstrip.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useRef, useEffect, useCallback } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface Asset {
+  id: string;
+  fileName: string;
+  storageUrl: string;
+}
+
+interface FilmstripProps {
+  assets: Asset[];
+  currentIndex: number;
+  onSelect: (index: number) => void;
+  annotationCounts?: Record<string, number>;
+  className?: string;
+}
+
+export function Filmstrip({
+  assets,
+  currentIndex,
+  onSelect,
+  annotationCounts = {},
+  className,
+}: FilmstripProps) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  // Auto-scroll to keep current item visible
+  useEffect(() => {
+    const currentItem = itemRefs.current[currentIndex];
+    if (currentItem && scrollContainerRef.current) {
+      const container = scrollContainerRef.current;
+      const itemLeft = currentItem.offsetLeft;
+      const itemWidth = currentItem.offsetWidth;
+      const containerWidth = container.clientWidth;
+      const scrollLeft = container.scrollLeft;
+
+      // Check if item is outside visible area
+      if (itemLeft < scrollLeft) {
+        // Item is to the left - scroll to show it with some padding
+        container.scrollTo({
+          left: itemLeft - 16,
+          behavior: "smooth",
+        });
+      } else if (itemLeft + itemWidth > scrollLeft + containerWidth) {
+        // Item is to the right - scroll to show it with some padding
+        container.scrollTo({
+          left: itemLeft + itemWidth - containerWidth + 16,
+          behavior: "smooth",
+        });
+      }
+    }
+  }, [currentIndex]);
+
+  const scrollLeft = useCallback(() => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollBy({
+        left: -200,
+        behavior: "smooth",
+      });
+    }
+  }, []);
+
+  const scrollRight = useCallback(() => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollBy({
+        left: 200,
+        behavior: "smooth",
+      });
+    }
+  }, []);
+
+  if (assets.length === 0) {
+    return (
+      <div className={cn("h-20 bg-gray-100 flex items-center justify-center text-gray-500 text-sm", className)}>
+        No images in this project
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("relative flex items-center bg-gray-900 h-20", className)}>
+      {/* Left scroll button */}
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={scrollLeft}
+        className="absolute left-0 z-10 h-full w-8 bg-gradient-to-r from-gray-900 to-transparent text-white hover:bg-transparent hover:text-white/80 rounded-none"
+      >
+        <ChevronLeft className="h-5 w-5" />
+      </Button>
+
+      {/* Scrollable filmstrip */}
+      <div
+        ref={scrollContainerRef}
+        className="flex-1 overflow-x-auto scrollbar-hide mx-8 py-2"
+        style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+      >
+        <div className="flex gap-1.5 px-2">
+          {assets.map((asset, index) => {
+            const isSelected = index === currentIndex;
+            const annotationCount = annotationCounts[asset.id] || 0;
+
+            return (
+              <button
+                key={asset.id}
+                ref={(el) => {
+                  itemRefs.current[index] = el;
+                }}
+                onClick={() => onSelect(index)}
+                className={cn(
+                  "relative flex-shrink-0 w-16 h-14 rounded overflow-hidden transition-all",
+                  "hover:ring-2 hover:ring-blue-400",
+                  isSelected
+                    ? "ring-2 ring-blue-500 ring-offset-2 ring-offset-gray-900"
+                    : "opacity-60 hover:opacity-100"
+                )}
+                title={`${asset.fileName} (${index + 1}/${assets.length})`}
+              >
+                {/* Thumbnail */}
+                <img
+                  src={asset.storageUrl}
+                  alt={asset.fileName}
+                  className="w-full h-full object-cover"
+                  loading="lazy"
+                />
+
+                {/* Index number */}
+                <span className="absolute bottom-0 left-0 right-0 text-[10px] text-white bg-black/60 text-center py-0.5 font-mono">
+                  {index + 1}
+                </span>
+
+                {/* Annotation count badge */}
+                {annotationCount > 0 && (
+                  <span className="absolute top-0.5 right-0.5 bg-green-500 text-white text-[9px] font-bold px-1 py-0.5 rounded-full min-w-[14px] text-center leading-none">
+                    {annotationCount}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Right scroll button */}
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={scrollRight}
+        className="absolute right-0 z-10 h-full w-8 bg-gradient-to-l from-gray-900 to-transparent text-white hover:bg-transparent hover:text-white/80 rounded-none"
+      >
+        <ChevronRight className="h-5 w-5" />
+      </Button>
+
+      {/* Progress indicator */}
+      <div className="absolute bottom-0 left-8 right-8 h-0.5 bg-gray-700">
+        <div
+          className="h-full bg-blue-500 transition-all duration-300"
+          style={{ width: `${((currentIndex + 1) / assets.length) * 100}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/annotation/HotkeyReference.tsx
+++ b/components/annotation/HotkeyReference.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { HOTKEY_DEFINITIONS } from "@/lib/hooks/useAnnotationHotkeys";
+
+interface HotkeyReferenceProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function HotkeyReference({ open, onClose }: HotkeyReferenceProps) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div className="relative bg-white rounded-lg shadow-xl max-w-md w-full mx-4 overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b bg-gray-50">
+          <h2 className="font-semibold text-gray-900">Keyboard Shortcuts</h2>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onClose}
+            className="h-8 w-8 p-0"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        {/* Content */}
+        <div className="p-4 max-h-[60vh] overflow-y-auto">
+          <div className="space-y-4">
+            {HOTKEY_DEFINITIONS.map((category) => (
+              <div key={category.category}>
+                <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">
+                  {category.category}
+                </h3>
+                <div className="space-y-1">
+                  {category.shortcuts.map((shortcut) => (
+                    <div
+                      key={shortcut.key}
+                      className="flex items-center justify-between py-1.5 px-2 rounded hover:bg-gray-50"
+                    >
+                      <span className="text-sm text-gray-700">
+                        {shortcut.action}
+                      </span>
+                      <kbd className="px-2 py-1 text-xs font-mono bg-gray-100 text-gray-600 rounded border border-gray-200">
+                        {shortcut.key}
+                      </kbd>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="px-4 py-3 border-t bg-gray-50 text-center">
+          <p className="text-xs text-gray-500">
+            Press <kbd className="px-1.5 py-0.5 bg-gray-200 rounded text-[10px]">H</kbd> or{" "}
+            <kbd className="px-1.5 py-0.5 bg-gray-200 rounded text-[10px]">Esc</kbd> to close
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/annotation/Toolbar.tsx
+++ b/components/annotation/Toolbar.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { Wand2, Pencil, Square, Undo2, Trash2, Check, HelpCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { AnnotationMode } from "@/lib/hooks/useAnnotationHotkeys";
+
+interface ToolButtonProps {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  hotkey?: string;
+  active?: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+}
+
+function ToolButton({
+  icon: Icon,
+  label,
+  hotkey,
+  active,
+  disabled,
+  onClick,
+}: ToolButtonProps) {
+  return (
+    <Button
+      variant={active ? "default" : "ghost"}
+      size="sm"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        "w-full justify-start gap-2 h-9",
+        active && "bg-blue-500 hover:bg-blue-600 text-white"
+      )}
+      title={`${label}${hotkey ? ` (${hotkey})` : ""}`}
+    >
+      <Icon className="h-4 w-4" />
+      <span className="flex-1 text-left text-sm">{label}</span>
+      {hotkey && (
+        <kbd className={cn(
+          "px-1.5 py-0.5 text-[10px] font-mono rounded",
+          active ? "bg-blue-600 text-blue-100" : "bg-gray-200 text-gray-600"
+        )}>
+          {hotkey}
+        </kbd>
+      )}
+    </Button>
+  );
+}
+
+interface ActionButtonProps {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  hotkey?: string;
+  variant?: "default" | "destructive" | "success";
+  disabled?: boolean;
+  onClick: () => void;
+}
+
+function ActionButton({
+  icon: Icon,
+  label,
+  hotkey,
+  variant = "default",
+  disabled,
+  onClick,
+}: ActionButtonProps) {
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        "w-full justify-start gap-2 h-8",
+        variant === "destructive" && "text-red-600 hover:text-red-700 hover:bg-red-50",
+        variant === "success" && "text-green-600 hover:text-green-700 hover:bg-green-50"
+      )}
+      title={`${label}${hotkey ? ` (${hotkey})` : ""}`}
+    >
+      <Icon className="h-4 w-4" />
+      <span className="flex-1 text-left text-xs">{label}</span>
+      {hotkey && (
+        <kbd className="px-1 py-0.5 text-[9px] font-mono bg-gray-100 text-gray-500 rounded">
+          {hotkey}
+        </kbd>
+      )}
+    </Button>
+  );
+}
+
+interface ToolbarProps {
+  mode: AnnotationMode;
+  onModeChange: (mode: AnnotationMode) => void;
+  sam3Available?: boolean;
+  sam3Loading?: boolean;
+  onUndo?: () => void;
+  onDelete?: () => void;
+  onAccept?: () => void;
+  onShowHelp?: () => void;
+  canUndo?: boolean;
+  canDelete?: boolean;
+  canAccept?: boolean;
+  className?: string;
+}
+
+export function Toolbar({
+  mode,
+  onModeChange,
+  sam3Available = true,
+  sam3Loading = false,
+  onUndo,
+  onDelete,
+  onAccept,
+  onShowHelp,
+  canUndo = false,
+  canDelete = false,
+  canAccept = false,
+  className,
+}: ToolbarProps) {
+  return (
+    <div className={cn("w-48 flex flex-col gap-3", className)}>
+      {/* Tool Mode Selection */}
+      <div className="bg-gray-100 rounded-lg p-2 space-y-1">
+        <div className="text-xs font-medium text-gray-500 px-2 pb-1">Tools</div>
+        <ToolButton
+          icon={Wand2}
+          label="AI Segment"
+          hotkey="S"
+          active={mode === "sam3"}
+          disabled={!sam3Available || sam3Loading}
+          onClick={() => onModeChange("sam3")}
+        />
+        <ToolButton
+          icon={Pencil}
+          label="Manual"
+          hotkey="P"
+          active={mode === "manual"}
+          onClick={() => onModeChange("manual")}
+        />
+        <ToolButton
+          icon={Square}
+          label="Few-Shot"
+          hotkey="B"
+          active={mode === "box-exemplar"}
+          disabled={!sam3Available || sam3Loading}
+          onClick={() => onModeChange("box-exemplar")}
+        />
+      </div>
+
+      {/* Quick Actions */}
+      <div className="bg-gray-100 rounded-lg p-2 space-y-0.5">
+        <div className="text-xs font-medium text-gray-500 px-2 pb-1">Actions</div>
+        <ActionButton
+          icon={Check}
+          label="Accept"
+          hotkey="Enter"
+          variant="success"
+          disabled={!canAccept}
+          onClick={() => onAccept?.()}
+        />
+        <ActionButton
+          icon={Undo2}
+          label="Undo"
+          hotkey="Ctrl+Z"
+          disabled={!canUndo}
+          onClick={() => onUndo?.()}
+        />
+        <ActionButton
+          icon={Trash2}
+          label="Delete"
+          hotkey="Del"
+          variant="destructive"
+          disabled={!canDelete}
+          onClick={() => onDelete?.()}
+        />
+      </div>
+
+      {/* Help */}
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={onShowHelp}
+        className="w-full justify-start gap-2 h-8 text-gray-500 hover:text-gray-700"
+      >
+        <HelpCircle className="h-4 w-4" />
+        <span className="flex-1 text-left text-xs">Shortcuts</span>
+        <kbd className="px-1 py-0.5 text-[9px] font-mono bg-gray-100 text-gray-500 rounded">
+          H
+        </kbd>
+      </Button>
+    </div>
+  );
+}

--- a/components/annotation/index.ts
+++ b/components/annotation/index.ts
@@ -1,0 +1,6 @@
+export { Filmstrip } from "./Filmstrip";
+export { Toolbar } from "./Toolbar";
+export { ClassSelector, DEFAULT_WEED_CLASSES, getClassByHotkey, getClassColor } from "./ClassSelector";
+export type { WeedClass } from "./ClassSelector";
+export { AnnotationList } from "./AnnotationList";
+export { HotkeyReference } from "./HotkeyReference";

--- a/lib/hooks/useAnnotationHotkeys.ts
+++ b/lib/hooks/useAnnotationHotkeys.ts
@@ -1,0 +1,230 @@
+"use client";
+
+import { useEffect, useCallback } from "react";
+
+export type AnnotationMode = "sam3" | "manual" | "box-exemplar";
+
+export interface HotkeyHandlers {
+  onNextImage?: () => void;
+  onPrevImage?: () => void;
+  onModeChange?: (mode: AnnotationMode) => void;
+  onClassSelect?: (index: number) => void;
+  onAccept?: () => void;
+  onCancel?: () => void;
+  onDelete?: () => void;
+  onUndo?: () => void;
+  onZoomIn?: () => void;
+  onZoomOut?: () => void;
+  onResetView?: () => void;
+  onToggleHelp?: () => void;
+  disabled?: boolean;
+}
+
+/**
+ * Global keyboard shortcuts for annotation interface
+ *
+ * Shortcuts:
+ * - Arrow Left/Right: Previous/Next image
+ * - S: SAM3 mode
+ * - P: Manual polygon mode
+ * - B: Bounding box mode
+ * - 1-9: Select class by index
+ * - 0: Select "Unknown" class
+ * - Enter: Accept/Save annotation
+ * - Escape: Cancel current action
+ * - Delete/Backspace: Delete selected annotation
+ * - Ctrl+Z / Cmd+Z: Undo last action
+ * - +/=: Zoom in
+ * - -: Zoom out
+ * - Space: Reset view (fit to screen)
+ * - H or ?: Show/hide hotkey reference
+ */
+export function useAnnotationHotkeys({
+  onNextImage,
+  onPrevImage,
+  onModeChange,
+  onClassSelect,
+  onAccept,
+  onCancel,
+  onDelete,
+  onUndo,
+  onZoomIn,
+  onZoomOut,
+  onResetView,
+  onToggleHelp,
+  disabled = false,
+}: HotkeyHandlers) {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (disabled) return;
+
+      // Don't trigger if typing in input, textarea, or contenteditable
+      const target = e.target as HTMLElement;
+      if (
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+
+      // Handle modifier keys
+      const isMod = e.ctrlKey || e.metaKey;
+
+      switch (e.key) {
+        // Image navigation
+        case "ArrowLeft":
+          e.preventDefault();
+          onPrevImage?.();
+          break;
+        case "ArrowRight":
+          e.preventDefault();
+          onNextImage?.();
+          break;
+
+        // Mode selection
+        case "s":
+        case "S":
+          if (!isMod) {
+            e.preventDefault();
+            onModeChange?.("sam3");
+          }
+          break;
+        case "p":
+        case "P":
+          if (!isMod) {
+            e.preventDefault();
+            onModeChange?.("manual");
+          }
+          break;
+        case "b":
+        case "B":
+          if (!isMod) {
+            e.preventDefault();
+            onModeChange?.("box-exemplar");
+          }
+          break;
+
+        // Class selection (1-9 for classes, 0 for Unknown)
+        case "1":
+        case "2":
+        case "3":
+        case "4":
+        case "5":
+        case "6":
+        case "7":
+        case "8":
+        case "9":
+        case "0":
+          if (!isMod) {
+            e.preventDefault();
+            onClassSelect?.(parseInt(e.key));
+          }
+          break;
+
+        // Actions
+        case "Enter":
+          e.preventDefault();
+          onAccept?.();
+          break;
+        case "Escape":
+          e.preventDefault();
+          onCancel?.();
+          break;
+        case "Delete":
+        case "Backspace":
+          // Only prevent default if not in an input
+          if (!isMod) {
+            e.preventDefault();
+            onDelete?.();
+          }
+          break;
+
+        // Undo (Ctrl+Z or Cmd+Z)
+        case "z":
+        case "Z":
+          if (isMod) {
+            e.preventDefault();
+            onUndo?.();
+          }
+          break;
+
+        // Zoom controls
+        case "+":
+        case "=":
+          e.preventDefault();
+          onZoomIn?.();
+          break;
+        case "-":
+          e.preventDefault();
+          onZoomOut?.();
+          break;
+        case " ": // Space
+          e.preventDefault();
+          onResetView?.();
+          break;
+
+        // Help
+        case "h":
+        case "H":
+        case "?":
+          if (!isMod) {
+            e.preventDefault();
+            onToggleHelp?.();
+          }
+          break;
+      }
+    },
+    [
+      disabled,
+      onNextImage,
+      onPrevImage,
+      onModeChange,
+      onClassSelect,
+      onAccept,
+      onCancel,
+      onDelete,
+      onUndo,
+      onZoomIn,
+      onZoomOut,
+      onResetView,
+      onToggleHelp,
+    ]
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+}
+
+/**
+ * Hotkey definitions for display in help modal
+ */
+export const HOTKEY_DEFINITIONS = [
+  { category: "Navigation", shortcuts: [
+    { key: "←", action: "Previous image" },
+    { key: "→", action: "Next image" },
+  ]},
+  { category: "Tools", shortcuts: [
+    { key: "S", action: "SAM3 AI Segment mode" },
+    { key: "P", action: "Manual polygon mode" },
+    { key: "B", action: "Bounding box mode" },
+  ]},
+  { category: "Classes", shortcuts: [
+    { key: "1-9", action: "Select class by number" },
+    { key: "0", action: "Select Unknown class" },
+  ]},
+  { category: "Actions", shortcuts: [
+    { key: "Enter", action: "Accept/Save annotation" },
+    { key: "Escape", action: "Cancel current action" },
+    { key: "Delete", action: "Delete selected annotation" },
+    { key: "Ctrl+Z", action: "Undo last action" },
+  ]},
+  { category: "View", shortcuts: [
+    { key: "+", action: "Zoom in" },
+    { key: "-", action: "Zoom out" },
+    { key: "Space", action: "Reset view (fit to screen)" },
+    { key: "H", action: "Show/hide shortcuts" },
+  ]},
+];


### PR DESCRIPTION
## Summary
Complete redesign of the annotation interface inspired by Roboflow's labeling UX:

- **Larger canvas** (75-80% viewport) for better image visibility
- **Image filmstrip** at top for quick navigation between project images
- **Compact right sidebar** with tool selection, class selector, and annotation list
- **Full keyboard shortcut support** for efficient annotation workflow
- **Zoom controls** in footer with keyboard shortcuts

## Key Features

### Keyboard Shortcuts
| Key | Action |
|-----|--------|
| `←` `→` | Previous/Next image |
| `S` | SAM3 AI Segment mode |
| `P` | Manual polygon mode |
| `B` | Bounding box mode |
| `1-9, 0` | Select class |
| `Enter` | Accept annotation |
| `Escape` | Cancel |
| `Delete` | Delete selected |
| `Ctrl+Z` | Undo |
| `+` `-` | Zoom in/out |
| `Space` | Reset view |
| `H` | Show shortcuts |

### New Components
- `Filmstrip` - Horizontal thumbnail strip with annotation counts and progress bar
- `Toolbar` - Compact tool selection with hotkey indicators
- `ClassSelector` - Class buttons with number hotkeys (1-9, 0)
- `AnnotationList` - Compact list with color coding and quick delete
- `HotkeyReference` - Modal showing all keyboard shortcuts
- `useAnnotationHotkeys` - Centralized keyboard handler hook

## Files Changed
- `app/annotate/[assetId]/page.tsx` - Refactored with new layout
- `components/annotation/*` - New modular components
- `lib/hooks/useAnnotationHotkeys.ts` - Keyboard shortcut handler

## Test plan
- [ ] Navigate to `/annotate/{assetId}` and verify new layout
- [ ] Test filmstrip navigation with clicks and arrow keys
- [ ] Verify keyboard shortcuts work (S/P/B for tools, 1-9 for classes)
- [ ] Test SAM3 annotation workflow with Enter to accept
- [ ] Verify zoom controls (+/-/Space)
- [ ] Press H to show hotkey reference modal
- [ ] Test on different screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)