### PR TITLE
[codex] Fix SAM3 v2 visual-match batch behavior

### DIFF
--- a/app/annotate/[assetId]/AnnotateClient.tsx
+++ b/app/annotate/[assetId]/AnnotateClient.tsx
@@ -2585,7 +2585,7 @@ export function AnnotateClient({ assetId }: AnnotateClientProps) {
                     onCheckedChange={(checked) => setUseVisualCrops(checked === true)}
                   />
                   <label htmlFor="use-visual-crops" className="cursor-pointer">
-                    Use visual crops only (skip concept propagation)
+                    Use example-based visual matching
                   </label>
                 </div>
                 <div className="flex items-center gap-2 text-[11px] text-purple-700">
@@ -2601,8 +2601,8 @@ export function AnnotateClient({ assetId }: AnnotateClientProps) {
               </div>
               <p className="text-[10px] text-purple-600 mt-2">
                 {useVisualCrops
-                  ? 'Visual crop matching only. Faster, but less class-specific.'
-                  : 'Concept propagation enabled. Better for class-specific matching.'}
+                  ? 'Uses your drawn examples as visual references. Best for domain-specific objects.'
+                  : 'Class-aware matching enabled. Better when the selected class generalizes well.'}
               </p>
               <p className="text-[10px] text-purple-600 mt-1">
                 {useBatchPipelineV2

--- a/lib/services/sam3-batch-v2.ts
+++ b/lib/services/sam3-batch-v2.ts
@@ -160,6 +160,25 @@ interface AwsSam3Like {
     error?: string;
     errorCode?: string;
   }>;
+  segment(request: {
+    image: string;
+    boxes: Array<{ x1: number; y1: number; x2: number; y2: number }>;
+    className: string;
+    minSize?: number;
+    maxSize?: number | null;
+  }): Promise<{
+    success: boolean;
+    response: {
+      detections: Array<{
+        bbox: [number, number, number, number];
+        confidence: number;
+        polygon?: [number, number][];
+      }>;
+      count: number;
+    } | null;
+    error?: string;
+    errorCode?: string;
+  }>;
   warmupConceptService(): Promise<{ success: boolean; data: { sam3Loaded: boolean; dinoLoaded: boolean } | null; error?: string }>;
   createConceptExemplar(request: {
     imageBuffer: Buffer;
@@ -202,6 +221,8 @@ interface PreparedBatchContext {
   sourceAssetId: string;
   sourceImageBuffer: Buffer;
   exemplars: BoxCoordinate[];
+  exemplarSourceWidth?: number;
+  exemplarSourceHeight?: number;
   exemplarCrops: string[];
   assets: AssetRecord[];
   missingAssetIds: string[];
@@ -425,6 +446,43 @@ function normalizePolygon(
     [bbox[2], bbox[3]],
     [bbox[0], bbox[3]],
   ];
+}
+
+function scaleBboxToOriginal(
+  bbox: [number, number, number, number],
+  scaleFactor: number
+): [number, number, number, number] {
+  if (scaleFactor === 1) {
+    return bbox;
+  }
+
+  const inverseScale = 1 / scaleFactor;
+  return [
+    Math.round(bbox[0] * inverseScale),
+    Math.round(bbox[1] * inverseScale),
+    Math.round(bbox[2] * inverseScale),
+    Math.round(bbox[3] * inverseScale),
+  ];
+}
+
+function scalePolygonToOriginal(
+  polygon: [number, number][] | undefined,
+  bbox: [number, number, number, number],
+  scaleFactor: number
+): [number, number][] {
+  if (!Array.isArray(polygon) || polygon.length < 3) {
+    return normalizePolygon(undefined, bbox);
+  }
+
+  if (scaleFactor === 1) {
+    return normalizePolygon(polygon, bbox);
+  }
+
+  const inverseScale = 1 / scaleFactor;
+  return polygon.map((point) => [
+    Math.round(point[0] * inverseScale),
+    Math.round(point[1] * inverseScale),
+  ] as [number, number]);
 }
 
 export class Sam3BatchV2Service {
@@ -753,6 +811,8 @@ export class Sam3BatchV2Service {
       sourceAssetId,
       sourceImageBuffer,
       exemplars: data.exemplars,
+      exemplarSourceWidth: data.exemplarSourceWidth,
+      exemplarSourceHeight: data.exemplarSourceHeight,
       exemplarCrops,
       assets: orderedAssets,
       missingAssetIds,
@@ -995,6 +1055,8 @@ export class Sam3BatchV2Service {
     });
 
     let conceptExemplarId: string | null = null;
+    let visualMatchExemplarId: string | null = null;
+    let visualMatchInitialized = false;
     if (prepared.mode === 'concept_propagation') {
       const warmup = await this.awsSam3Service.warmupConceptService();
       if (!warmup.success) {
@@ -1028,6 +1090,12 @@ export class Sam3BatchV2Service {
       });
     }
 
+    const assetsToProcess = [...prepared.assets].sort((left, right) => {
+      if (left.id === prepared.sourceAssetId) return -1;
+      if (right.id === prepared.sourceAssetId) return 1;
+      return 0;
+    });
+
     for (const missingAssetId of prepared.missingAssetIds) {
       const result: AssetInferenceResult = {
         assetId: missingAssetId,
@@ -1052,15 +1120,29 @@ export class Sam3BatchV2Service {
       );
     }
 
-    for (const asset of prepared.assets) {
+    for (const asset of assetsToProcess) {
       const runStartedAt = this.now().getTime();
       let result: AssetInferenceResult;
 
       try {
         const imageBuffer = await fetchAssetImage(asset);
+        const isSourceAsset = asset.id === prepared.sourceAssetId;
 
         if (prepared.mode === 'visual_crop_match') {
-          result = await this.runVisualCropMatch(asset, imageBuffer, prepared);
+          if (isSourceAsset) {
+            result = await this.runSourceBoxMatch(asset, imageBuffer, prepared);
+          } else {
+            if (!visualMatchInitialized) {
+              visualMatchExemplarId = await this.initializeVisualMatchExemplar(prepared);
+              visualMatchInitialized = true;
+            }
+
+            if (visualMatchExemplarId) {
+              result = await this.runVisualConceptMatch(asset, imageBuffer, visualMatchExemplarId);
+            } else {
+              result = await this.runVisualCropMatch(asset, imageBuffer, prepared);
+            }
+          }
         } else {
           result = await this.runConceptPropagation(asset, imageBuffer, conceptExemplarId, prepared.weedType);
         }
@@ -1127,6 +1209,91 @@ export class Sam3BatchV2Service {
     return results;
   }
 
+  private async initializeVisualMatchExemplar(
+    prepared: PreparedBatchContext
+  ): Promise<string | null> {
+    const warmup = await this.awsSam3Service.warmupConceptService();
+    if (!warmup.success) {
+      return null;
+    }
+
+    const exemplarResult = await this.awsSam3Service.createConceptExemplar({
+      imageBuffer: prepared.sourceImageBuffer,
+      boxes: prepared.exemplars,
+      className: prepared.textPrompt,
+      imageId: prepared.sourceAssetId,
+    });
+
+    if (!exemplarResult.success || !exemplarResult.data?.exemplarId) {
+      return null;
+    }
+
+    return exemplarResult.data.exemplarId;
+  }
+
+  private async runSourceBoxMatch(
+    asset: AssetRecord,
+    imageBuffer: Buffer,
+    prepared: PreparedBatchContext
+  ): Promise<AssetInferenceResult> {
+    const scaledBoxes = scaleExemplarBoxes({
+      exemplars: prepared.exemplars,
+      sourceWidth: prepared.exemplarSourceWidth,
+      sourceHeight: prepared.exemplarSourceHeight,
+      targetWidth: asset.imageWidth || prepared.exemplarSourceWidth || 0,
+      targetHeight: asset.imageHeight || prepared.exemplarSourceHeight || 0,
+      jobId: prepared.batchJobId,
+      assetId: asset.id,
+    });
+
+    if (scaledBoxes.boxes.length === 0) {
+      return {
+        assetId: asset.id,
+        detections: [],
+        outcome: 'prepare_error',
+        errorCode: 'INVALID_EXEMPLAR_BOXES',
+        errorMessage: 'Source exemplar boxes could not be scaled for the source asset.',
+      };
+    }
+
+    const resized = await this.awsSam3Service.resizeImage(imageBuffer);
+    const result = await this.awsSam3Service.segment({
+      image: resized.buffer.toString('base64'),
+      boxes: scaledBoxes.boxes.map((box) => ({
+        x1: Math.round(box.x1 * resized.scaling.scaleFactor),
+        y1: Math.round(box.y1 * resized.scaling.scaleFactor),
+        x2: Math.round(box.x2 * resized.scaling.scaleFactor),
+        y2: Math.round(box.y2 * resized.scaling.scaleFactor),
+      })),
+      className: prepared.textPrompt,
+    });
+
+    if (!result.success || !result.response) {
+      return {
+        assetId: asset.id,
+        detections: [],
+        outcome: classifyInferenceFailure(result.errorCode, result.error),
+        errorCode: result.errorCode || 'SAM3_SOURCE_MATCH_FAILED',
+        errorMessage: result.error || 'SAM3 source-image box matching failed.',
+      };
+    }
+
+    const detections = result.response.detections.map((detection) => {
+      const bbox = scaleBboxToOriginal(detection.bbox, resized.scaling.scaleFactor);
+      return {
+        bbox,
+        polygon: scalePolygonToOriginal(detection.polygon, bbox, resized.scaling.scaleFactor),
+        confidence: detection.confidence,
+      };
+    });
+
+    return {
+      assetId: asset.id,
+      detections,
+      outcome: detections.length > 0 ? 'success' : 'zero_detections',
+    };
+  }
+
   private async runVisualCropMatch(
     asset: AssetRecord,
     imageBuffer: Buffer,
@@ -1149,10 +1316,49 @@ export class Sam3BatchV2Service {
       };
     }
 
-    const detections = result.response.detections.map((detection) => ({
+    const detections = result.response.detections.map((detection) => {
+      const bbox = scaleBboxToOriginal(detection.bbox, resized.scaling.scaleFactor);
+      return {
+        bbox,
+        polygon: scalePolygonToOriginal(detection.polygon, bbox, resized.scaling.scaleFactor),
+        confidence: detection.confidence,
+      };
+    });
+
+    return {
+      assetId: asset.id,
+      detections,
+      outcome: detections.length > 0 ? 'success' : 'zero_detections',
+    };
+  }
+
+  private async runVisualConceptMatch(
+    asset: AssetRecord,
+    imageBuffer: Buffer,
+    exemplarId: string
+  ): Promise<AssetInferenceResult> {
+    const result = await this.awsSam3Service.applyConceptExemplar({
+      exemplarId,
+      imageBuffer,
+      imageId: asset.id,
+      options: { returnPolygons: true },
+    });
+
+    if (!result.success || !result.data) {
+      return {
+        assetId: asset.id,
+        detections: [],
+        outcome: classifyInferenceFailure(result.errorCode, result.error),
+        errorCode: result.errorCode || 'VISUAL_MATCH_EXEMPLAR_FAILED',
+        errorMessage: result.error || 'Visual example matching failed.',
+      };
+    }
+
+    const detections = result.data.detections.map((detection) => ({
       bbox: detection.bbox,
       polygon: normalizePolygon(detection.polygon, detection.bbox),
       confidence: detection.confidence,
+      similarity: detection.similarity,
     }));
 
     return {

--- a/services/sam3-service/app/routers/segment.py
+++ b/services/sam3-service/app/routers/segment.py
@@ -1,12 +1,14 @@
-"""Segment router for SAM3 concept-based segmentation.
+"""Segment router for SAM3 concept-style segmentation.
 
-This endpoint provides true few-shot detection using visual exemplar crops
-extracted from a source image to find similar objects in target images.
+This endpoint supports same-image box prompting and a best-effort
+cross-image exemplar-crop fallback. The exemplar-crop path currently
+uses the crop set as context for text-assisted matching; it is not a
+fully crop-conditioned few-shot detector.
 
 Supports three modes:
-1. Exemplar crops mode: Use visual crops as concept reference (cross-image detection)
-2. Box mode: Use boxes on same image as exemplars (same-image detection)
-3. Text mode: Use class_name as text prompt (fallback for known concepts)
+1. Exemplar crops mode: best-effort cross-image matching with crop context
+2. Box mode: use boxes on the same image as prompts
+3. Text mode: use class_name as a text prompt fallback
 """
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
@@ -211,9 +213,9 @@ async def segment(request: SegmentRequest):
     Supports three detection modes:
 
     1. **Exemplar crops mode** (`exemplar_crops` provided):
-       Uses visual crops extracted from a source image to find similar
-       objects in the target image. Best for domain-specific objects
-       that SAM3 may not recognize by text.
+       Uses a best-effort exemplar-crop fallback for cross-image matching.
+       In the current implementation this is still text-assisted, so it
+       should be treated as weaker than the dedicated exemplar service.
 
     2. **Box mode** (`boxes` provided):
        Uses bounding boxes on the same image as visual exemplars.
@@ -250,19 +252,10 @@ async def segment(request: SegmentRequest):
                 crop_image = decode_base64_image(crop_b64)
                 crop_w, crop_h = crop_image.size
 
-                # For cross-image detection with crops, we use the crop
-                # as a visual reference. The approach is to:
-                # 1. Create a composite where the crop establishes the concept
-                # 2. Use SAM3 to find similar objects in the target
-
-                # Since SAM3's box prompts work by extracting features from
-                # the box region, we need a different approach for cross-image:
-                # We'll use text-assisted detection with the crop as context
-                # This is a simplification - full implementation may need
-                # custom feature extraction
-
-                # For now, use boxes as approximate locations if available
-                # and let SAM3 find similar objects
+                # This is a compatibility fallback, not a fully crop-conditioned
+                # exemplar matcher. We decode the crop so callers can pass real
+                # example imagery, but the current model invocation still uses
+                # text-assisted target-image segmentation.
                 inputs = processor(
                     images=target_image,
                     text=request.class_name or "object",

--- a/tests/unit/sam3-batch-v2.test.ts
+++ b/tests/unit/sam3-batch-v2.test.ts
@@ -6,7 +6,7 @@ describe('sam3-batch-v2', () => {
   const originalFetch = global.fetch;
 
   beforeEach(() => {
-    global.fetch = vi.fn().mockResolvedValue(
+    global.fetch = vi.fn().mockImplementation(async () =>
       new Response(Buffer.from('image-bytes'), {
         status: 200,
         headers: {
@@ -265,6 +265,252 @@ describe('sam3-batch-v2', () => {
         }),
       ])
     );
+  });
+
+  it('rescales visual-crop detections back to original image coordinates', async () => {
+    const service = new Sam3BatchV2Service({
+      prisma: {} as never,
+      awsSam3Service: {
+        resizeImage: vi.fn().mockResolvedValue({
+          buffer: Buffer.from('resized-image'),
+          scaling: { scaleFactor: 0.5 },
+        }),
+        segmentWithExemplars: vi.fn().mockResolvedValue({
+          success: true,
+          response: {
+            detections: [
+              {
+                bbox: [10, 20, 30, 40],
+                confidence: 0.84,
+                polygon: [
+                  [10, 20],
+                  [30, 20],
+                  [30, 40],
+                  [10, 40],
+                ],
+              },
+            ],
+            count: 1,
+          },
+        }),
+      } as any,
+      acquireGpuLock: vi.fn(),
+      refreshGpuLock: vi.fn(),
+      releaseGpuLock: vi.fn(),
+      sleep: vi.fn(),
+      now: () => new Date('2026-03-31T00:00:00.000Z'),
+    });
+
+    const result = await (service as any).runVisualCropMatch(
+      {
+        id: 'asset-1',
+        storageUrl: 'http://localhost/asset-1.jpg',
+        s3Key: null,
+        s3Bucket: null,
+        storageType: 'local',
+        imageWidth: 4000,
+        imageHeight: 3000,
+      },
+      Buffer.from('original-image'),
+      {
+        batchJobId: 'batch-1',
+        projectId: 'proj-1',
+        weedType: 'Pine Sapling',
+        mode: 'visual_crop_match',
+        textPrompt: 'Pine Sapling',
+        sourceAssetId: 'asset-1',
+        sourceImageBuffer: Buffer.from('source-image'),
+        exemplars: [{ x1: 1, y1: 2, x2: 3, y2: 4 }],
+        exemplarCrops: ['abc123'],
+        assets: [],
+        missingAssetIds: [],
+        cropCount: 1,
+      }
+    );
+
+    expect(result).toMatchObject({
+      assetId: 'asset-1',
+      outcome: 'success',
+      detections: [
+        {
+          bbox: [20, 40, 60, 80],
+          polygon: [
+            [20, 40],
+            [60, 40],
+            [60, 80],
+            [20, 80],
+          ],
+          confidence: 0.84,
+        },
+      ],
+    });
+  });
+
+  it('uses source-image box matching before concept-backed visual matching for target assets', async () => {
+    let stageLog: unknown[] = [];
+    const segment = vi.fn().mockResolvedValue({
+      success: true,
+      response: {
+        detections: [
+          {
+            bbox: [5, 5, 15, 15],
+            confidence: 0.9,
+            polygon: [
+              [5, 5],
+              [15, 5],
+              [15, 15],
+              [5, 15],
+            ],
+          },
+        ],
+        count: 1,
+      },
+    });
+    const createConceptExemplar = vi.fn().mockResolvedValue({
+      success: true,
+      data: { exemplarId: 'visual-exemplar-1' },
+    });
+    const applyConceptExemplar = vi.fn().mockResolvedValue({
+      success: true,
+      data: {
+        detections: [
+          {
+            bbox: [20, 25, 40, 45],
+            confidence: 0.82,
+            similarity: 0.88,
+            polygon: [
+              [20, 25],
+              [40, 25],
+              [40, 45],
+              [20, 45],
+            ],
+            class_name: 'object',
+          },
+        ],
+        processingTimeMs: 12,
+      },
+    });
+    const prismaMock = {
+      batchJob: {
+        findUnique: vi.fn().mockImplementation(async ({ select }) => {
+          if (select?.stageLog) {
+            return { stageLog };
+          }
+          if (select?.sourceAssetId) {
+            return { sourceAssetId: 'asset-source' };
+          }
+          return { stageLog };
+        }),
+        update: vi.fn().mockImplementation(async ({ data }) => {
+          if (data?.stageLog) {
+            stageLog = data.stageLog as unknown[];
+          }
+        }),
+      },
+      asset: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: 'asset-target',
+            storageUrl: 'http://localhost/asset-target.jpg',
+            s3Key: null,
+            s3Bucket: null,
+            storageType: 'local',
+            imageWidth: 4000,
+            imageHeight: 3000,
+          },
+          {
+            id: 'asset-source',
+            storageUrl: 'http://localhost/asset-source.jpg',
+            s3Key: null,
+            s3Bucket: null,
+            storageType: 'local',
+            imageWidth: 4000,
+            imageHeight: 3000,
+          },
+        ]),
+        findUnique: vi.fn().mockResolvedValue({
+          id: 'asset-source',
+          storageUrl: 'http://localhost/asset-source.jpg',
+          s3Key: null,
+          s3Bucket: null,
+          storageType: 'local',
+          imageWidth: 4000,
+          imageHeight: 3000,
+        }),
+      },
+      $transaction: vi.fn().mockImplementation(async <T>(callback: (tx: any) => Promise<T>) => {
+        return callback({
+          pendingAnnotation: {
+            deleteMany: vi.fn(async () => undefined),
+            createMany: vi.fn(async () => undefined),
+          },
+          batchJob: {
+            update: vi.fn(async () => undefined),
+          },
+        });
+      }),
+    } as any;
+
+    const service = new Sam3BatchV2Service({
+      prisma: prismaMock,
+      awsSam3Service: {
+        isConfigured: vi.fn().mockReturnValue(true),
+        isReady: vi.fn().mockReturnValue(true),
+        refreshStatus: vi.fn().mockResolvedValue({
+          modelLoaded: true,
+          instanceState: 'ready',
+          ipAddress: '127.0.0.1',
+        }),
+        startInstance: vi.fn().mockResolvedValue(true),
+        resizeImage: vi.fn().mockImplementation(async (imageBuffer: Buffer) => ({
+          buffer: imageBuffer,
+          scaling: { scaleFactor: 1 },
+        })),
+        segment,
+        segmentWithExemplars: vi.fn(),
+        warmupConceptService: vi.fn().mockResolvedValue({
+          success: true,
+          data: { sam3Loaded: true, dinoLoaded: true },
+        }),
+        createConceptExemplar,
+        applyConceptExemplar,
+      },
+      acquireGpuLock: vi.fn().mockResolvedValue({ acquired: true, token: 'gpu-token' }),
+      refreshGpuLock: vi.fn().mockResolvedValue(true),
+      releaseGpuLock: vi.fn().mockResolvedValue(true),
+      sleep: vi.fn(),
+      now: () => new Date('2026-03-31T00:00:00.000Z'),
+    });
+
+    const result = await service.processJob({
+      data: {
+        batchJobId: 'batch-visual-1',
+        projectId: 'proj-1',
+        weedType: 'Pine Sapling',
+        mode: 'visual_crop_match',
+        exemplars: [{ x1: 100, y1: 100, x2: 150, y2: 160 }],
+        exemplarSourceWidth: 4000,
+        exemplarSourceHeight: 3000,
+        exemplarCrops: ['abc123'],
+        sourceAssetId: 'asset-source',
+        assetIds: ['asset-target', 'asset-source'],
+        textPrompt: 'Pine Sapling',
+      },
+      attemptsMade: 0,
+      updateProgress: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(result.terminalState).toBe('completed');
+    expect(segment).toHaveBeenCalledTimes(1);
+    expect(createConceptExemplar).toHaveBeenCalledTimes(1);
+    expect(createConceptExemplar).toHaveBeenCalledWith(
+      expect.objectContaining({
+        className: 'Pine Sapling',
+        imageId: 'asset-source',
+      })
+    );
+    expect(applyConceptExemplar).toHaveBeenCalledTimes(1);
+    expect((service as any).awsSam3Service.segmentWithExemplars).not.toHaveBeenCalled();
   });
 
   it('configures the v2 BullMQ queue with global concurrency 1', async () => {


### PR DESCRIPTION
## What changed
- fixed SAM3 batch v2 visual-match persistence so resized detections are scaled back to original image coordinates
- restored source-versus-target handling in v2 visual-match batches: the source asset uses direct box matching, while target assets use the stronger concept exemplar service when available
- added targeted unit coverage for the scaling fix and the source/target visual-match flow
- clarified the annotate UI copy and the Python `/segment` router comments so the current visual-match semantics are explicit

## Why it changed
Recent testing showed two separate issues in the cleared v2 path:
- detections that did come back could render in the wrong place because v2 persisted resized-image coordinates
- the pure visual-crop path was weaker than the historical user expectation, because the deeper exemplar support lives in the concept exemplar service rather than the `/segment` crop fallback

This PR fixes the hard v2 regression and routes visual example batches through the stronger existing exemplar service when it is available.

## Impact
- v2 visual-match batches should no longer cluster detections into the top-left of the image
- source images should behave like the older working flow again
- target-image matching in v2 should use the better exemplar path instead of relying on the weak crop fallback first
- UI text is less misleading for internal testers

## Validation
- `npm run test:unit`
