### PR TITLE
Broaden SAM3 target fallback on underfilled matches

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,7 +65,9 @@ SAM3_CONCEPT_API_KEY=""
 # SAM3_CONCEPT_MIN_BOX_SIZE="16"
 # SAM3_CONCEPT_MAX_BOX_SIZE="600"
 # SAM3_CONCEPT_NMS_THRESHOLD="0.5"
-# Optional: lower-confidence fallback when strict v2 matching finds zero target-image candidates
+# Optional: lower-confidence fallback when strict v2 matching underfills target-image candidates
+# SAM3_CONCEPT_MIN_TARGET_CANDIDATES="25"
+# SAM3_CONCEPT_MAX_TARGET_CANDIDATES="120"
 # SAM3_CONCEPT_FALLBACK_SIMILARITY_THRESHOLD="0.5"
 # SAM3_CONCEPT_FALLBACK_TOP_K="40"
 

--- a/lib/services/sam3-batch-v2.ts
+++ b/lib/services/sam3-batch-v2.ts
@@ -59,6 +59,15 @@ export const SAM3_BATCH_V2_FALLBACK_SIMILARITY_THRESHOLD =
   parseOptionalNumber(process.env.SAM3_CONCEPT_FALLBACK_SIMILARITY_THRESHOLD) ?? 0.5;
 export const SAM3_BATCH_V2_FALLBACK_TOP_K =
   parseOptionalInt(process.env.SAM3_CONCEPT_FALLBACK_TOP_K) ?? 40;
+export const SAM3_BATCH_V2_MIN_TARGET_CANDIDATES = Math.max(
+  0,
+  parseOptionalInt(process.env.SAM3_CONCEPT_MIN_TARGET_CANDIDATES) ?? 25
+);
+export const SAM3_BATCH_V2_MAX_TARGET_CANDIDATES = Math.max(
+  SAM3_BATCH_V2_MIN_TARGET_CANDIDATES,
+  parseOptionalInt(process.env.SAM3_CONCEPT_MAX_TARGET_CANDIDATES) ??
+    SAM3_BATCH_V2_DEFAULT_TOP_K
+);
 
 export function buildBatchV2ConceptApplyOptions(): SAM3ConceptApplyOptions {
   return {
@@ -578,6 +587,33 @@ function bboxIou(
   const union = bboxArea(first) + bboxArea(second) - intersection;
 
   return union > 0 ? intersection / union : 0;
+}
+
+function dedupeAndLimitConceptDetections(
+  detections: SAM3ConceptDetection[],
+  options: SAM3ConceptApplyOptions,
+  limit = SAM3_BATCH_V2_MAX_TARGET_CANDIDATES
+): SAM3ConceptDetection[] {
+  const nmsThreshold =
+    typeof options.nmsThreshold === 'number'
+      ? options.nmsThreshold
+      : SAM3_BATCH_V2_DEFAULT_NMS_THRESHOLD;
+  const selected: SAM3ConceptDetection[] = [];
+
+  for (const detection of [...detections].sort(
+    (left, right) => conceptDetectionScore(right) - conceptDetectionScore(left)
+  )) {
+    if (selected.some((candidate) => bboxIou(candidate.bbox, detection.bbox) > nmsThreshold)) {
+      continue;
+    }
+
+    selected.push(detection);
+    if (selected.length >= limit) {
+      break;
+    }
+  }
+
+  return selected;
 }
 
 function bestConceptCandidateForBbox(
@@ -1662,8 +1698,8 @@ export class Sam3BatchV2Service {
     failureCode: string;
   }): Promise<SAM3ConceptDetection[]> {
     const primaryCandidates = filterBatchV2ConceptDetections(primaryDetections, primaryOptions);
-    if (primaryCandidates.length > 0) {
-      return primaryCandidates;
+    if (primaryCandidates.length >= SAM3_BATCH_V2_MIN_TARGET_CANDIDATES) {
+      return dedupeAndLimitConceptDetections(primaryCandidates, primaryOptions);
     }
 
     const fallbackOptions = buildBatchV2ConceptFallbackApplyOptions();
@@ -1680,11 +1716,15 @@ export class Sam3BatchV2Service {
       console.warn(
         `[SAM3 V2] Target fallback matching failed for ${asset.id}: ${code}${message}`
       );
-      return [];
+      return dedupeAndLimitConceptDetections(primaryCandidates, primaryOptions);
     }
 
     const fallbackCandidates = filterBatchV2ConceptDetections(
       fallbackResult.data.detections,
+      fallbackOptions
+    );
+    const mergedCandidates = dedupeAndLimitConceptDetections(
+      [...primaryCandidates, ...fallbackCandidates],
       fallbackOptions
     );
 
@@ -1692,11 +1732,12 @@ export class Sam3BatchV2Service {
       console.warn(
         `[SAM3 V2] Target ${asset.id} used fallback concept threshold ` +
           `${fallbackOptions.similarityThreshold} after strict threshold ` +
-          `${primaryOptions.similarityThreshold} returned zero candidates.`
+          `${primaryOptions.similarityThreshold} returned ${primaryCandidates.length} ` +
+          `candidate(s), below target floor ${SAM3_BATCH_V2_MIN_TARGET_CANDIDATES}.`
       );
     }
 
-    return fallbackCandidates;
+    return mergedCandidates;
   }
 
   private async refineConceptDetectionsWithBoxPrompts(

--- a/tests/unit/sam3-batch-v2.test.ts
+++ b/tests/unit/sam3-batch-v2.test.ts
@@ -232,6 +232,149 @@ describe('sam3-batch-v2', () => {
     });
   });
 
+  it('broadens target matching when strict matching returns too few candidates', async () => {
+    const applyConceptExemplar = vi
+      .fn()
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          detections: [
+            {
+              bbox: [20, 25, 40, 45],
+              confidence: 0.82,
+              similarity: 0.82,
+              polygon: [
+                [20, 25],
+                [40, 25],
+                [40, 45],
+                [20, 45],
+              ],
+              class_name: 'pine sapling',
+            },
+          ],
+          processingTimeMs: 8,
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          detections: [
+            {
+              bbox: [20, 25, 40, 45],
+              confidence: 0.61,
+              similarity: 0.61,
+              polygon: [
+                [20, 25],
+                [40, 25],
+                [40, 45],
+                [20, 45],
+              ],
+              class_name: 'pine sapling',
+            },
+            {
+              bbox: [80, 90, 110, 120],
+              confidence: 0.55,
+              similarity: 0.55,
+              polygon: [
+                [80, 90],
+                [110, 90],
+                [110, 120],
+                [80, 120],
+              ],
+              class_name: 'pine sapling',
+            },
+          ],
+          processingTimeMs: 11,
+        },
+      });
+    const segment = vi.fn().mockResolvedValue({
+      success: true,
+      response: {
+        detections: [
+          {
+            bbox: [20, 25, 40, 45],
+            confidence: 0.92,
+            polygon: [
+              [20, 25],
+              [40, 25],
+              [40, 45],
+              [20, 45],
+            ],
+          },
+          {
+            bbox: [80, 90, 110, 120],
+            confidence: 0.88,
+            polygon: [
+              [80, 90],
+              [110, 90],
+              [110, 120],
+              [80, 120],
+            ],
+          },
+        ],
+        count: 2,
+      },
+    });
+    const service = new Sam3BatchV2Service({
+      prisma: {} as never,
+      awsSam3Service: {
+        applyConceptExemplar,
+        resizeImage: vi.fn().mockImplementation(async (imageBuffer: Buffer) => ({
+          buffer: imageBuffer,
+          scaling: { scaleFactor: 1 },
+        })),
+        segment,
+      } as any,
+      acquireGpuLock: vi.fn(),
+      refreshGpuLock: vi.fn(),
+      releaseGpuLock: vi.fn(),
+      sleep: vi.fn(),
+      now: () => new Date('2026-03-31T00:00:00.000Z'),
+    });
+
+    const result = await (service as any).runVisualConceptMatch(
+      {
+        id: 'asset-target',
+        storageUrl: 'http://localhost/asset-target.jpg',
+        s3Key: null,
+        s3Bucket: null,
+        storageType: 'local',
+        imageWidth: 4000,
+        imageHeight: 3000,
+      },
+      Buffer.from('target-image'),
+      'visual-exemplar-1',
+      'Pine Sapling'
+    );
+
+    expect(applyConceptExemplar).toHaveBeenCalledTimes(2);
+    expect(segment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        boxes: [
+          { x1: 20, y1: 25, x2: 40, y2: 45 },
+          { x1: 80, y1: 90, x2: 110, y2: 120 },
+        ],
+        className: 'Pine Sapling',
+      })
+    );
+    expect(result).toMatchObject({
+      assetId: 'asset-target',
+      outcome: 'success',
+      detections: [
+        {
+          bbox: [20, 25, 40, 45],
+          confidence: 0.82,
+          similarity: 0.82,
+        },
+        {
+          bbox: [80, 90, 110, 120],
+          confidence: 0.55,
+          similarity: 0.55,
+        },
+      ],
+    });
+  });
+
   it('deletes existing annotations before recreating them on retry', async () => {
     const operations: string[] = [];
     let stageLog: unknown[] = [];
@@ -701,13 +844,27 @@ describe('sam3-batch-v2', () => {
         imageId: 'asset-source',
       })
     );
-    expect(applyConceptExemplar).toHaveBeenCalledTimes(1);
-    expect(applyConceptExemplar).toHaveBeenCalledWith(
+    expect(applyConceptExemplar).toHaveBeenCalledTimes(2);
+    expect(applyConceptExemplar).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         options: expect.objectContaining({
           returnPolygons: true,
           similarityThreshold: 0.65,
           topK: 120,
+          minBoxSize: 16,
+          maxBoxSize: 600,
+          nmsThreshold: 0.5,
+        }),
+      })
+    );
+    expect(applyConceptExemplar).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        options: expect.objectContaining({
+          returnPolygons: true,
+          similarityThreshold: 0.5,
+          topK: 40,
           minBoxSize: 16,
           maxBoxSize: 600,
           nmsThreshold: 0.5,


### PR DESCRIPTION
## Summary
- Run the lower-threshold SAM3 concept fallback when strict target matching returns too few candidates, not only when it returns zero.
- Merge and NMS-dedupe strict + fallback candidates before the existing SAM box-refinement step.
- Add env knobs for target candidate floor/cap and unit coverage for the underfilled-target case.

## Why
Manas's latest AG-3 retest shows the source image transfers well, but subsequent images only receive a handful of pending annotations. That means strict matching is returning low non-zero counts, so the previous zero-only fallback was skipped.

## Verification
- npm run test:unit -- tests/unit/sam3-batch-v2.test.ts
- npm run lint
- npm run build