### PR TITLE
feat: use polygon segmentation from AWS SAM3 API v0.6.0

### DIFF
--- a/lib/services/sam3-orchestrator.ts
+++ b/lib/services/sam3-orchestrator.ts
@@ -280,13 +280,24 @@ class SAM3Orchestrator {
           scaling
         );
 
-        // Create polygon from bbox (AWS API returns bbox, not polygon)
-        const polygon: [number, number][] = [
-          [scaledBbox.x1, scaledBbox.y1],
-          [scaledBbox.x2, scaledBbox.y1],
-          [scaledBbox.x2, scaledBbox.y2],
-          [scaledBbox.x1, scaledBbox.y2],
-        ];
+        // Use polygon from API if available (v0.6.0+), otherwise fall back to bbox rectangle
+        let polygon: [number, number][];
+        if (det.polygon && Array.isArray(det.polygon) && det.polygon.length >= 3) {
+          // Scale polygon coordinates back to original image space
+          const inverseScale = 1 / scaling.scaleFactor;
+          polygon = det.polygon.map((point: number[]) => [
+            Math.round(point[0] * inverseScale),
+            Math.round(point[1] * inverseScale),
+          ] as [number, number]);
+        } else {
+          // Fallback: Create polygon from bbox (for older API versions)
+          polygon = [
+            [scaledBbox.x1, scaledBbox.y1],
+            [scaledBbox.x2, scaledBbox.y1],
+            [scaledBbox.x2, scaledBbox.y2],
+            [scaledBbox.x1, scaledBbox.y2],
+          ];
+        }
 
         return {
           polygon,


### PR DESCRIPTION
## Summary
Updates the SAM3 orchestrator to use the new polygon segmentation data from the AWS SAM3 API v0.6.0.

## Before vs After

| Mode | Before | After |
|------|--------|-------|
| Point-click | Precise polygon outline | Precise polygon outline |
| Few-Shot (boxes) | **Rectangle approximation** | **Precise polygon outline** ✨ |

## Changes
- Check for `detection.polygon` in API response
- Scale polygon coordinates back to original image space
- Backward compatible: falls back to bbox rectangle if polygon not present

## API Response (v0.6.0)
```json
{
  "detections": [{
    "bbox": [1765, 395, 1828, 442],
    "confidence": 0.835,
    "area": 2178,
    "polygon": [[1825, 409], [1809, 398], [1779, 398], ...]
  }],
  "count": 39
}
```

## Test Plan
- [ ] Deploy AWS SAM3 service v0.6.0
- [ ] Use Few-Shot mode to draw boxes around targets
- [ ] Click "Apply to This Image"
- [ ] Verify annotations show precise outlines, not rectangles

🤖 Generated with [Claude Code](https://claude.com/claude-code)