### PR TITLE
Fix Redis CROSSSLOT error for cluster mode compatibility

### DIFF
--- a/lib/queue/batch-queue.ts
+++ b/lib/queue/batch-queue.ts
@@ -5,7 +5,7 @@
  * Jobs are processed by the worker in workers/batch-worker.ts
  */
 import { Queue } from 'bullmq';
-import { createRedisConnection } from './redis';
+import { createRedisConnection, QUEUE_PREFIX } from './redis';
 
 // Job data structure
 export interface BatchJobData {
@@ -39,6 +39,7 @@ export function getBatchQueue(): Queue<BatchJobData, BatchJobResult> {
   if (!batchQueue) {
     batchQueue = new Queue<BatchJobData, BatchJobResult>(BATCH_QUEUE_NAME, {
       connection: createRedisConnection(),
+      prefix: QUEUE_PREFIX, // Hash tag prefix for Redis Cluster compatibility
       defaultJobOptions: {
         attempts: 3,
         backoff: {

--- a/lib/queue/inference-queue.ts
+++ b/lib/queue/inference-queue.ts
@@ -5,7 +5,7 @@
  * Jobs are processed by workers/inference-worker.ts
  */
 import { Queue } from 'bullmq';
-import { createRedisConnection } from './redis';
+import { createRedisConnection, QUEUE_PREFIX } from './redis';
 
 export interface InferenceJobData {
   processingJobId: string;
@@ -33,6 +33,7 @@ export function getInferenceQueue(): Queue<InferenceJobData, InferenceJobResult>
   if (!inferenceQueue) {
     inferenceQueue = new Queue<InferenceJobData, InferenceJobResult>(INFERENCE_QUEUE_NAME, {
       connection: createRedisConnection(),
+      prefix: QUEUE_PREFIX, // Hash tag prefix for Redis Cluster compatibility
       defaultJobOptions: {
         attempts: 2,
         backoff: {

--- a/lib/queue/redis.ts
+++ b/lib/queue/redis.ts
@@ -3,10 +3,20 @@
  *
  * Provides a shared Redis connection for job queues.
  * Uses REDIS_URL from environment variables.
+ *
+ * IMPORTANT: Uses hash tag prefix for Redis Cluster compatibility.
+ * In Redis Cluster, all keys for a queue must hash to the same slot.
+ * The {agridrone} hash tag ensures all BullMQ keys are in the same slot.
  */
 import IORedis from 'ioredis';
 
 const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6379';
+
+/**
+ * Queue prefix with hash tag for Redis Cluster compatibility.
+ * All keys with {agridrone} will hash to the same slot, preventing CROSSSLOT errors.
+ */
+export const QUEUE_PREFIX = '{agridrone}';
 
 // Connection options for BullMQ
 export const redisConnection = {

--- a/workers/batch-worker.ts
+++ b/workers/batch-worker.ts
@@ -13,7 +13,7 @@
  */
 import { Worker, Job } from 'bullmq';
 import { PrismaClient } from '@prisma/client';
-import { createRedisConnection } from '../lib/queue/redis';
+import { createRedisConnection, QUEUE_PREFIX } from '../lib/queue/redis';
 import { BATCH_QUEUE_NAME, BatchJobData, BatchJobResult } from '../lib/queue/batch-queue';
 import { sam3Orchestrator } from '../lib/services/sam3-orchestrator';
 import { normalizeDetectionType } from '../lib/utils/detection-types';
@@ -308,6 +308,7 @@ async function startWorker() {
     },
     {
       connection: redisConnection,
+      prefix: QUEUE_PREFIX, // Hash tag prefix for Redis Cluster compatibility
       concurrency: 2, // Process up to 2 jobs in parallel
     }
   );

--- a/workers/inference-worker.ts
+++ b/workers/inference-worker.ts
@@ -6,7 +6,7 @@
  */
 import { Worker, Job } from 'bullmq';
 import { PrismaClient } from '@prisma/client';
-import { createRedisConnection } from '../lib/queue/redis';
+import { createRedisConnection, QUEUE_PREFIX } from '../lib/queue/redis';
 import {
   INFERENCE_QUEUE_NAME,
   InferenceJobData,
@@ -85,6 +85,7 @@ async function startWorker() {
     async (job) => handleInferenceJob(job),
     {
       connection: redisConnection,
+      prefix: QUEUE_PREFIX, // Hash tag prefix for Redis Cluster compatibility
       concurrency: 2,
     }
   );


### PR DESCRIPTION
Add hash tag prefix {agridrone} to all BullMQ queues and workers.
In Redis Cluster, all keys involved in multi-key Lua scripts must
hash to the same slot. The hash tag ensures all queue keys
(wait, active, completed, etc.) are in the same slot.

- Export QUEUE_PREFIX constant from lib/queue/redis.ts
- Apply prefix to inference queue and worker
- Apply prefix to batch queue and worker