### PR TITLE
Implemented the operator-flow update.

### DIFF
--- a/app/training-hub/page.tsx
+++ b/app/training-hub/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Sam3Ec2Control } from '@/components/dashboard/sam3-ec2-control';
 import {
   Plus,
   RefreshCw,
@@ -70,19 +71,6 @@ interface BatchJob {
   };
 }
 
-interface Sam3StartResponse {
-  success: boolean;
-  ready: boolean;
-  starting: boolean;
-  message?: string;
-}
-
-interface Sam3StatusResponse {
-  aws: {
-    ready: boolean;
-  };
-}
-
 export default function TrainingHubPage() {
   const [projects, setProjects] = useState<RoboflowProject[]>([]);
   const [batchJobs, setBatchJobs] = useState<BatchJob[]>([]);
@@ -90,7 +78,7 @@ export default function TrainingHubPage() {
   const [syncing, setSyncing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
-  const [sam3WarmupMessage, setSam3WarmupMessage] = useState<string | null>(null);
+  const [sam3Ready, setSam3Ready] = useState(false);
   const [deletingBatchId, setDeletingBatchId] = useState<string | null>(null);
   const [batchToDelete, setBatchToDelete] = useState<BatchJob | null>(null);
 
@@ -149,41 +137,8 @@ export default function TrainingHubPage() {
     fetchBatchJobs();
   }, []);
 
-  useEffect(() => {
-    let pollTimer: ReturnType<typeof setInterval> | null = null;
-
-    const startSam3 = async () => {
-      try {
-        const response = await fetch('/api/sam3/start', { method: 'POST' });
-        if (!response.ok) return;
-
-        const data: Sam3StartResponse = await response.json();
-        if (data.starting && !data.ready) {
-          setSam3WarmupMessage(data.message || 'Warming up the SAM3 GPU...');
-          pollTimer = setInterval(async () => {
-            try {
-              const statusResponse = await fetch('/api/sam3/status');
-              if (!statusResponse.ok) return;
-              const statusData: Sam3StatusResponse = await statusResponse.json();
-              if (statusData.aws?.ready) {
-                setSam3WarmupMessage(null);
-                if (pollTimer) clearInterval(pollTimer);
-              }
-            } catch {
-              // Ignore transient status errors
-            }
-          }, 5000);
-        }
-      } catch {
-        // Ignore warmup failures on load
-      }
-    };
-
-    startSam3();
-
-    return () => {
-      if (pollTimer) clearInterval(pollTimer);
-    };
+  const handleSam3ReadyChange = useCallback((ready: boolean) => {
+    setSam3Ready(ready);
   }, []);
 
   const handleProjectCreated = () => {
@@ -237,33 +192,60 @@ export default function TrainingHubPage() {
       </div>
 
       <div>
-        {sam3WarmupMessage && (
-          <Card className="border-blue-200 bg-blue-50 mb-6">
-            <CardContent className="py-4">
-              <div className="flex items-center gap-3 text-blue-700">
-                <RefreshCw className="w-5 h-5 animate-spin" />
-                <div>
-                  <p className="font-medium">Starting SAM3 GPU…</p>
-                  <p className="text-sm text-blue-600">{sam3WarmupMessage}</p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        )}
+        <Sam3Ec2Control
+          showDetails
+          title="SAM3 Readiness"
+          onReadyChange={handleSam3ReadyChange}
+        />
+
         <WorkflowGuide current="sam3" />
         {/* Workflow Cards */}
         <div className="grid md:grid-cols-2 gap-6 mb-8">
           {/* Label New Species */}
-          <Card className="hover:shadow-lg transition-all cursor-pointer group border-2 hover:border-green-300">
-            <Link href="/training-hub/new-species">
+          <Card className={`transition-all group border-2 ${sam3Ready ? 'hover:shadow-lg cursor-pointer hover:border-green-300' : 'cursor-not-allowed border-gray-200 bg-gray-50 opacity-70'}`}>
+            {sam3Ready ? (
+              <Link href="/training-hub/new-species">
+                <CardHeader className="pb-3">
+                  <div className="flex items-center gap-3">
+                    <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center group-hover:scale-110 transition-transform">
+                      <Sparkles className="w-6 h-6 text-white" />
+                    </div>
+                    <div>
+                      <CardTitle className="text-xl">Label New Species</CardTitle>
+                      <CardDescription>Train AI to detect a new weed type</CardDescription>
+                    </div>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <ul className="space-y-2 text-sm text-gray-600 mb-4">
+                    <li className="flex items-center gap-2">
+                      <CheckCircle2 className="w-4 h-4 text-green-500" />
+                      Upload images without AI detection
+                    </li>
+                    <li className="flex items-center gap-2">
+                      <CheckCircle2 className="w-4 h-4 text-green-500" />
+                      Use SAM3 click-to-segment labeling
+                    </li>
+                    <li className="flex items-center gap-2">
+                      <CheckCircle2 className="w-4 h-4 text-green-500" />
+                      Push annotations to create new model
+                    </li>
+                  </ul>
+                  <div className="flex items-center text-green-600 font-medium group-hover:gap-3 transition-all">
+                    Start Labeling <ArrowRight className="w-4 h-4 ml-2" />
+                  </div>
+                </CardContent>
+              </Link>
+            ) : (
+              <div>
               <CardHeader className="pb-3">
                 <div className="flex items-center gap-3">
-                  <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center group-hover:scale-110 transition-transform">
+                  <div className="w-12 h-12 rounded-xl bg-gray-200 flex items-center justify-center">
                     <Sparkles className="w-6 h-6 text-white" />
                   </div>
                   <div>
                     <CardTitle className="text-xl">Label New Species</CardTitle>
-                    <CardDescription>Train AI to detect a new weed type</CardDescription>
+                    <CardDescription>Wake SAM3 before starting a labeling run</CardDescription>
                   </div>
                 </div>
               </CardHeader>
@@ -282,11 +264,12 @@ export default function TrainingHubPage() {
                     Push annotations to create new model
                   </li>
                 </ul>
-                <div className="flex items-center text-green-600 font-medium group-hover:gap-3 transition-all">
-                  Start Labeling <ArrowRight className="w-4 h-4 ml-2" />
+                <div className="flex items-center text-gray-500 font-medium">
+                  SAM3 not ready
                 </div>
               </CardContent>
-            </Link>
+              </div>
+            )}
           </Card>
 
           {/* Improve Existing Model */}
@@ -327,19 +310,53 @@ export default function TrainingHubPage() {
         </div>
 
         {/* Assisted Labeling Card - Full Width */}
-        <Card className="hover:shadow-lg transition-all cursor-pointer group border-2 hover:border-purple-300 mb-8">
-          <Link href="/training-hub/new-species">
+        <Card className={`transition-all group border-2 mb-8 ${sam3Ready ? 'hover:shadow-lg cursor-pointer hover:border-purple-300' : 'cursor-not-allowed border-gray-200 bg-gray-50 opacity-70'}`}>
+          {sam3Ready ? (
+            <Link href="/training-hub/new-species">
+              <CardHeader className="pb-3">
+                <div className="flex items-center gap-3">
+                  <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-purple-400 to-purple-600 flex items-center justify-center group-hover:scale-110 transition-transform">
+                    <Wand2 className="w-6 h-6 text-white" />
+                  </div>
+                  <div className="flex-1">
+                    <CardTitle className="text-xl">Assisted Labeling (SAM3 Batch)</CardTitle>
+                    <CardDescription>Label a few exemplars, then apply to entire dataset</CardDescription>
+                  </div>
+                  <div className="flex items-center text-purple-600 font-medium group-hover:gap-3 transition-all">
+                    Start <ArrowRight className="w-4 h-4 ml-2" />
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="grid md:grid-cols-3 gap-4 text-sm text-gray-600">
+                  <div className="flex items-center gap-2">
+                    <span className="w-6 h-6 rounded-full bg-purple-100 text-purple-600 flex items-center justify-center text-xs font-bold">1</span>
+                    Label 2-5 examples with SAM3
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="w-6 h-6 rounded-full bg-purple-100 text-purple-600 flex items-center justify-center text-xs font-bold">2</span>
+                    AI applies predictions to all images
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="w-6 h-6 rounded-full bg-purple-100 text-purple-600 flex items-center justify-center text-xs font-bold">3</span>
+                    Review & push accepted annotations
+                  </div>
+                </div>
+              </CardContent>
+            </Link>
+          ) : (
+            <div>
             <CardHeader className="pb-3">
               <div className="flex items-center gap-3">
-                <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-purple-400 to-purple-600 flex items-center justify-center group-hover:scale-110 transition-transform">
+                <div className="w-12 h-12 rounded-xl bg-gray-200 flex items-center justify-center">
                   <Wand2 className="w-6 h-6 text-white" />
                 </div>
                 <div className="flex-1">
                   <CardTitle className="text-xl">Assisted Labeling (SAM3 Batch)</CardTitle>
-                  <CardDescription>Label a few exemplars, then apply to entire dataset</CardDescription>
+                  <CardDescription>Wake SAM3 and wait for safe-to-process before batch runs</CardDescription>
                 </div>
-                <div className="flex items-center text-purple-600 font-medium group-hover:gap-3 transition-all">
-                  Start <ArrowRight className="w-4 h-4 ml-2" />
+                <div className="flex items-center text-gray-500 font-medium">
+                  SAM3 not ready
                 </div>
               </div>
             </CardHeader>
@@ -359,7 +376,8 @@ export default function TrainingHubPage() {
                 </div>
               </div>
             </CardContent>
-          </Link>
+            </div>
+          )}
         </Card>
 
         {/* YOLO Training Quick Link */}

--- a/components/dashboard/sam3-ec2-control.tsx
+++ b/components/dashboard/sam3-ec2-control.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Power, PowerOff, RefreshCw, Server } from 'lucide-react';
+import { AlertCircle, CheckCircle2, Power, PowerOff, RefreshCw, Server } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -30,18 +30,30 @@ type HealthState = {
   available: boolean;
 };
 
+interface Sam3Ec2ControlProps {
+  autoStartOnLoad?: boolean;
+  showDetails?: boolean;
+  title?: string;
+  onReadyChange?: (ready: boolean) => void;
+}
+
 const STARTUP_MESSAGE = 'Waiting for the EC2 instance and SAM3 model to become ready.';
 
-export function Sam3Ec2Control() {
+export function Sam3Ec2Control({
+  autoStartOnLoad = false,
+  showDetails = false,
+  title = 'SAM3 GPU Service',
+  onReadyChange,
+}: Sam3Ec2ControlProps) {
   const [health, setHealth] = useState<HealthState>({ loading: true, available: false });
   const [status, setStatus] = useState<Sam3StatusResponse | null>(null);
   const [sam3WarmupMessage, setSam3WarmupMessage] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState<'start' | 'stop' | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [statusError, setStatusError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
   const startRequestedRef = useRef(false);
 
   const fetchStatus = useCallback(async () => {
-    setError(null);
     setHealth((current) => ({ ...current, loading: true }));
 
     try {
@@ -52,8 +64,15 @@ export function Sam3Ec2Control() {
         throw new Error('Failed to check SAM3 status');
       }
 
+      setStatusError(null);
       setStatus(data);
-      setHealth({ loading: false, available: Boolean(data.aws?.ready) });
+      const safeToProcess = Boolean(
+        data.aws?.ready &&
+        data.aws.modelLoaded !== false &&
+        data.aws.gpuAvailable !== false
+      );
+      setHealth({ loading: false, available: safeToProcess });
+      onReadyChange?.(safeToProcess);
 
       if (data.aws?.ready) {
         setSam3WarmupMessage(null);
@@ -65,18 +84,20 @@ export function Sam3Ec2Control() {
       return data;
     } catch (err) {
       setHealth({ loading: false, available: false });
-      setError(err instanceof Error ? err.message : 'Failed to check SAM3 status');
+      onReadyChange?.(false);
+      setStatusError(err instanceof Error ? err.message : 'Failed to check SAM3 status');
       return null;
     }
-  }, []);
+  }, [onReadyChange]);
 
   const startSam3 = useCallback(async (manual = false) => {
     if (!manual && startRequestedRef.current) return;
 
     startRequestedRef.current = true;
     setActionLoading('start');
-    setError(null);
+    setActionError(null);
     setSam3WarmupMessage(STARTUP_MESSAGE);
+    let accepted = false;
 
     try {
       const response = await fetch('/api/sam3/start', { method: 'POST' });
@@ -89,19 +110,24 @@ export function Sam3Ec2Control() {
       if (data.ready) {
         setSam3WarmupMessage(null);
       }
+      setActionError(null);
+      accepted = true;
     } catch (err) {
       startRequestedRef.current = false;
       setSam3WarmupMessage(null);
-      setError(err instanceof Error ? err.message : 'Failed to start SAM3 GPU instance');
+      setActionError(err instanceof Error ? err.message : 'Failed to start SAM3 GPU instance');
     } finally {
       setActionLoading(null);
-      void fetchStatus();
+      if (accepted) {
+        void fetchStatus();
+      }
     }
   }, [fetchStatus]);
 
   const stopSam3 = async () => {
     setActionLoading('stop');
-    setError(null);
+    setActionError(null);
+    let stopped = false;
 
     try {
       const response = await fetch('/api/sam3/stop', { method: 'POST' });
@@ -113,11 +139,15 @@ export function Sam3Ec2Control() {
 
       startRequestedRef.current = false;
       setSam3WarmupMessage(null);
-      await fetchStatus();
+      setActionError(null);
+      stopped = true;
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to stop SAM3 GPU instance');
+      setActionError(err instanceof Error ? err.message : 'Failed to stop SAM3 GPU instance');
     } finally {
       setActionLoading(null);
+      if (stopped) {
+        await fetchStatus();
+      }
     }
   };
 
@@ -128,6 +158,7 @@ export function Sam3Ec2Control() {
       const currentStatus = await fetchStatus();
 
       if (
+        autoStartOnLoad &&
         !cancelled &&
         currentStatus?.aws?.configured &&
         !currentStatus.aws.ready &&
@@ -145,10 +176,13 @@ export function Sam3Ec2Control() {
       cancelled = true;
       clearInterval(pollTimer);
     };
-  }, [fetchStatus, startSam3]);
+  }, [autoStartOnLoad, fetchStatus, startSam3]);
 
   const awsConfigured = Boolean(status?.aws?.configured);
   const stateLabel = status?.aws?.state ? `EC2: ${status.aws.state}` : 'EC2 status pending';
+  const modelLoaded = status?.aws?.modelLoaded === true;
+  const gpuAvailable = status?.aws?.gpuAvailable === true;
+  const visibleError = actionError || statusError;
 
   return (
     <div className="mb-8">
@@ -167,60 +201,103 @@ export function Sam3Ec2Control() {
       )}
 
       <Card className="border-gray-200">
-        <CardContent className="flex flex-col gap-4 py-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-green-100 text-green-700">
-              <Server className="h-5 w-5" />
-            </div>
-            <div>
-              <div className="flex flex-wrap items-center gap-2">
-                <p className="font-medium text-gray-900">SAM3 GPU Service</p>
-                {health.loading ? (
-                  <Badge variant="secondary">Checking...</Badge>
-                ) : health.available ? (
-                  <Badge className="bg-emerald-100 text-emerald-700">Service Online</Badge>
-                ) : (
-                  <Badge className="bg-red-100 text-red-700">Service Offline</Badge>
-                )}
+        <CardContent className="flex flex-col gap-4 py-4">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-green-100 text-green-700">
+                <Server className="h-5 w-5" />
               </div>
-              <p className="text-sm text-gray-600">
-                {awsConfigured ? stateLabel : 'AWS SAM3 is not configured'}
-                {error ? <span className="text-red-600"> - {error}</span> : null}
-              </p>
+              <div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="font-medium text-gray-900">{title}</p>
+                  {health.loading ? (
+                    <Badge variant="secondary">Checking...</Badge>
+                  ) : health.available ? (
+                    <Badge className="bg-emerald-100 text-emerald-700">Service Online</Badge>
+                  ) : (
+                    <Badge className="bg-red-100 text-red-700">Service Offline</Badge>
+                  )}
+                </div>
+                <p className="text-sm text-gray-600">
+                  {awsConfigured ? stateLabel : 'AWS SAM3 is not configured'}
+                </p>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => fetchStatus()}
+                disabled={health.loading || actionLoading !== null}
+              >
+                <RefreshCw className={`mr-2 h-4 w-4 ${health.loading ? 'animate-spin' : ''}`} />
+                Refresh
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => startSam3(true)}
+                disabled={!awsConfigured || health.available || actionLoading !== null}
+              >
+                <Power className="mr-2 h-4 w-4" />
+                {actionLoading === 'start' ? 'Waking...' : 'Wake SAM3'}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={stopSam3}
+                disabled={!awsConfigured || !status?.aws || actionLoading !== null || status.aws.state === 'stopped'}
+              >
+                <PowerOff className="mr-2 h-4 w-4" />
+                {actionLoading === 'stop' ? 'Stopping...' : 'Stop GPU'}
+              </Button>
             </div>
           </div>
 
-          <div className="flex flex-wrap gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => fetchStatus()}
-              disabled={health.loading || actionLoading !== null}
-            >
-              <RefreshCw className={`mr-2 h-4 w-4 ${health.loading ? 'animate-spin' : ''}`} />
-              Refresh
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              onClick={() => startSam3(true)}
-              disabled={!awsConfigured || health.available || actionLoading !== null}
-            >
-              <Power className="mr-2 h-4 w-4" />
-              {actionLoading === 'start' ? 'Starting...' : 'Start GPU'}
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={stopSam3}
-              disabled={!awsConfigured || !status?.aws || actionLoading !== null || status.aws.state === 'stopped'}
-            >
-              <PowerOff className="mr-2 h-4 w-4" />
-              {actionLoading === 'stop' ? 'Stopping...' : 'Stop GPU'}
-            </Button>
-          </div>
+          {showDetails && (
+            <div className="grid w-full gap-3 border-t pt-4 text-sm sm:grid-cols-4">
+              <div>
+                <p className="text-gray-500">EC2 State</p>
+                <p className="font-medium text-gray-900">{status?.aws?.state || 'unknown'}</p>
+              </div>
+              <div>
+                <p className="text-gray-500">GPU Available</p>
+                <p className={gpuAvailable ? 'font-medium text-emerald-700' : 'font-medium text-gray-900'}>
+                  {gpuAvailable ? 'Yes' : 'No'}
+                </p>
+              </div>
+              <div>
+                <p className="text-gray-500">Model Loaded</p>
+                <p className={modelLoaded ? 'font-medium text-emerald-700' : 'font-medium text-gray-900'}>
+                  {modelLoaded ? 'Yes' : 'No'}
+                </p>
+              </div>
+              <div>
+                <p className="text-gray-500">Processing</p>
+                <p className={`flex items-center gap-1 font-medium ${health.available ? 'text-emerald-700' : 'text-amber-700'}`}>
+                  {health.available ? (
+                    <>
+                      <CheckCircle2 className="h-4 w-4" />
+                      Safe to process
+                    </>
+                  ) : (
+                    <>
+                      <AlertCircle className="h-4 w-4" />
+                      Not ready
+                    </>
+                  )}
+                </p>
+              </div>
+              {visibleError && (
+                <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-red-700 sm:col-span-4">
+                  {visibleError}
+                </div>
+              )}
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/lib/services/aws-sam3.ts
+++ b/lib/services/aws-sam3.ts
@@ -515,6 +515,27 @@ class AWSSAM3Service {
 
     const baseUrl = `http://${this.instanceIp}:${SAM3_PORT}`;
 
+    const tryModernStatus = async () => {
+      try {
+        const response = await fetch(`${baseUrl}/api/v1/status`, {
+          signal: AbortSignal.timeout(5000),
+        });
+        if (!response.ok) return null;
+
+        const data = await response.json();
+        this.apiFlavor = 'modern';
+        this.supportsExemplarCrops = true;
+        this.modelLoaded = data.predictor?.model_loaded === true;
+        this.gpuAvailable = data.device === 'cuda' || data.predictor?.device === 'cuda' || data.device === 'mps';
+        return {
+          modelLoaded: this.modelLoaded,
+          gpuAvailable: this.gpuAvailable,
+        };
+      } catch {
+        return null;
+      }
+    };
+
     const tryModernHealth = async () => {
       try {
         const response = await fetch(`${baseUrl}/api/v1/health`, {
@@ -558,6 +579,9 @@ class AWSSAM3Service {
       }
     };
 
+    const modernStatus = await tryModernStatus();
+    if (modernStatus) return modernStatus;
+
     const modernHealth = await tryModernHealth();
     if (modernHealth) return modernHealth;
 
@@ -589,7 +613,11 @@ class AWSSAM3Service {
       }
       const data = await response.json();
       this.apiFlavor = flavor;
-      this.modelLoaded = data.status === 'loaded' || data.success === true;
+      this.modelLoaded =
+        data.status === 'loaded' ||
+        data.success === true ||
+        data.model_loaded === true ||
+        data.predictor?.model_loaded === true;
       return { success: true as const, data };
     };
 


### PR DESCRIPTION
Changed:

Sam3Ec2Control is now a visible manual readiness/control card: No hidden auto-start by default.
Manual Wake SAM3 button.
Shows EC2 state, GPU available, model loaded, and Safe to process / Not ready. Shows start/stop/status errors in the card.
Still supports optional autoStartOnLoad if needed later. Training Hub now renders Sam3Ec2Control as SAM3 Readiness. Removed the old hidden Training Hub auto-start effect. Disabled SAM3-dependent Training Hub actions until ready: Label New Species
Assisted Labeling (SAM3 Batch)
Updated AWS SAM3 health probing to check SAM3_SERVICE_URL/api/v1/status first and treat predictor.model_loaded === true as model ready. Warmup handling now also accepts /api/v1/warmup responses with predictor.model_loaded === true.