### PR TITLE
Fix batch worker selecting non-existent filePath field

### DIFF
--- a/workers/batch-worker.ts
+++ b/workers/batch-worker.ts
@@ -76,7 +76,6 @@ async function processBatchJob(job: Job<BatchJobData>): Promise<BatchJobResult> 
     select: {
       id: true,
       storageUrl: true,
-      filePath: true,
       s3Key: true,
       s3Bucket: true,
       storageType: true,
@@ -116,13 +115,6 @@ async function processBatchJob(job: Job<BatchJobData>): Promise<BatchJobResult> 
           continue;
         }
         imageUrl = asset.storageUrl.startsWith('/') ? `${BASE_URL}${asset.storageUrl}` : asset.storageUrl;
-      } else if (asset.filePath) {
-        const urlPath = asset.filePath.replace(/^public\//, '/');
-        if (urlPath.includes('..') || !urlPath.startsWith('/')) {
-          errors.push(`Asset ${asset.id}: Invalid file path`);
-          continue;
-        }
-        imageUrl = `${BASE_URL}${urlPath}`;
       } else {
         errors.push(`Asset ${asset.id}: No image URL available`);
         continue;


### PR DESCRIPTION
The Asset model doesn't have a filePath field in production. Removed the field from select query and removed unused code branch.