### PR TITLE
Gate SAM3 target refinement by candidate overlap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,8 @@ SAM3_CONCEPT_API_KEY=""
 # SAM3_CONCEPT_MAX_TARGET_CANDIDATES="120"
 # SAM3_CONCEPT_FALLBACK_SIMILARITY_THRESHOLD="0.5"
 # SAM3_CONCEPT_FALLBACK_TOP_K="40"
+# Optional: reject SAM box-refinement masks that drift away from target-image concept candidates
+# SAM3_TARGET_REFINEMENT_MIN_IOU="0.1"
 
 # Note: AWS credentials (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION)
 # are used for EC2 instance management. The instance must have tag Name=agridrone-sam3

--- a/lib/services/sam3-batch-v2.ts
+++ b/lib/services/sam3-batch-v2.ts
@@ -68,6 +68,10 @@ export const SAM3_BATCH_V2_MAX_TARGET_CANDIDATES = Math.max(
   parseOptionalInt(process.env.SAM3_CONCEPT_MAX_TARGET_CANDIDATES) ??
     SAM3_BATCH_V2_DEFAULT_TOP_K
 );
+export const SAM3_BATCH_V2_MIN_REFINEMENT_IOU = Math.max(
+  0,
+  parseOptionalNumber(process.env.SAM3_TARGET_REFINEMENT_MIN_IOU) ?? 0.1
+);
 
 export function buildBatchV2ConceptApplyOptions(): SAM3ConceptApplyOptions {
   return {
@@ -616,10 +620,10 @@ function dedupeAndLimitConceptDetections(
   return selected;
 }
 
-function bestConceptCandidateForBbox(
+function bestConceptCandidateMatchForBbox(
   bbox: [number, number, number, number],
   candidates: SAM3ConceptDetection[]
-): SAM3ConceptDetection | null {
+): { candidate: SAM3ConceptDetection; iou: number } | null {
   let bestCandidate: SAM3ConceptDetection | null = null;
   let bestScore = -1;
 
@@ -631,7 +635,11 @@ function bestConceptCandidateForBbox(
     }
   }
 
-  return bestCandidate;
+  return bestCandidate ? { candidate: bestCandidate, iou: bestScore } : null;
+}
+
+function conceptCandidateKey(candidate: SAM3ConceptDetection): string {
+  return `${candidate.bbox.join(',')}:${conceptDetectionScore(candidate).toFixed(6)}`;
 }
 
 function mapConceptDetectionToAssetDetection(
@@ -1772,22 +1780,46 @@ export class Sam3BatchV2Service {
       return candidates.map(mapConceptDetectionToAssetDetection);
     }
 
-    return result.response.detections.map((detection) => {
+    const matchedCandidateKeys = new Set<string>();
+    const refinedDetections = result.response.detections.flatMap((detection) => {
       const bbox = scaleBboxToOriginal(detection.bbox, resized.scaling.scaleFactor);
-      const sourceCandidate = bestConceptCandidateForBbox(bbox, candidates);
-      const score = sourceCandidate ? conceptDetectionScore(sourceCandidate) : detection.confidence;
+      const sourceCandidateMatch = bestConceptCandidateMatchForBbox(bbox, candidates);
+      if (
+        !sourceCandidateMatch ||
+        sourceCandidateMatch.iou < SAM3_BATCH_V2_MIN_REFINEMENT_IOU
+      ) {
+        return [];
+      }
+
+      const sourceCandidate = sourceCandidateMatch.candidate;
+      matchedCandidateKeys.add(conceptCandidateKey(sourceCandidate));
+      const score = conceptDetectionScore(sourceCandidate);
       const similarity =
-        sourceCandidate && typeof sourceCandidate.similarity === 'number'
+        typeof sourceCandidate.similarity === 'number'
           ? sourceCandidate.similarity
           : score;
 
-      return {
+      return [{
         bbox,
         polygon: scalePolygonToOriginal(detection.polygon, bbox, resized.scaling.scaleFactor),
         confidence: score,
         similarity,
-      };
+      }];
     });
+
+    const unmatchedCandidates = candidates
+      .filter((candidate) => !matchedCandidateKeys.has(conceptCandidateKey(candidate)))
+      .map(mapConceptDetectionToAssetDetection);
+
+    if (refinedDetections.length === 0) {
+      console.warn(
+        `[SAM3 V2] Target box refinement drifted away from candidates for ${asset.id}; ` +
+          'falling back to concept candidates.'
+      );
+      return candidates.map(mapConceptDetectionToAssetDetection);
+    }
+
+    return [...refinedDetections, ...unmatchedCandidates];
   }
 
   private async persistAssetResult(

--- a/tests/unit/sam3-batch-v2.test.ts
+++ b/tests/unit/sam3-batch-v2.test.ts
@@ -375,6 +375,103 @@ describe('sam3-batch-v2', () => {
     });
   });
 
+  it('falls back to concept candidates when target refinement drifts away from candidates', async () => {
+    const candidate = {
+      bbox: [20, 25, 40, 45],
+      confidence: 0.82,
+      similarity: 0.82,
+      polygon: [
+        [20, 25],
+        [40, 25],
+        [40, 45],
+        [20, 45],
+      ],
+      class_name: 'pine sapling',
+    };
+    const applyConceptExemplar = vi
+      .fn()
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          detections: [candidate],
+          processingTimeMs: 8,
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          detections: [],
+          processingTimeMs: 11,
+        },
+      });
+    const segment = vi.fn().mockResolvedValue({
+      success: true,
+      response: {
+        detections: [
+          {
+            bbox: [220, 225, 260, 265],
+            confidence: 0.93,
+            polygon: [
+              [220, 225],
+              [260, 225],
+              [260, 265],
+              [220, 265],
+            ],
+          },
+        ],
+        count: 1,
+      },
+    });
+    const service = new Sam3BatchV2Service({
+      prisma: {} as never,
+      awsSam3Service: {
+        applyConceptExemplar,
+        resizeImage: vi.fn().mockImplementation(async (imageBuffer: Buffer) => ({
+          buffer: imageBuffer,
+          scaling: { scaleFactor: 1 },
+        })),
+        segment,
+      } as any,
+      acquireGpuLock: vi.fn(),
+      refreshGpuLock: vi.fn(),
+      releaseGpuLock: vi.fn(),
+      sleep: vi.fn(),
+      now: () => new Date('2026-03-31T00:00:00.000Z'),
+    });
+
+    const result = await (service as any).runVisualConceptMatch(
+      {
+        id: 'asset-target',
+        storageUrl: 'http://localhost/asset-target.jpg',
+        s3Key: null,
+        s3Bucket: null,
+        storageType: 'local',
+        imageWidth: 4000,
+        imageHeight: 3000,
+      },
+      Buffer.from('target-image'),
+      'visual-exemplar-1',
+      'Pine Sapling'
+    );
+
+    expect(segment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        boxes: [{ x1: 20, y1: 25, x2: 40, y2: 45 }],
+      })
+    );
+    expect(result).toMatchObject({
+      assetId: 'asset-target',
+      outcome: 'success',
+      detections: [
+        {
+          bbox: [20, 25, 40, 45],
+          confidence: 0.82,
+          similarity: 0.82,
+        },
+      ],
+    });
+  });
+
   it('deletes existing annotations before recreating them on retry', async () => {
     const operations: string[] = [];
     let stageLog: unknown[] = [];


### PR DESCRIPTION
## Summary
- Keep target-image concept candidates as the source of truth for cross-image Apply-to-All matches.
- Reject SAM box-refinement masks that drift away from the concept candidate boxes.
- Fall back to concept candidate geometry when refinement drifts, so image 2+ does not accept spatially wrong SAM masks.
- Add  as a tuning knob and unit coverage for the drift case.

## Why
Manas's latest AG-3 update shows SAM3 reliability/startup is improved and Apply-to-All runs, but annotations are correct on the first/source image and incorrect from the second image onward. The source image uses same-image box prompting; target images use concept candidates followed by SAM refinement. If SAM refinement returns masks away from the candidate boxes, the old code accepted them anyway by assigning the nearest candidate score. This patch gates that refinement spatially.

## Verification
- npm run test:unit -- tests/unit/sam3-batch-v2.test.ts
- npm run lint
- npm run build