### PR TITLE
Stabilize SAM review YOLO workflow

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1,0 +1,45 @@
+name: Quality Gate
+
+on:
+  pull_request:
+    branches:
+      - main
+      - production
+  push:
+    branches:
+      - main
+      - production
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      DATABASE_URL: mysql://root:password@127.0.0.1:3306/agridrone_ci
+      NEXT_TELEMETRY_DISABLED: '1'
+      NEXTAUTH_SECRET: ci-nextauth-secret
+      NEXTAUTH_URL: http://localhost:3000
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm run test:unit
+
+      - name: Build
+        run: npm run build

--- a/app/annotate/[assetId]/AnnotateClient.tsx
+++ b/app/annotate/[assetId]/AnnotateClient.tsx
@@ -2620,28 +2620,38 @@ export function AnnotateClient({ assetId }: AnnotateClientProps) {
                   )}
                   Apply to All {projectAssets.length} Images
                 </Button>
-                <div className="flex items-center gap-2 text-[11px] text-purple-700">
-                  <Checkbox
-                    id="use-visual-crops"
-                    checked={projectAssets.length > 1 || useVisualCrops}
-                    disabled={projectAssets.length > 1}
-                    onCheckedChange={(checked) => setUseVisualCrops(checked === true)}
-                  />
-                  <label htmlFor="use-visual-crops" className="cursor-pointer">
-                    Use example-based visual matching{projectAssets.length > 1 ? ' (required)' : ''}
-                  </label>
-                </div>
-                <div className="flex items-center gap-2 text-[11px] text-purple-700">
-                  <Checkbox
-                    id="use-batch-pipeline-v2"
-                    checked={projectAssets.length > 1 || useBatchPipelineV2}
-                    disabled={projectAssets.length > 1}
-                    onCheckedChange={(checked) => setUseBatchPipelineV2(checked === true)}
-                  />
-                  <label htmlFor="use-batch-pipeline-v2" className="cursor-pointer">
-                    Use cleared SAM3 Pipeline v2{projectAssets.length > 1 ? ' (required)' : ''}
-                  </label>
-                </div>
+                {projectAssets.length > 1 ? (
+                  <div className="rounded-md border border-purple-200 bg-purple-50 px-2 py-1.5 text-[11px] text-purple-800">
+                    Dataset runs use SAM3 v2 visual matching. Your drawn examples are matched
+                    by appearance across the dataset, then sent to review before training.
+                  </div>
+                ) : (
+                  <div className="space-y-1 rounded-md border border-purple-100 bg-white/70 p-2">
+                    <p className="text-[10px] font-medium uppercase tracking-wide text-purple-500">
+                      Advanced single-image debug options
+                    </p>
+                    <div className="flex items-center gap-2 text-[11px] text-purple-700">
+                      <Checkbox
+                        id="use-visual-crops"
+                        checked={useVisualCrops}
+                        onCheckedChange={(checked) => setUseVisualCrops(checked === true)}
+                      />
+                      <label htmlFor="use-visual-crops" className="cursor-pointer">
+                        Use example-based visual matching
+                      </label>
+                    </div>
+                    <div className="flex items-center gap-2 text-[11px] text-purple-700">
+                      <Checkbox
+                        id="use-batch-pipeline-v2"
+                        checked={useBatchPipelineV2}
+                        onCheckedChange={(checked) => setUseBatchPipelineV2(checked === true)}
+                      />
+                      <label htmlFor="use-batch-pipeline-v2" className="cursor-pointer">
+                        Use SAM3 Pipeline v2
+                      </label>
+                    </div>
+                  </div>
+                )}
               </div>
               <p className="text-[10px] text-purple-600 mt-2">
                 {projectAssets.length > 1 || useVisualCrops

--- a/app/api/sam3/batch/route.ts
+++ b/app/api/sam3/batch/route.ts
@@ -28,7 +28,10 @@ import { ensureVisualCropBatchAwsReady } from '@/lib/services/sam3-batch-startup
 import { normalizeDetectionType } from '@/lib/utils/detection-types';
 import { scaleExemplarBoxes } from '@/lib/utils/exemplar-scaling';
 import { buildExemplarCrops, normalizeExemplarCrops } from '@/lib/utils/exemplar-crops';
-import { SAM3_BATCH_JOB_KINDS } from '@/lib/utils/sam3-batch-jobs';
+import {
+  guardLegacySam3BatchScope,
+  SAM3_BATCH_JOB_KINDS,
+} from '@/lib/utils/sam3-batch-jobs';
 import { logStructured } from '@/lib/utils/structured-log';
 import { S3Service } from '@/lib/services/s3';
 
@@ -853,6 +856,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         { error: 'Invalid source asset ID format', success: false },
         { status: 400 }
       );
+    }
+
+    const legacyScopeGuard = guardLegacySam3BatchScope(body.assetIds);
+    if (!legacyScopeGuard.allowed) {
+      return NextResponse.json(legacyScopeGuard.response, { status: 409 });
     }
 
     // Get target asset IDs

--- a/app/api/training-hub/readiness/route.ts
+++ b/app/api/training-hub/readiness/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from 'next/server';
+import { getAuthenticatedUser } from '@/lib/auth/api-auth';
+import { checkRedisConnection } from '@/lib/queue/redis';
+import {
+  summarizeCommercialWorkflowReadiness,
+} from '@/lib/services/commercial-workflow-readiness';
+import { roboflowService } from '@/lib/services/roboflow';
+import { sam3Orchestrator } from '@/lib/services/sam3-orchestrator';
+import { yoloService } from '@/lib/services/yolo';
+
+export async function GET() {
+  try {
+    const auth = await getAuthenticatedUser();
+    if (!auth.authenticated) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const [samStatus, queueReady, yoloResult] = await Promise.all([
+      sam3Orchestrator.getStatus(),
+      checkRedisConnection(),
+      yoloService
+        .checkHealth()
+        .then((health) => ({ ready: health.status === 'healthy', health, error: null }))
+        .catch((error) => ({
+          ready: false,
+          health: null,
+          error: error instanceof Error ? error.message : 'YOLO service unavailable',
+        })),
+    ]);
+
+    const roboflowModelCount = roboflowService.getEnabledModels().length;
+    const roboflowConfigured = Boolean(
+      process.env.ROBOFLOW_API_KEY &&
+        process.env.ROBOFLOW_WORKSPACE &&
+        roboflowModelCount > 0
+    );
+
+    const readiness = summarizeCommercialWorkflowReadiness({
+      samConfigured: samStatus.awsConfigured,
+      samReady: samStatus.awsAvailable,
+      samState: samStatus.awsState,
+      samGpuAvailable: samStatus.awsGpuAvailable,
+      samModelLoaded: samStatus.awsModelLoaded,
+      queueReady,
+      yoloReady: yoloResult.ready,
+      yoloError: yoloResult.error,
+      roboflowConfigured,
+      roboflowModelCount,
+    });
+
+    return NextResponse.json({
+      ...readiness,
+      raw: {
+        sam: {
+          configured: samStatus.awsConfigured,
+          state: samStatus.awsState,
+          ready: samStatus.awsAvailable,
+          gpuAvailable: samStatus.awsGpuAvailable,
+          modelLoaded: samStatus.awsModelLoaded,
+        },
+        queue: { ready: queueReady },
+        yolo: {
+          ready: yoloResult.ready,
+          health: yoloResult.health,
+          error: yoloResult.error,
+        },
+        roboflow: {
+          configured: roboflowConfigured,
+          enabledModelCount: roboflowModelCount,
+        },
+      },
+    });
+  } catch (error) {
+    console.error('[Training Hub Readiness] Failed to build readiness summary:', error);
+    return NextResponse.json(
+      { error: 'Failed to check commercial workflow readiness' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/training/datasets/preview/route.ts
+++ b/app/api/training/datasets/preview/route.ts
@@ -8,6 +8,7 @@ import prisma from '@/lib/db';
 import { datasetPreparation } from '@/lib/services/dataset-preparation';
 import { getAuthenticatedUser } from '@/lib/auth/api-auth';
 import { checkRateLimit } from '@/lib/utils/security';
+import { normalizeTrainingDatasetSourceFlags } from '@/lib/utils/training-dataset-sources';
 
 export async function POST(request: NextRequest) {
   try {
@@ -37,10 +38,16 @@ export async function POST(request: NextRequest) {
       sessionIds,
       classes,
       splitRatio,
-      includeAIDetections = true,
-      includeManualAnnotations = true,
+      includeAIDetections,
+      includeManualAnnotations,
+      includeSAM3,
       minConfidence = 0.5,
     } = body;
+    const sourceFlags = normalizeTrainingDatasetSourceFlags({
+      includeAIDetections,
+      includeManualAnnotations,
+      includeSAM3,
+    });
 
     if (!projectId) {
       return NextResponse.json({ error: 'projectId is required' }, { status: 400 });
@@ -99,12 +106,13 @@ export async function POST(request: NextRequest) {
       sessionIds,
       classes,
       splitRatio: splitRatio || { train: 0.7, val: 0.2, test: 0.1 },
-      includeAIDetections,
-      includeManualAnnotations,
+      includeAIDetections: sourceFlags.includeAIDetections,
+      includeManualAnnotations: sourceFlags.includeManualAnnotations,
+      includeSAM3: sourceFlags.includeSAM3,
       minConfidence,
     });
 
-    return NextResponse.json({ preview });
+    return NextResponse.json({ preview, sources: sourceFlags });
   } catch (error) {
     console.error('Error previewing dataset:', error);
     const message = error instanceof Error ? error.message : 'Failed to preview dataset';

--- a/app/api/training/datasets/route.ts
+++ b/app/api/training/datasets/route.ts
@@ -9,6 +9,7 @@ import prisma from '@/lib/db';
 import { datasetPreparation } from '@/lib/services/dataset-preparation';
 import { getAuthenticatedUser, getUserTeamIds } from '@/lib/auth/api-auth';
 import { checkRateLimit } from '@/lib/utils/security';
+import { normalizeTrainingDatasetSourceFlags } from '@/lib/utils/training-dataset-sources';
 
 const ALLOWED_AUGMENTATION_PRESETS = new Set([
   'none',
@@ -48,12 +49,18 @@ export async function POST(request: NextRequest) {
       sessionIds,
       classes,
       splitRatio,
-      includeAIDetections = true,
-      includeManualAnnotations = true,
+      includeAIDetections,
+      includeManualAnnotations,
+      includeSAM3,
       minConfidence = 0.5,
       augmentationPreset = 'none',
       augmentationConfig,
     } = body;
+    const sourceFlags = normalizeTrainingDatasetSourceFlags({
+      includeAIDetections,
+      includeManualAnnotations,
+      includeSAM3,
+    });
 
     if (!name || typeof name !== 'string') {
       return NextResponse.json({ error: 'name is required' }, { status: 400 });
@@ -140,8 +147,9 @@ export async function POST(request: NextRequest) {
       sessionIds,
       classes,
       splitRatio: splitRatio || { train: 0.7, val: 0.2, test: 0.1 },
-      includeAIDetections,
-      includeManualAnnotations,
+      includeAIDetections: sourceFlags.includeAIDetections,
+      includeManualAnnotations: sourceFlags.includeManualAnnotations,
+      includeSAM3: sourceFlags.includeSAM3,
       minConfidence,
       createdById: auth.userId,
       augmentationPreset,
@@ -198,6 +206,7 @@ export async function POST(request: NextRequest) {
           augmentationPreset && augmentationPreset !== 'none'
             ? augmentationConfig || null
             : null,
+        sources: sourceFlags,
       },
     });
   } catch (error) {

--- a/app/training-hub/page.tsx
+++ b/app/training-hub/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useState, useEffect } from 'react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Sam3Ec2Control } from '@/components/dashboard/sam3-ec2-control';
 import {
@@ -71,6 +72,21 @@ interface BatchJob {
   };
 }
 
+interface WorkflowReadinessCheck {
+  key: 'sam' | 'queue' | 'yolo' | 'roboflow';
+  label: string;
+  ready: boolean;
+  state: 'ready' | 'blocked' | 'available';
+  message: string;
+}
+
+interface WorkflowReadinessResponse {
+  readyForSamDatasetRun: boolean;
+  readyForYoloTraining: boolean;
+  roboflowFallbackAvailable: boolean;
+  checks: WorkflowReadinessCheck[];
+}
+
 export default function TrainingHubPage() {
   const [projects, setProjects] = useState<RoboflowProject[]>([]);
   const [batchJobs, setBatchJobs] = useState<BatchJob[]>([]);
@@ -79,6 +95,9 @@ export default function TrainingHubPage() {
   const [error, setError] = useState<string | null>(null);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [sam3Ready, setSam3Ready] = useState(false);
+  const [workflowReadiness, setWorkflowReadiness] =
+    useState<WorkflowReadinessResponse | null>(null);
+  const [workflowReadinessError, setWorkflowReadinessError] = useState<string | null>(null);
   const [deletingBatchId, setDeletingBatchId] = useState<string | null>(null);
   const [batchToDelete, setBatchToDelete] = useState<BatchJob | null>(null);
 
@@ -132,9 +151,25 @@ export default function TrainingHubPage() {
     }
   };
 
+  const fetchWorkflowReadiness = async () => {
+    try {
+      setWorkflowReadinessError(null);
+      const response = await fetch('/api/training-hub/readiness');
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(data?.error || `Readiness check failed (${response.status})`);
+      }
+      setWorkflowReadiness(data);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load workflow readiness';
+      setWorkflowReadinessError(message);
+    }
+  };
+
   useEffect(() => {
     fetchProjects();
     fetchBatchJobs();
+    fetchWorkflowReadiness();
   }, []);
 
   const handleSam3ReadyChange = useCallback((ready: boolean) => {
@@ -197,7 +232,58 @@ export default function TrainingHubPage() {
           title="SAM3 Readiness"
           onReadyChange={handleSam3ReadyChange}
         />
-
+        <Card className="border-slate-200 bg-white mb-6">
+          <CardHeader className="pb-3">
+            <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+              <div>
+                <CardTitle className="text-lg">Commercial Workflow Readiness</CardTitle>
+                <CardDescription>
+                  SAM labels, review gate, YOLO 11 training, and Roboflow fallback.
+                </CardDescription>
+              </div>
+              <Button variant="outline" size="sm" onClick={fetchWorkflowReadiness}>
+                <RefreshCw className="w-4 h-4 mr-2" />
+                Refresh
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent>
+            {workflowReadinessError ? (
+              <div className="flex items-center gap-2 text-sm text-amber-700">
+                <AlertCircle className="h-4 w-4" />
+                {workflowReadinessError}
+              </div>
+            ) : workflowReadiness ? (
+              <div className="grid gap-3 md:grid-cols-4">
+                {workflowReadiness.checks.map((check) => (
+                  <div
+                    key={check.key}
+                    className="rounded-lg border border-slate-200 bg-slate-50 p-3"
+                  >
+                    <Badge
+                      variant={check.state === 'blocked' ? 'destructive' : 'secondary'}
+                      className={
+                        check.state === 'ready'
+                          ? 'bg-green-100 text-green-700 hover:bg-green-100'
+                          : check.state === 'available'
+                            ? 'bg-blue-100 text-blue-700 hover:bg-blue-100'
+                            : undefined
+                      }
+                    >
+                      {check.label}
+                    </Badge>
+                    <p className="mt-2 text-xs text-slate-600">{check.message}</p>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="flex items-center gap-2 text-sm text-slate-500">
+                <RefreshCw className="h-4 w-4 animate-spin" />
+                Checking workflow readiness...
+              </div>
+            )}
+          </CardContent>
+        </Card>
         <WorkflowGuide current="sam3" />
         {/* Workflow Cards */}
         <div className="grid md:grid-cols-2 gap-6 mb-8">

--- a/docs/COMMERCIAL_WORKFLOW_CONTRACT.md
+++ b/docs/COMMERCIAL_WORKFLOW_CONTRACT.md
@@ -1,0 +1,22 @@
+# Commercial Labelling Workflow Contract
+
+AgriDrone production should optimize for one reliable operator workflow:
+
+1. Use SAM3 to identify objects of interest from operator examples.
+2. Apply those examples across a dataset to speed up labelling.
+3. Review labels, approve the good ones, then train YOLO 11 on AWS with the selected augmentation preset.
+
+## Supported Production Path
+
+- Multi-image SAM runs must use `/api/sam3/v2/batch` with visual matching.
+- Legacy `/api/sam3/batch` is for one explicit debug image only.
+- SAM3 outputs enter review as pending labels.
+- Only accepted SAM3 labels can enter YOLO training datasets.
+- Roboflow is an explicit fallback/benchmark source, not a silent replacement.
+- Only reviewed Roboflow detections can enter YOLO training datasets.
+
+## Operator Safety
+
+- Do not train from unreviewed labels.
+- Do not silently route multi-image runs through legacy SAM.
+- Do not hide SAM, YOLO, or Roboflow readiness failures behind generic errors.

--- a/lib/services/commercial-workflow-readiness.ts
+++ b/lib/services/commercial-workflow-readiness.ts
@@ -1,0 +1,87 @@
+export type CommercialWorkflowReadinessKey = 'sam' | 'queue' | 'yolo' | 'roboflow';
+
+export interface CommercialWorkflowReadinessInput {
+  samConfigured: boolean;
+  samReady: boolean;
+  samState?: string | null;
+  samGpuAvailable?: boolean | null;
+  samModelLoaded?: boolean | null;
+  queueReady: boolean;
+  yoloReady: boolean;
+  yoloError?: string | null;
+  roboflowConfigured: boolean;
+  roboflowModelCount: number;
+}
+
+export interface CommercialWorkflowReadinessCheck {
+  key: CommercialWorkflowReadinessKey;
+  label: string;
+  ready: boolean;
+  state: 'ready' | 'blocked' | 'available';
+  message: string;
+}
+
+export interface CommercialWorkflowReadinessSummary {
+  readyForSamDatasetRun: boolean;
+  readyForYoloTraining: boolean;
+  roboflowFallbackAvailable: boolean;
+  checks: CommercialWorkflowReadinessCheck[];
+}
+
+export function summarizeCommercialWorkflowReadiness(
+  input: CommercialWorkflowReadinessInput
+): CommercialWorkflowReadinessSummary {
+  const samReady = Boolean(
+    input.samConfigured &&
+      input.samReady &&
+      input.samGpuAvailable &&
+      input.samModelLoaded
+  );
+  const roboflowFallbackAvailable = input.roboflowConfigured && input.roboflowModelCount > 0;
+
+  return {
+    readyForSamDatasetRun: samReady && input.queueReady,
+    readyForYoloTraining: input.yoloReady,
+    roboflowFallbackAvailable,
+    checks: [
+      {
+        key: 'sam',
+        label: samReady ? 'SAM ready' : 'SAM blocked',
+        ready: samReady,
+        state: samReady ? 'ready' : 'blocked',
+        message: samReady
+          ? 'SAM3 v2 visual matching is ready for dataset labelling.'
+          : `SAM3 is not ready${input.samState ? ` (state: ${input.samState})` : ''}.`,
+      },
+      {
+        key: 'queue',
+        label: input.queueReady ? 'Queue ready' : 'Queue blocked',
+        ready: input.queueReady,
+        state: input.queueReady ? 'ready' : 'blocked',
+        message: input.queueReady
+          ? 'Redis/BullMQ can accept SAM3 dataset jobs.'
+          : 'Redis/BullMQ is unavailable, so dataset labelling cannot be queued.',
+      },
+      {
+        key: 'yolo',
+        label: input.yoloReady ? 'YOLO ready' : 'YOLO blocked',
+        ready: input.yoloReady,
+        state: input.yoloReady ? 'ready' : 'blocked',
+        message: input.yoloReady
+          ? 'AWS YOLO 11 training service is reachable.'
+          : input.yoloError || 'AWS YOLO 11 training service is not reachable.',
+      },
+      {
+        key: 'roboflow',
+        label: roboflowFallbackAvailable
+          ? 'Roboflow fallback available'
+          : 'Roboflow fallback blocked',
+        ready: roboflowFallbackAvailable,
+        state: roboflowFallbackAvailable ? 'available' : 'blocked',
+        message: roboflowFallbackAvailable
+          ? `${input.roboflowModelCount} Roboflow model${input.roboflowModelCount === 1 ? '' : 's'} available as explicit fallback/benchmark.`
+          : 'Roboflow credentials or enabled models are missing.',
+      },
+    ],
+  };
+}

--- a/lib/services/dataset-preparation.ts
+++ b/lib/services/dataset-preparation.ts
@@ -80,6 +80,9 @@ interface DatasetDetection {
   boundingBox: unknown;
   type?: string | null;
   preprocessingMeta?: unknown;
+  verified?: boolean | null;
+  rejected?: boolean | null;
+  userCorrected?: boolean | null;
 }
 
 interface DatasetAnnotation {
@@ -537,6 +540,9 @@ class DatasetPreparationService {
 
     if (includeAI && asset.detections) {
       for (const detection of asset.detections) {
+        if (detection.rejected) continue;
+        if (detection.verified === false && detection.userCorrected !== true) continue;
+
         const confidence = typeof detection.confidence === 'number' ? detection.confidence : 0;
         if (confidence < minConfidence) continue;
 
@@ -563,6 +569,8 @@ class DatasetPreparationService {
 
     if (includeSAM3 && asset.pendingAnnotations) {
       for (const pending of asset.pendingAnnotations) {
+        if (pending.status && pending.status !== 'ACCEPTED') continue;
+
         if (typeof pending.confidence === 'number' && pending.confidence < minConfidence) {
           continue;
         }

--- a/lib/utils/sam3-batch-jobs.ts
+++ b/lib/utils/sam3-batch-jobs.ts
@@ -7,6 +7,39 @@ export const SAM3_BATCH_JOB_KINDS = {
 export type Sam3BatchJobKind =
   (typeof SAM3_BATCH_JOB_KINDS)[keyof typeof SAM3_BATCH_JOB_KINDS];
 
+export const SAM3_V2_BATCH_ENDPOINT = '/api/sam3/v2/batch';
+
+export const LEGACY_SAM3_REQUIRES_V2_MESSAGE =
+  'Multi-image Apply to Dataset requires SAM3 v2 visual matching.';
+
+export interface LegacySam3BatchGuardResult {
+  allowed: boolean;
+  response?: {
+    success: false;
+    error: string;
+    requiresV2: true;
+    recommendedEndpoint: typeof SAM3_V2_BATCH_ENDPOINT;
+  };
+}
+
+export function guardLegacySam3BatchScope(
+  assetIds: string[] | undefined | null
+): LegacySam3BatchGuardResult {
+  if (Array.isArray(assetIds) && assetIds.length === 1) {
+    return { allowed: true };
+  }
+
+  return {
+    allowed: false,
+    response: {
+      success: false,
+      error: LEGACY_SAM3_REQUIRES_V2_MESSAGE,
+      requiresV2: true,
+      recommendedEndpoint: SAM3_V2_BATCH_ENDPOINT,
+    },
+  };
+}
+
 export interface BatchJobChildSnapshot {
   id: string;
   status: string;

--- a/lib/utils/training-dataset-sources.ts
+++ b/lib/utils/training-dataset-sources.ts
@@ -1,0 +1,21 @@
+export interface TrainingDatasetSourceFlags {
+  includeAIDetections: boolean;
+  includeManualAnnotations: boolean;
+  includeSAM3: boolean;
+}
+
+export function normalizeTrainingDatasetSourceFlags(input: {
+  includeAIDetections?: unknown;
+  includeManualAnnotations?: unknown;
+  includeSAM3?: unknown;
+}): TrainingDatasetSourceFlags {
+  return {
+    includeAIDetections:
+      typeof input.includeAIDetections === 'boolean' ? input.includeAIDetections : true,
+    includeManualAnnotations:
+      typeof input.includeManualAnnotations === 'boolean'
+        ? input.includeManualAnnotations
+        : true,
+    includeSAM3: typeof input.includeSAM3 === 'boolean' ? input.includeSAM3 : true,
+  };
+}

--- a/tests/unit/commercial-workflow-readiness.test.ts
+++ b/tests/unit/commercial-workflow-readiness.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { summarizeCommercialWorkflowReadiness } from '@/lib/services/commercial-workflow-readiness';
+
+describe('commercial workflow readiness', () => {
+  it('marks the full SAM-to-YOLO workflow ready when core services are healthy', () => {
+    const summary = summarizeCommercialWorkflowReadiness({
+      samConfigured: true,
+      samReady: true,
+      samState: 'running',
+      samGpuAvailable: true,
+      samModelLoaded: true,
+      queueReady: true,
+      yoloReady: true,
+      roboflowConfigured: true,
+      roboflowModelCount: 2,
+    });
+
+    expect(summary.readyForSamDatasetRun).toBe(true);
+    expect(summary.readyForYoloTraining).toBe(true);
+    expect(summary.roboflowFallbackAvailable).toBe(true);
+    expect(summary.checks.map((check) => check.label)).toEqual([
+      'SAM ready',
+      'Queue ready',
+      'YOLO ready',
+      'Roboflow fallback available',
+    ]);
+  });
+
+  it('blocks SAM dataset runs when the EC2 host is stopped or the model is unloaded', () => {
+    const summary = summarizeCommercialWorkflowReadiness({
+      samConfigured: true,
+      samReady: false,
+      samState: 'stopped',
+      samGpuAvailable: true,
+      samModelLoaded: false,
+      queueReady: true,
+      yoloReady: true,
+      roboflowConfigured: true,
+      roboflowModelCount: 1,
+    });
+
+    expect(summary.readyForSamDatasetRun).toBe(false);
+    expect(summary.checks.find((check) => check.key === 'sam')).toMatchObject({
+      label: 'SAM blocked',
+      state: 'blocked',
+      message: 'SAM3 is not ready (state: stopped).',
+    });
+  });
+
+  it('keeps Roboflow as an explicit fallback without marking SAM ready', () => {
+    const summary = summarizeCommercialWorkflowReadiness({
+      samConfigured: false,
+      samReady: false,
+      queueReady: false,
+      yoloReady: false,
+      yoloError: 'YOLO service unavailable',
+      roboflowConfigured: true,
+      roboflowModelCount: 3,
+    });
+
+    expect(summary.readyForSamDatasetRun).toBe(false);
+    expect(summary.readyForYoloTraining).toBe(false);
+    expect(summary.roboflowFallbackAvailable).toBe(true);
+    expect(summary.checks.find((check) => check.key === 'roboflow')).toMatchObject({
+      label: 'Roboflow fallback available',
+      state: 'available',
+    });
+  });
+});

--- a/tests/unit/export-review-filters.test.ts
+++ b/tests/unit/export-review-filters.test.ts
@@ -21,6 +21,13 @@ describe('export review filters', () => {
     expect(filter).not.toMatchObject({ verified: false, userCorrected: false });
   });
 
+  it('uses the same review gate for Roboflow fallback detections', () => {
+    expect(buildDetectionReviewFilter(false)).toEqual({
+      rejected: false,
+      OR: [{ verified: true }, { userCorrected: true }],
+    });
+  });
+
   it('exports pending AI detections only for explicit review QA exports', () => {
     expect(buildDetectionReviewFilter(true)).toEqual({
       rejected: false,

--- a/tests/unit/sam3-batch-job-utils.test.ts
+++ b/tests/unit/sam3-batch-job-utils.test.ts
@@ -1,10 +1,26 @@
 import { describe, expect, it } from 'vitest';
 import {
   chunkAssetIds,
+  guardLegacySam3BatchScope,
   summarizeChildBatchJobs,
 } from '@/lib/utils/sam3-batch-jobs';
 
 describe('sam3-batch-job-utils', () => {
+  it.each([
+    [1, [1]],
+    [10, [10]],
+    [500, [500]],
+    [501, [500, 1]],
+    [2200, [500, 500, 500, 500, 200]],
+  ])('chunks %i-image v2 dataset runs deterministically', (assetCount, expectedSizes) => {
+    const assetIds = Array.from({ length: assetCount }, (_, index) => `asset-${index + 1}`);
+
+    const chunks = chunkAssetIds(assetIds, 500);
+
+    expect(chunks.map((chunk) => chunk.length)).toEqual(expectedSizes);
+    expect(chunks.flat()).toEqual(assetIds);
+  });
+
   it('chunks a 2200-image dataset into deterministic 500-image shards', () => {
     const assetIds = Array.from({ length: 2200 }, (_, index) => `asset-${index + 1}`);
 
@@ -14,6 +30,32 @@ describe('sam3-batch-job-utils', () => {
     expect(chunks.map((chunk) => chunk.length)).toEqual([500, 500, 500, 500, 200]);
     expect(chunks[0][0]).toBe('asset-1');
     expect(chunks[4][199]).toBe('asset-2200');
+  });
+
+  it('blocks project-wide legacy SAM3 batch calls before they can silently run', () => {
+    expect(guardLegacySam3BatchScope(undefined)).toEqual({
+      allowed: false,
+      response: {
+        success: false,
+        error: 'Multi-image Apply to Dataset requires SAM3 v2 visual matching.',
+        requiresV2: true,
+        recommendedEndpoint: '/api/sam3/v2/batch',
+      },
+    });
+  });
+
+  it('blocks multi-asset legacy SAM3 batch calls before they can silently run', () => {
+    expect(guardLegacySam3BatchScope(['asset-1', 'asset-2'])).toMatchObject({
+      allowed: false,
+      response: {
+        requiresV2: true,
+        recommendedEndpoint: '/api/sam3/v2/batch',
+      },
+    });
+  });
+
+  it('allows only a single explicit legacy SAM3 debug asset', () => {
+    expect(guardLegacySam3BatchScope(['asset-1'])).toEqual({ allowed: true });
   });
 
   it('summarizes mixed shard outcomes as a completed dataset run with warnings', () => {

--- a/tests/unit/training-dataset-sources.test.ts
+++ b/tests/unit/training-dataset-sources.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import { datasetPreparation } from '@/lib/services/dataset-preparation';
+import { buildTrainingAugmentationFromDataset } from '@/lib/services/training-augmentation';
+import { normalizeTrainingDatasetSourceFlags } from '@/lib/utils/training-dataset-sources';
+
+describe('training dataset sources', () => {
+  const classMap = new Map([['lantana', 0]]);
+  const datasetPreparationInternals = datasetPreparation as unknown as {
+    convertToYOLO: (
+      asset: Record<string, unknown>,
+      classMap: Map<string, number>,
+      includeAI: boolean,
+      includeManual: boolean,
+      minConfidence: number,
+      includeSAM3: boolean
+    ) => Array<{
+      classId: number;
+      bbox: { x: number; y: number; width: number; height: number };
+    }>;
+  };
+
+  function convertToYOLO(asset: Record<string, unknown>) {
+    return datasetPreparationInternals.convertToYOLO(
+      {
+        id: 'asset-1',
+        fileName: 'asset-1.jpg',
+        imageWidth: 100,
+        imageHeight: 100,
+        ...asset,
+      },
+      classMap,
+      true,
+      true,
+      0.5,
+      true
+    );
+  }
+
+  it('includes accepted SAM3 labels by default when building training datasets', () => {
+    expect(normalizeTrainingDatasetSourceFlags({})).toEqual({
+      includeAIDetections: true,
+      includeManualAnnotations: true,
+      includeSAM3: true,
+    });
+  });
+
+  it('allows callers to explicitly disable SAM3 labels', () => {
+    expect(normalizeTrainingDatasetSourceFlags({ includeSAM3: false })).toMatchObject({
+      includeSAM3: false,
+    });
+  });
+
+  it('converts accepted SAM3 pending annotations into YOLO labels', () => {
+    const labels = convertToYOLO({
+      pendingAnnotations: [
+        {
+          weedType: 'Lantana',
+          confidence: 0.92,
+          status: 'ACCEPTED',
+          bbox: [10, 20, 50, 80],
+          polygon: [],
+        },
+      ],
+    });
+
+    expect(labels).toEqual([
+      {
+        classId: 0,
+        bbox: {
+          x: 0.3,
+          y: 0.5,
+          width: 0.4,
+          height: 0.6,
+        },
+      },
+    ]);
+  });
+
+  it('excludes pending and rejected SAM3 labels from YOLO datasets', () => {
+    const labels = convertToYOLO({
+      pendingAnnotations: [
+        {
+          weedType: 'Lantana',
+          confidence: 0.92,
+          status: 'PENDING',
+          bbox: [10, 20, 50, 80],
+          polygon: [],
+        },
+        {
+          weedType: 'Lantana',
+          confidence: 0.92,
+          status: 'REJECTED',
+          bbox: [10, 20, 50, 80],
+          polygon: [],
+        },
+      ],
+    });
+
+    expect(labels).toEqual([]);
+  });
+
+  it('includes reviewed Roboflow fallback detections through the same review gate', () => {
+    const labels = convertToYOLO({
+      detections: [
+        {
+          type: 'AI',
+          className: 'Lantana',
+          confidence: 0.88,
+          verified: true,
+          rejected: false,
+          userCorrected: false,
+          boundingBox: { x: 20, y: 30, width: 10, height: 12 },
+          metadata: { source: 'roboflow_batch_detection' },
+        },
+      ],
+    });
+
+    expect(labels).toHaveLength(1);
+    expect(labels[0].classId).toBe(0);
+  });
+
+  it('excludes unreviewed Roboflow fallback detections from YOLO datasets', () => {
+    const labels = convertToYOLO({
+      detections: [
+        {
+          type: 'AI',
+          className: 'Lantana',
+          confidence: 0.88,
+          verified: false,
+          rejected: false,
+          userCorrected: false,
+          boundingBox: { x: 20, y: 30, width: 10, height: 12 },
+          metadata: { source: 'roboflow_batch_detection' },
+        },
+      ],
+    });
+
+    expect(labels).toEqual([]);
+  });
+
+  it('carries dataset augmentation presets into YOLO training config', () => {
+    expect(
+      buildTrainingAugmentationFromDataset({
+        augmentationPreset: 'agricultural',
+        augmentationConfig: JSON.stringify({
+          horizontalFlip: true,
+          rotation: 12,
+          brightness: 20,
+          copiesPerImage: 3,
+        }),
+      })
+    ).toMatchObject({
+      preset: 'agricultural',
+      horizontal_flip: true,
+      fliplr: 0.5,
+      rotation_degrees: 12,
+      degrees: 12,
+      brightness_pct: 20,
+      hsv_v: 0.2,
+      copies_per_image: 3,
+    });
+  });
+});

--- a/tests/unit/yolo-training-service.test.ts
+++ b/tests/unit/yolo-training-service.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { YOLOService } from '@/lib/services/yolo';
+
+describe('yolo training service', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('sends dataset augmentation through to the AWS YOLO 11 training request', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ job_id: 'job-1', status: 'queued' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    global.fetch = fetchMock as typeof fetch;
+    const service = new YOLOService({ baseUrl: 'http://yolo.test', timeout: 1000 });
+
+    await service.startTraining({
+      dataset_s3_path: 's3://bucket/datasets/project/v1/',
+      model_name: 'lantana-v1',
+      base_model: 'yolo11m',
+      epochs: 50,
+      batch_size: 8,
+      image_size: 960,
+      learning_rate: 0.005,
+      augmentation: {
+        preset: 'agricultural',
+        fliplr: 0.5,
+        degrees: 12,
+        hsv_v: 0.2,
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('http://yolo.test/api/v1/train');
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect(body).toMatchObject({
+      dataset_s3_path: 's3://bucket/datasets/project/v1/',
+      model_name: 'lantana-v1',
+      base_model: 'yolo11m',
+      epochs: 50,
+      batch_size: 8,
+      image_size: 960,
+      learning_rate: 0.005,
+      augmentation: {
+        preset: 'agricultural',
+        fliplr: 0.5,
+        degrees: 12,
+        hsv_v: 0.2,
+      },
+      fliplr: 0.5,
+      degrees: 12,
+      hsv_v: 0.2,
+    });
+  });
+
+  it('fails with a clear unavailable-service error when YOLO training cannot be reached', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('connect ECONNREFUSED')) as typeof fetch;
+    const service = new YOLOService({ baseUrl: 'http://yolo.test', timeout: 1000 });
+
+    await expect(
+      service.startTraining({
+        dataset_s3_path: 's3://bucket/datasets/project/v1/',
+        model_name: 'lantana-v1',
+      })
+    ).rejects.toMatchObject({
+      name: 'YOLOServiceError',
+      statusCode: 503,
+      message: 'Failed to connect to YOLO service: connect ECONNREFUSED',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- lock legacy SAM3 batch out of unsafe multi-image dataset runs and keep multi-image Apply to All on SAM3 v2 visual matching
- include accepted SAM3 labels in YOLO training datasets by default while keeping pending/rejected SAM and unreviewed Roboflow labels out
- add Training Hub commercial workflow readiness checks for SAM, queue, YOLO 11, and Roboflow fallback
- add a GitHub Actions quality gate and document the production workflow contract

## Verification
- npm run test:unit
- npm run lint
- npm run build

## Notes
- Roboflow remains explicit fallback/benchmark only; no silent auto-switching was introduced.
- Existing lint warnings remain in unrelated files.