### PR TITLE
Use source SAM detections for target exemplars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,8 @@ SAM3_CONCEPT_API_KEY=""
 # SAM3_CONCEPT_FALLBACK_TOP_K="40"
 # Optional: reject SAM box-refinement masks that drift away from target-image concept candidates
 # SAM3_TARGET_REFINEMENT_MIN_IOU="0.1"
+# Optional: cap high-confidence source-image SAM detections used as target matching exemplars
+# SAM3_SOURCE_DETECTION_EXEMPLAR_LIMIT="30"
 
 # Note: AWS credentials (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION)
 # are used for EC2 instance management. The instance must have tag Name=agridrone-sam3

--- a/lib/services/sam3-batch-v2.ts
+++ b/lib/services/sam3-batch-v2.ts
@@ -72,6 +72,10 @@ export const SAM3_BATCH_V2_MIN_REFINEMENT_IOU = Math.max(
   0,
   parseOptionalNumber(process.env.SAM3_TARGET_REFINEMENT_MIN_IOU) ?? 0.1
 );
+export const SAM3_BATCH_V2_SOURCE_DETECTION_EXEMPLAR_LIMIT = Math.max(
+  1,
+  parseOptionalInt(process.env.SAM3_SOURCE_DETECTION_EXEMPLAR_LIMIT) ?? 30
+);
 
 export function buildBatchV2ConceptApplyOptions(): SAM3ConceptApplyOptions {
   return {
@@ -573,6 +577,24 @@ function bboxToBoxCoordinate(
 
 function isValidBox(box: BoxCoordinate): boolean {
   return box.x2 > box.x1 && box.y2 > box.y1;
+}
+
+function sourceDetectionExemplarBoxes(
+  sourceResult: AssetInferenceResult | null
+): BoxCoordinate[] {
+  if (!sourceResult || sourceResult.outcome !== 'success') {
+    return [];
+  }
+
+  return sourceResult.detections
+    .map((detection) => ({
+      box: bboxToBoxCoordinate(detection.bbox),
+      confidence: detection.confidence,
+    }))
+    .filter(({ box }) => isValidBox(box))
+    .sort((left, right) => right.confidence - left.confidence)
+    .slice(0, SAM3_BATCH_V2_SOURCE_DETECTION_EXEMPLAR_LIMIT)
+    .map(({ box }) => box);
 }
 
 function bboxArea(bbox: [number, number, number, number]): number {
@@ -1296,6 +1318,7 @@ export class Sam3BatchV2Service {
     let conceptExemplarId: string | null = null;
     let visualMatchExemplarId: string | null = null;
     let visualMatchInitialized = false;
+    let sourceMatchResult: AssetInferenceResult | null = null;
     if (prepared.mode === 'concept_propagation') {
       const warmup = await this.awsSam3Service.warmupConceptService();
       if (!warmup.success) {
@@ -1376,9 +1399,13 @@ export class Sam3BatchV2Service {
         if (prepared.mode === 'visual_crop_match') {
           if (isSourceAsset) {
             result = await this.runSourceBoxMatch(asset, imageBuffer, prepared);
+            sourceMatchResult = result;
           } else {
             if (!visualMatchInitialized) {
-              visualMatchExemplarId = await this.initializeVisualMatchExemplar(prepared);
+              visualMatchExemplarId = await this.initializeVisualMatchExemplar(
+                prepared,
+                sourceMatchResult
+              );
               visualMatchInitialized = true;
             }
 
@@ -1466,16 +1493,18 @@ export class Sam3BatchV2Service {
   }
 
   private async initializeVisualMatchExemplar(
-    prepared: PreparedBatchContext
+    prepared: PreparedBatchContext,
+    sourceResult: AssetInferenceResult | null
   ): Promise<string | null> {
     const warmup = await this.awsSam3Service.warmupConceptService();
     if (!warmup.success) {
       return null;
     }
 
+    const sourceBoxes = sourceDetectionExemplarBoxes(sourceResult);
     const exemplarResult = await this.awsSam3Service.createConceptExemplar({
       imageBuffer: prepared.sourceImageBuffer,
-      boxes: prepared.exemplars,
+      boxes: sourceBoxes.length > 0 ? sourceBoxes : prepared.exemplars,
       className: prepared.textPrompt,
       imageId: prepared.sourceAssetId,
     });

--- a/tests/unit/sam3-batch-v2.test.ts
+++ b/tests/unit/sam3-batch-v2.test.ts
@@ -937,6 +937,7 @@ describe('sam3-batch-v2', () => {
     expect(createConceptExemplar).toHaveBeenCalledTimes(1);
     expect(createConceptExemplar).toHaveBeenCalledWith(
       expect.objectContaining({
+        boxes: [{ x1: 5, y1: 5, x2: 15, y2: 15 }],
         className: 'Pine Sapling',
         imageId: 'asset-source',
       })


### PR DESCRIPTION
## Summary
- seed SAM3 v2 target-image visual matching from successful source-image SAM detections
- fall back to the original manual exemplar boxes if the source image produces no detections
- add an env cap for source-detection exemplars and update the focused unit test

## Why
Manas retested AG-3 and confirmed the first/source image is good, but images 2+ are still wrong. The source image uses same-image SAM box prompting, while later images were seeding concept matching from only the tiny manual exemplar set. This change carries the richer source-image SAM result forward into target matching.

## Verification
- npm run test:unit -- tests/unit/sam3-batch-v2.test.ts
- npm run lint
- npm run build