### PR TITLE
Add SAM3 v2 target match fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,9 @@ SAM3_CONCEPT_API_KEY=""
 # SAM3_CONCEPT_MIN_BOX_SIZE="16"
 # SAM3_CONCEPT_MAX_BOX_SIZE="600"
 # SAM3_CONCEPT_NMS_THRESHOLD="0.5"
+# Optional: lower-confidence fallback when strict v2 matching finds zero target-image candidates
+# SAM3_CONCEPT_FALLBACK_SIMILARITY_THRESHOLD="0.5"
+# SAM3_CONCEPT_FALLBACK_TOP_K="40"
 
 # Note: AWS credentials (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION)
 # are used for EC2 instance management. The instance must have tag Name=agridrone-sam3

--- a/lib/services/sam3-batch-v2.ts
+++ b/lib/services/sam3-batch-v2.ts
@@ -55,12 +55,27 @@ export const SAM3_BATCH_V2_DEFAULT_MAX_BOX_SIZE =
   parseOptionalInt(process.env.SAM3_CONCEPT_MAX_BOX_SIZE) ?? 600;
 export const SAM3_BATCH_V2_DEFAULT_NMS_THRESHOLD =
   parseOptionalNumber(process.env.SAM3_CONCEPT_NMS_THRESHOLD) ?? 0.5;
+export const SAM3_BATCH_V2_FALLBACK_SIMILARITY_THRESHOLD =
+  parseOptionalNumber(process.env.SAM3_CONCEPT_FALLBACK_SIMILARITY_THRESHOLD) ?? 0.5;
+export const SAM3_BATCH_V2_FALLBACK_TOP_K =
+  parseOptionalInt(process.env.SAM3_CONCEPT_FALLBACK_TOP_K) ?? 40;
 
 export function buildBatchV2ConceptApplyOptions(): SAM3ConceptApplyOptions {
   return {
     returnPolygons: true,
     similarityThreshold: SAM3_BATCH_V2_DEFAULT_SIMILARITY_THRESHOLD,
     topK: SAM3_BATCH_V2_DEFAULT_TOP_K,
+    minBoxSize: SAM3_BATCH_V2_DEFAULT_MIN_BOX_SIZE,
+    maxBoxSize: SAM3_BATCH_V2_DEFAULT_MAX_BOX_SIZE,
+    nmsThreshold: SAM3_BATCH_V2_DEFAULT_NMS_THRESHOLD,
+  };
+}
+
+export function buildBatchV2ConceptFallbackApplyOptions(): SAM3ConceptApplyOptions {
+  return {
+    returnPolygons: true,
+    similarityThreshold: SAM3_BATCH_V2_FALLBACK_SIMILARITY_THRESHOLD,
+    topK: SAM3_BATCH_V2_FALLBACK_TOP_K,
     minBoxSize: SAM3_BATCH_V2_DEFAULT_MIN_BOX_SIZE,
     maxBoxSize: SAM3_BATCH_V2_DEFAULT_MAX_BOX_SIZE,
     nmsThreshold: SAM3_BATCH_V2_DEFAULT_NMS_THRESHOLD,
@@ -1553,7 +1568,14 @@ export class Sam3BatchV2Service {
       };
     }
 
-    const candidates = filterBatchV2ConceptDetections(result.data.detections, conceptOptions);
+    const candidates = await this.getConceptCandidatesWithFallback({
+      asset,
+      imageBuffer,
+      exemplarId,
+      primaryDetections: result.data.detections,
+      primaryOptions: conceptOptions,
+      failureCode: 'VISUAL_MATCH_EXEMPLAR_FALLBACK_FAILED',
+    });
     const detections = await this.refineConceptDetectionsWithBoxPrompts(
       asset,
       imageBuffer,
@@ -1602,7 +1624,14 @@ export class Sam3BatchV2Service {
       };
     }
 
-    const candidates = filterBatchV2ConceptDetections(result.data.detections, conceptOptions);
+    const candidates = await this.getConceptCandidatesWithFallback({
+      asset,
+      imageBuffer,
+      exemplarId: conceptExemplarId,
+      primaryDetections: result.data.detections,
+      primaryOptions: conceptOptions,
+      failureCode: 'CONCEPT_FALLBACK_FAILED',
+    });
     const detections = await this.refineConceptDetectionsWithBoxPrompts(
       asset,
       imageBuffer,
@@ -1615,6 +1644,59 @@ export class Sam3BatchV2Service {
       detections,
       outcome: detections.length > 0 ? 'success' : 'zero_detections',
     };
+  }
+
+  private async getConceptCandidatesWithFallback({
+    asset,
+    imageBuffer,
+    exemplarId,
+    primaryDetections,
+    primaryOptions,
+    failureCode,
+  }: {
+    asset: AssetRecord;
+    imageBuffer: Buffer;
+    exemplarId: string;
+    primaryDetections: SAM3ConceptDetection[];
+    primaryOptions: SAM3ConceptApplyOptions;
+    failureCode: string;
+  }): Promise<SAM3ConceptDetection[]> {
+    const primaryCandidates = filterBatchV2ConceptDetections(primaryDetections, primaryOptions);
+    if (primaryCandidates.length > 0) {
+      return primaryCandidates;
+    }
+
+    const fallbackOptions = buildBatchV2ConceptFallbackApplyOptions();
+    const fallbackResult = await this.awsSam3Service.applyConceptExemplar({
+      exemplarId,
+      imageBuffer,
+      imageId: asset.id,
+      options: fallbackOptions,
+    });
+
+    if (!fallbackResult.success || !fallbackResult.data) {
+      const code = fallbackResult.errorCode || failureCode;
+      const message = fallbackResult.error ? ` ${fallbackResult.error}` : '';
+      console.warn(
+        `[SAM3 V2] Target fallback matching failed for ${asset.id}: ${code}${message}`
+      );
+      return [];
+    }
+
+    const fallbackCandidates = filterBatchV2ConceptDetections(
+      fallbackResult.data.detections,
+      fallbackOptions
+    );
+
+    if (fallbackCandidates.length > 0) {
+      console.warn(
+        `[SAM3 V2] Target ${asset.id} used fallback concept threshold ` +
+          `${fallbackOptions.similarityThreshold} after strict threshold ` +
+          `${primaryOptions.similarityThreshold} returned zero candidates.`
+      );
+    }
+
+    return fallbackCandidates;
   }
 
   private async refineConceptDetectionsWithBoxPrompts(

--- a/tests/unit/sam3-batch-v2.test.ts
+++ b/tests/unit/sam3-batch-v2.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { configureSam3BatchV2Queue } from '@/lib/queue/batch-queue-v2';
 import {
   buildBatchV2ConceptApplyOptions,
+  buildBatchV2ConceptFallbackApplyOptions,
   filterBatchV2ConceptDetections,
   Sam3BatchV2Service,
 } from '@/lib/services/sam3-batch-v2';
@@ -106,6 +107,129 @@ describe('sam3-batch-v2', () => {
     });
     expect(detections).toHaveLength(1);
     expect(detections[0].bbox).toEqual([20, 20, 40, 40]);
+  });
+
+  it('falls back to lower-confidence target candidates when strict matching returns zero', async () => {
+    const applyConceptExemplar = vi
+      .fn()
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          detections: [],
+          processingTimeMs: 8,
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          detections: [
+            {
+              bbox: [20, 25, 40, 45],
+              confidence: 0.59,
+              similarity: 0.56,
+              polygon: [
+                [20, 25],
+                [40, 25],
+                [40, 45],
+                [20, 45],
+              ],
+              class_name: 'pine sapling',
+            },
+          ],
+          processingTimeMs: 11,
+        },
+      });
+    const segment = vi.fn().mockResolvedValue({
+      success: true,
+      response: {
+        detections: [
+          {
+            bbox: [20, 25, 40, 45],
+            confidence: 0.91,
+            polygon: [
+              [21, 25],
+              [39, 25],
+              [39, 44],
+              [21, 44],
+            ],
+          },
+        ],
+        count: 1,
+      },
+    });
+    const service = new Sam3BatchV2Service({
+      prisma: {} as never,
+      awsSam3Service: {
+        applyConceptExemplar,
+        resizeImage: vi.fn().mockImplementation(async (imageBuffer: Buffer) => ({
+          buffer: imageBuffer,
+          scaling: { scaleFactor: 1 },
+        })),
+        segment,
+      } as any,
+      acquireGpuLock: vi.fn(),
+      refreshGpuLock: vi.fn(),
+      releaseGpuLock: vi.fn(),
+      sleep: vi.fn(),
+      now: () => new Date('2026-03-31T00:00:00.000Z'),
+    });
+
+    const result = await (service as any).runVisualConceptMatch(
+      {
+        id: 'asset-target',
+        storageUrl: 'http://localhost/asset-target.jpg',
+        s3Key: null,
+        s3Bucket: null,
+        storageType: 'local',
+        imageWidth: 4000,
+        imageHeight: 3000,
+      },
+      Buffer.from('target-image'),
+      'visual-exemplar-1',
+      'Pine Sapling'
+    );
+
+    expect(applyConceptExemplar).toHaveBeenCalledTimes(2);
+    expect(applyConceptExemplar).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        options: expect.objectContaining({
+          similarityThreshold: 0.65,
+          topK: 120,
+        }),
+      })
+    );
+    expect(applyConceptExemplar).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        options: expect.objectContaining({
+          similarityThreshold: 0.5,
+          topK: 40,
+        }),
+      })
+    );
+    expect(buildBatchV2ConceptFallbackApplyOptions()).toMatchObject({
+      returnPolygons: true,
+      similarityThreshold: 0.5,
+      topK: 40,
+    });
+    expect(segment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        boxes: [{ x1: 20, y1: 25, x2: 40, y2: 45 }],
+        className: 'Pine Sapling',
+      })
+    );
+    expect(result).toMatchObject({
+      assetId: 'asset-target',
+      outcome: 'success',
+      detections: [
+        {
+          bbox: [20, 25, 40, 45],
+          confidence: 0.56,
+          similarity: 0.56,
+        },
+      ],
+    });
   });
 
   it('deletes existing annotations before recreating them on retry', async () => {


### PR DESCRIPTION
## Summary
- keep the strict 0.65 SAM3 v2 target-image matching threshold for clean results
- when strict target matching returns zero candidates, retry concept matching at a capped lower threshold of 0.50/topK 40
- continue refining fallback candidates through SAM box prompts before creating pending annotations

## Why
Manas retested AG-3 after PR #172 and image 1/source was fine, but target images generated no annotations. That means the previous fix reached production but the strict target threshold overcorrected from noisy detections to zero detections.

## Verification
- npm run test:unit -- tests/unit/sam3-batch-v2.test.ts
- npm run lint
- npm run build