### PR TITLE
Fix credentials login redirect

### DIFF
--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
@@ -11,7 +10,6 @@ import { Label } from "@/components/ui/label";
 import { Loader2 } from "lucide-react";
 
 export default function SignIn() {
-  const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
@@ -29,12 +27,13 @@ export default function SignIn() {
         email,
         password,
         redirect: false,
+        callbackUrl: "/dashboard",
       });
 
       if (result?.error) {
         setError("Invalid email or password");
       } else {
-        router.push("/dashboard");
+        window.location.assign(result?.url || "/dashboard");
       }
     } catch {
       setError("An error occurred. Please try again.");


### PR DESCRIPTION
## Summary
- Make credentials login perform a hard navigation to the NextAuth callback URL after a successful sign-in.
- Keep the existing invalid-credentials error behavior unchanged.

## Why
The production credentials callback successfully creates a session for b.harris@nationaldrones.com, but the current client-side router.push('/dashboard') can leave the browser sitting on the sign-in screen with no error. A full navigation after the cookie is set avoids stale client auth/navigation state.

## Verification
- Confirmed production credentials callback returns a session cookie for b.harris@nationaldrones.com after password reset.
- Confirmed /api/auth/session returns the authenticated user with that cookie.
- Confirmed /dashboard returns 200 with the session cookie.
- Ran git diff --check for this patch.

Note: dependency install/build was not run in the isolated worktree because node_modules is not installed there.