### PR TITLE
Refine SAM3 v2 target image matches

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,9 +59,9 @@ SAM3_CONCEPT_PORT="8002"
 # SAM3_CONCEPT_API_URL="http://localhost:8002"
 # Optional: API key for concept propagation service
 SAM3_CONCEPT_API_KEY=""
-# Optional: tweak concept apply defaults (leave blank to use service defaults)
-# SAM3_CONCEPT_SIMILARITY_THRESHOLD="0.6"
-# SAM3_CONCEPT_TOP_K="150"
+# Optional: tweak concept apply defaults used by SAM3 v2 target-image matching
+# SAM3_CONCEPT_SIMILARITY_THRESHOLD="0.65"
+# SAM3_CONCEPT_TOP_K="120"
 # SAM3_CONCEPT_MIN_BOX_SIZE="16"
 # SAM3_CONCEPT_MAX_BOX_SIZE="600"
 # SAM3_CONCEPT_NMS_THRESHOLD="0.5"

--- a/lib/services/sam3-batch-v2.ts
+++ b/lib/services/sam3-batch-v2.ts
@@ -33,6 +33,66 @@ export const SAM3_BATCH_V2_GPU_LOCK_RETRY_TIMEOUT_MS = 60000;
 export const SAM3_BATCH_V2_GPU_MEMORY_THRESHOLD_MB = 12 * 1024;
 export const SAM3_BATCH_V2_MODEL_OVERHEAD_MB = 4096;
 
+const parseOptionalNumber = (value: string | undefined): number | undefined => {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const parseOptionalInt = (value: string | undefined): number | undefined => {
+  if (!value) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+export const SAM3_BATCH_V2_DEFAULT_SIMILARITY_THRESHOLD =
+  parseOptionalNumber(process.env.SAM3_CONCEPT_SIMILARITY_THRESHOLD) ?? 0.65;
+export const SAM3_BATCH_V2_DEFAULT_TOP_K =
+  parseOptionalInt(process.env.SAM3_CONCEPT_TOP_K) ?? 120;
+export const SAM3_BATCH_V2_DEFAULT_MIN_BOX_SIZE =
+  parseOptionalInt(process.env.SAM3_CONCEPT_MIN_BOX_SIZE) ?? 16;
+export const SAM3_BATCH_V2_DEFAULT_MAX_BOX_SIZE =
+  parseOptionalInt(process.env.SAM3_CONCEPT_MAX_BOX_SIZE) ?? 600;
+export const SAM3_BATCH_V2_DEFAULT_NMS_THRESHOLD =
+  parseOptionalNumber(process.env.SAM3_CONCEPT_NMS_THRESHOLD) ?? 0.5;
+
+export function buildBatchV2ConceptApplyOptions(): SAM3ConceptApplyOptions {
+  return {
+    returnPolygons: true,
+    similarityThreshold: SAM3_BATCH_V2_DEFAULT_SIMILARITY_THRESHOLD,
+    topK: SAM3_BATCH_V2_DEFAULT_TOP_K,
+    minBoxSize: SAM3_BATCH_V2_DEFAULT_MIN_BOX_SIZE,
+    maxBoxSize: SAM3_BATCH_V2_DEFAULT_MAX_BOX_SIZE,
+    nmsThreshold: SAM3_BATCH_V2_DEFAULT_NMS_THRESHOLD,
+  };
+}
+
+function conceptDetectionScore(
+  detection: Pick<SAM3ConceptDetection, 'similarity' | 'confidence'>
+): number {
+  if (typeof detection.similarity === 'number' && Number.isFinite(detection.similarity)) {
+    return detection.similarity;
+  }
+  if (typeof detection.confidence === 'number' && Number.isFinite(detection.confidence)) {
+    return detection.confidence;
+  }
+  return 0;
+}
+
+export function filterBatchV2ConceptDetections(
+  detections: SAM3ConceptDetection[],
+  options: SAM3ConceptApplyOptions = buildBatchV2ConceptApplyOptions()
+): SAM3ConceptDetection[] {
+  const threshold =
+    typeof options.similarityThreshold === 'number'
+      ? options.similarityThreshold
+      : SAM3_BATCH_V2_DEFAULT_SIMILARITY_THRESHOLD;
+
+  return detections
+    .filter((detection) => conceptDetectionScore(detection) >= threshold)
+    .sort((left, right) => conceptDetectionScore(right) - conceptDetectionScore(left));
+}
+
 const EMPIRICAL_GPU_MEMORY_LOOKUP_MB: Record<number, number> = {
   1: 4608,
   2: 5632,
@@ -469,6 +529,70 @@ function normalizePolygon(
     [bbox[2], bbox[3]],
     [bbox[0], bbox[3]],
   ];
+}
+
+function bboxToBoxCoordinate(
+  bbox: [number, number, number, number],
+  scaleFactor = 1
+): BoxCoordinate {
+  return {
+    x1: Math.round(bbox[0] * scaleFactor),
+    y1: Math.round(bbox[1] * scaleFactor),
+    x2: Math.round(bbox[2] * scaleFactor),
+    y2: Math.round(bbox[3] * scaleFactor),
+  };
+}
+
+function isValidBox(box: BoxCoordinate): boolean {
+  return box.x2 > box.x1 && box.y2 > box.y1;
+}
+
+function bboxArea(bbox: [number, number, number, number]): number {
+  return Math.max(0, bbox[2] - bbox[0]) * Math.max(0, bbox[3] - bbox[1]);
+}
+
+function bboxIou(
+  first: [number, number, number, number],
+  second: [number, number, number, number]
+): number {
+  const x1 = Math.max(first[0], second[0]);
+  const y1 = Math.max(first[1], second[1]);
+  const x2 = Math.min(first[2], second[2]);
+  const y2 = Math.min(first[3], second[3]);
+  const intersection = bboxArea([x1, y1, x2, y2]);
+  const union = bboxArea(first) + bboxArea(second) - intersection;
+
+  return union > 0 ? intersection / union : 0;
+}
+
+function bestConceptCandidateForBbox(
+  bbox: [number, number, number, number],
+  candidates: SAM3ConceptDetection[]
+): SAM3ConceptDetection | null {
+  let bestCandidate: SAM3ConceptDetection | null = null;
+  let bestScore = -1;
+
+  for (const candidate of candidates) {
+    const score = bboxIou(bbox, candidate.bbox);
+    if (score > bestScore) {
+      bestCandidate = candidate;
+      bestScore = score;
+    }
+  }
+
+  return bestCandidate;
+}
+
+function mapConceptDetectionToAssetDetection(
+  detection: SAM3ConceptDetection
+): AssetInferenceResult['detections'][number] {
+  const score = conceptDetectionScore(detection);
+  return {
+    bbox: detection.bbox,
+    polygon: normalizePolygon(detection.polygon, detection.bbox),
+    confidence: score,
+    similarity: typeof detection.similarity === 'number' ? detection.similarity : score,
+  };
 }
 
 function scaleBboxToOriginal(
@@ -1200,7 +1324,12 @@ export class Sam3BatchV2Service {
             }
 
             if (visualMatchExemplarId) {
-              result = await this.runVisualConceptMatch(asset, imageBuffer, visualMatchExemplarId);
+              result = await this.runVisualConceptMatch(
+                asset,
+                imageBuffer,
+                visualMatchExemplarId,
+                prepared.textPrompt
+              );
             } else {
               result = await this.runVisualCropMatch(asset, imageBuffer, prepared);
             }
@@ -1403,13 +1532,15 @@ export class Sam3BatchV2Service {
   private async runVisualConceptMatch(
     asset: AssetRecord,
     imageBuffer: Buffer,
-    exemplarId: string
+    exemplarId: string,
+    className: string
   ): Promise<AssetInferenceResult> {
+    const conceptOptions = buildBatchV2ConceptApplyOptions();
     const result = await this.awsSam3Service.applyConceptExemplar({
       exemplarId,
       imageBuffer,
       imageId: asset.id,
-      options: { returnPolygons: true },
+      options: conceptOptions,
     });
 
     if (!result.success || !result.data) {
@@ -1422,12 +1553,13 @@ export class Sam3BatchV2Service {
       };
     }
 
-    const detections = result.data.detections.map((detection) => ({
-      bbox: detection.bbox,
-      polygon: normalizePolygon(detection.polygon, detection.bbox),
-      confidence: detection.confidence,
-      similarity: detection.similarity,
-    }));
+    const candidates = filterBatchV2ConceptDetections(result.data.detections, conceptOptions);
+    const detections = await this.refineConceptDetectionsWithBoxPrompts(
+      asset,
+      imageBuffer,
+      className,
+      candidates
+    );
 
     return {
       assetId: asset.id,
@@ -1452,11 +1584,12 @@ export class Sam3BatchV2Service {
       };
     }
 
+    const conceptOptions = buildBatchV2ConceptApplyOptions();
     const result = await this.awsSam3Service.applyConceptExemplar({
       exemplarId: conceptExemplarId,
       imageBuffer,
       imageId: asset.id,
-      options: { returnPolygons: true },
+      options: conceptOptions,
     });
 
     if (!result.success || !result.data) {
@@ -1469,18 +1602,69 @@ export class Sam3BatchV2Service {
       };
     }
 
-    const detections = result.data.detections.map((detection) => ({
-      bbox: detection.bbox,
-      polygon: normalizePolygon(detection.polygon, detection.bbox),
-      confidence: detection.confidence,
-      similarity: detection.similarity,
-    }));
+    const candidates = filterBatchV2ConceptDetections(result.data.detections, conceptOptions);
+    const detections = await this.refineConceptDetectionsWithBoxPrompts(
+      asset,
+      imageBuffer,
+      weedType,
+      candidates
+    );
 
     return {
       assetId: asset.id,
       detections,
       outcome: detections.length > 0 ? 'success' : 'zero_detections',
     };
+  }
+
+  private async refineConceptDetectionsWithBoxPrompts(
+    asset: AssetRecord,
+    imageBuffer: Buffer,
+    className: string,
+    candidates: SAM3ConceptDetection[]
+  ): Promise<AssetInferenceResult['detections']> {
+    if (candidates.length === 0) {
+      return [];
+    }
+
+    const resized = await this.awsSam3Service.resizeImage(imageBuffer);
+    const boxes = candidates
+      .map((candidate) => bboxToBoxCoordinate(candidate.bbox, resized.scaling.scaleFactor))
+      .filter(isValidBox);
+
+    if (boxes.length === 0) {
+      return [];
+    }
+
+    const result = await this.awsSam3Service.segment({
+      image: resized.buffer.toString('base64'),
+      boxes,
+      className,
+    });
+
+    if (!result.success || !result.response || result.response.detections.length === 0) {
+      console.warn(
+        `[SAM3 V2] Target box refinement failed for ${asset.id}; falling back to concept candidates.`
+      );
+      return candidates.map(mapConceptDetectionToAssetDetection);
+    }
+
+    return result.response.detections.map((detection) => {
+      const bbox = scaleBboxToOriginal(detection.bbox, resized.scaling.scaleFactor);
+      const sourceCandidate = bestConceptCandidateForBbox(bbox, candidates);
+      const score = sourceCandidate ? conceptDetectionScore(sourceCandidate) : detection.confidence;
+      const similarity =
+        sourceCandidate && typeof sourceCandidate.similarity === 'number'
+          ? sourceCandidate.similarity
+          : score;
+
+      return {
+        bbox,
+        polygon: scalePolygonToOriginal(detection.polygon, bbox, resized.scaling.scaleFactor),
+        confidence: score,
+        similarity,
+      };
+    });
   }
 
   private async persistAssetResult(

--- a/tests/unit/sam3-batch-v2.test.ts
+++ b/tests/unit/sam3-batch-v2.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { configureSam3BatchV2Queue } from '@/lib/queue/batch-queue-v2';
-import { Sam3BatchV2Service } from '@/lib/services/sam3-batch-v2';
+import {
+  buildBatchV2ConceptApplyOptions,
+  filterBatchV2ConceptDetections,
+  Sam3BatchV2Service,
+} from '@/lib/services/sam3-batch-v2';
 
 describe('sam3-batch-v2', () => {
   const originalFetch = global.fetch;
@@ -70,6 +74,38 @@ describe('sam3-batch-v2', () => {
       errorMessage: 'GPU busy (held by another process), retry later.',
     });
     expect((service as any).acquireGpuLock).toHaveBeenCalledTimes(12);
+  });
+
+  it('filters concept candidates with the v2 similarity floor before target refinement', () => {
+    const options = buildBatchV2ConceptApplyOptions();
+    const detections = filterBatchV2ConceptDetections(
+      [
+        {
+          bbox: [1, 1, 10, 10],
+          confidence: 0.91,
+          similarity: 0.62,
+          class_name: 'pine sapling',
+        },
+        {
+          bbox: [20, 20, 40, 40],
+          confidence: 0.72,
+          similarity: 0.87,
+          class_name: 'pine sapling',
+        },
+      ] as any,
+      options
+    );
+
+    expect(options).toMatchObject({
+      returnPolygons: true,
+      similarityThreshold: 0.65,
+      topK: 120,
+      minBoxSize: 16,
+      maxBoxSize: 600,
+      nmsThreshold: 0.5,
+    });
+    expect(detections).toHaveLength(1);
+    expect(detections[0].bbox).toEqual([20, 20, 40, 40]);
   });
 
   it('deletes existing annotations before recreating them on retry', async () => {
@@ -353,24 +389,44 @@ describe('sam3-batch-v2', () => {
 
   it('uses source-image box matching before concept-backed visual matching for target assets', async () => {
     let stageLog: unknown[] = [];
-    const segment = vi.fn().mockResolvedValue({
-      success: true,
-      response: {
-        detections: [
-          {
-            bbox: [5, 5, 15, 15],
-            confidence: 0.9,
-            polygon: [
-              [5, 5],
-              [15, 5],
-              [15, 15],
-              [5, 15],
-            ],
-          },
-        ],
-        count: 1,
-      },
-    });
+    const segment = vi
+      .fn()
+      .mockResolvedValueOnce({
+        success: true,
+        response: {
+          detections: [
+            {
+              bbox: [5, 5, 15, 15],
+              confidence: 0.9,
+              polygon: [
+                [5, 5],
+                [15, 5],
+                [15, 15],
+                [5, 15],
+              ],
+            },
+          ],
+          count: 1,
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        response: {
+          detections: [
+            {
+              bbox: [20, 25, 40, 45],
+              confidence: 0.93,
+              polygon: [
+                [21, 25],
+                [39, 25],
+                [39, 44],
+                [21, 44],
+              ],
+            },
+          ],
+          count: 1,
+        },
+      });
     const createConceptExemplar = vi.fn().mockResolvedValue({
       success: true,
       data: { exemplarId: 'visual-exemplar-1' },
@@ -506,7 +562,14 @@ describe('sam3-batch-v2', () => {
     });
 
     expect(result.terminalState).toBe('completed');
-    expect(segment).toHaveBeenCalledTimes(1);
+    expect(segment).toHaveBeenCalledTimes(2);
+    expect(segment).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        boxes: [{ x1: 20, y1: 25, x2: 40, y2: 45 }],
+        className: 'Pine Sapling',
+      })
+    );
     expect(createConceptExemplar).toHaveBeenCalledTimes(1);
     expect(createConceptExemplar).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -515,6 +578,18 @@ describe('sam3-batch-v2', () => {
       })
     );
     expect(applyConceptExemplar).toHaveBeenCalledTimes(1);
+    expect(applyConceptExemplar).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          returnPolygons: true,
+          similarityThreshold: 0.65,
+          topK: 120,
+          minBoxSize: 16,
+          maxBoxSize: 600,
+          nmsThreshold: 0.5,
+        }),
+      })
+    );
     expect((service as any).awsSam3Service.segmentWithExemplars).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- tighten SAM3 v2 concept matching defaults for target images
- filter low-similarity target candidates before review annotations are persisted
- refine target-image concept candidates through SAM box prompting so image 2+ annotations use cleaner geometry instead of raw concept output

## Why
Manas reproduced AG-3 where Apply to All works, but annotations after the source image are not clean. The source image path already uses box-prompted SAM; target images were accepting concept/exemplar output directly, with no v2-side similarity defaults or SAM refinement.

## Verification
- npm run test:unit -- tests/unit/sam3-batch-v2.test.ts
- npm run lint
- npm run build

Note: full tsc --noEmit still fails on existing repo-wide Next 15 route-context/type debt unrelated to this patch.