### PR TITLE
fix: Assisted Labeling card links to setup page

### DIFF
--- a/app/training-hub/page.tsx
+++ b/app/training-hub/page.tsx
@@ -240,7 +240,7 @@ export default function TrainingHubPage() {
 
         {/* Assisted Labeling Card - Full Width */}
         <Card className="hover:shadow-lg transition-all cursor-pointer group border-2 hover:border-purple-300 mb-8">
-          <Link href="/training-hub/new-species/label">
+          <Link href="/training-hub/new-species">
             <CardHeader className="pb-3">
               <div className="flex items-center gap-3">
                 <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-purple-400 to-purple-600 flex items-center justify-center group-hover:scale-110 transition-transform">


### PR DESCRIPTION
## Summary
The "Assisted Labeling (SAM3 Batch)" card on the Training Hub was incorrectly linking directly to `/training-hub/new-species/label` which requires a `?project=` query parameter. Users saw "No project selected" error immediately after clicking.

## Problem
- Training Hub → Click "Assisted Labeling" → Shows "No project selected" error
- The label page requires a project to be selected first

## Fix
Changed the link from `/training-hub/new-species/label` to `/training-hub/new-species` (setup page) where users can select a project before proceeding.

## Test plan
- [ ] Navigate to Training Hub
- [ ] Click "Assisted Labeling (SAM3 Batch)" card
- [ ] Verify it goes to the setup page (not the label page with error)
- [ ] Select a project and Roboflow project
- [ ] Click "Start Labeling" and verify it goes to label page with images

🤖 Generated with [Claude Code](https://claude.com/claude-code)