### PR TITLE
Treat SAM3 concept readiness as visual matching ready

### DIFF
--- a/app/annotate/[assetId]/AnnotateClient.tsx
+++ b/app/annotate/[assetId]/AnnotateClient.tsx
@@ -588,34 +588,14 @@ export function AnnotateClient({ assetId }: AnnotateClientProps) {
       try {
         const response = await fetch('/api/sam3/status');
         const status: SAM3StatusResponse = await response.json();
-
-        const isAvailable = status.preferredBackend !== 'none';
-        const device = status.aws.ready ? 'aws-gpu' : status.roboflow.ready ? 'roboflow-serverless' : null;
-
-        setSam3Health({
-          available: isAvailable,
-          mode: status.aws.ready ? 'realtime' : (isAvailable ? 'degraded' : 'unavailable'),
-          device,
-          latencyMs: null,
-          backend: status.preferredBackend === 'none' ? undefined : status.preferredBackend,
-          funMessage: status.funMessage,
-        });
-
-        if (!isAvailable) {
-          setAnnotationMode('manual');
-          setSam3Error('No SAM3 backend configured');
-        }
-
-        if (useVisualCrops) {
-          setSam3ConceptStatus(null);
-          return;
-        }
+        let conceptStatus: SAM3ConceptStatusResponse | null = null;
 
         try {
           const conceptResponse = await fetch('/api/sam3/concept/status');
-          const conceptStatus: SAM3ConceptStatusResponse | null = await conceptResponse
+          conceptStatus = await conceptResponse
             .json()
             .catch(() => null);
+
           if (conceptStatus) {
             setSam3ConceptStatus(conceptStatus);
             if (
@@ -643,6 +623,25 @@ export function AnnotateClient({ assetId }: AnnotateClientProps) {
             sam3Loaded: false,
             dinoLoaded: false,
           });
+        }
+
+        const visualMatchingReady = useVisualCrops && conceptStatus?.ready === true;
+        const awsReadyForMode = status.aws.ready || visualMatchingReady;
+        const isAvailable = awsReadyForMode || status.roboflow.ready || status.preferredBackend !== 'none';
+        const device = awsReadyForMode ? 'aws-gpu' : status.roboflow.ready ? 'roboflow-serverless' : null;
+
+        setSam3Health({
+          available: isAvailable,
+          mode: awsReadyForMode ? 'realtime' : (isAvailable ? 'degraded' : 'unavailable'),
+          device,
+          latencyMs: null,
+          backend: status.preferredBackend === 'none' ? undefined : status.preferredBackend,
+          funMessage: status.funMessage,
+        });
+
+        if (!isAvailable) {
+          setAnnotationMode('manual');
+          setSam3Error('No SAM3 backend configured');
         }
       } catch {
         setSam3Health({ available: false, mode: 'unavailable', device: null, latencyMs: null });
@@ -2315,10 +2314,12 @@ export function AnnotateClient({ assetId }: AnnotateClientProps) {
                 : 'SAM3 Unavailable'}
             </Badge>
           )}
-          {!useVisualCrops && sam3ConceptStatus && (
+          {sam3ConceptStatus && (
             <Badge variant={sam3ConceptStatus.ready ? "default" : "secondary"} className="text-xs">
               {sam3ConceptStatus.configured
-                ? (sam3ConceptStatus.ready ? 'Concept Ready' : 'Concept Warming')
+                ? sam3ConceptStatus.ready
+                  ? useVisualCrops ? 'Visual Match Ready' : 'Concept Ready'
+                  : useVisualCrops ? 'Visual Match Warming' : 'Concept Warming'
                 : 'Concept Off'}
             </Badge>
           )}

--- a/app/api/training-hub/readiness/route.ts
+++ b/app/api/training-hub/readiness/route.ts
@@ -5,6 +5,7 @@ import {
   summarizeCommercialWorkflowReadiness,
 } from '@/lib/services/commercial-workflow-readiness';
 import { roboflowService } from '@/lib/services/roboflow';
+import { sam3ConceptService } from '@/lib/services/sam3-concept';
 import { sam3Orchestrator } from '@/lib/services/sam3-orchestrator';
 import { yoloService } from '@/lib/services/yolo';
 
@@ -15,8 +16,23 @@ export async function GET() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const [samStatus, queueReady, yoloResult] = await Promise.all([
+    const [samStatus, conceptResult, queueReady, yoloResult] = await Promise.all([
       sam3Orchestrator.getStatus(),
+      sam3ConceptService.isConfigured()
+        ? sam3ConceptService
+            .checkHealth()
+            .then((health) => ({
+              configured: true,
+              ready: Boolean(health.success && health.data?.sam3Loaded && health.data?.dinoLoaded),
+              health,
+            }))
+            .catch((error) => ({
+              configured: true,
+              ready: false,
+              health: null,
+              error: error instanceof Error ? error.message : 'SAM3 concept service unavailable',
+            }))
+        : Promise.resolve({ configured: false, ready: false, health: null }),
       checkRedisConnection(),
       yoloService
         .checkHealth()
@@ -41,6 +57,7 @@ export async function GET() {
       samState: samStatus.awsState,
       samGpuAvailable: samStatus.awsGpuAvailable,
       samModelLoaded: samStatus.awsModelLoaded,
+      samConceptReady: conceptResult.ready,
       queueReady,
       yoloReady: yoloResult.ready,
       yoloError: yoloResult.error,
@@ -57,6 +74,7 @@ export async function GET() {
           ready: samStatus.awsAvailable,
           gpuAvailable: samStatus.awsGpuAvailable,
           modelLoaded: samStatus.awsModelLoaded,
+          conceptReady: conceptResult.ready,
         },
         queue: { ready: queueReady },
         yolo: {

--- a/lib/services/commercial-workflow-readiness.ts
+++ b/lib/services/commercial-workflow-readiness.ts
@@ -6,6 +6,7 @@ export interface CommercialWorkflowReadinessInput {
   samState?: string | null;
   samGpuAvailable?: boolean | null;
   samModelLoaded?: boolean | null;
+  samConceptReady?: boolean | null;
   queueReady: boolean;
   yoloReady: boolean;
   yoloError?: string | null;
@@ -31,11 +32,12 @@ export interface CommercialWorkflowReadinessSummary {
 export function summarizeCommercialWorkflowReadiness(
   input: CommercialWorkflowReadinessInput
 ): CommercialWorkflowReadinessSummary {
+  const samPrimaryReady = Boolean(input.samReady && input.samModelLoaded);
+  const samConceptReady = Boolean(input.samConceptReady);
   const samReady = Boolean(
     input.samConfigured &&
-      input.samReady &&
       input.samGpuAvailable &&
-      input.samModelLoaded
+      (samPrimaryReady || samConceptReady)
   );
   const roboflowFallbackAvailable = input.roboflowConfigured && input.roboflowModelCount > 0;
 
@@ -50,7 +52,9 @@ export function summarizeCommercialWorkflowReadiness(
         ready: samReady,
         state: samReady ? 'ready' : 'blocked',
         message: samReady
-          ? 'SAM3 v2 visual matching is ready for dataset labelling.'
+          ? samConceptReady && !samPrimaryReady
+            ? 'SAM3 v2 visual matching is ready via the concept service.'
+            : 'SAM3 v2 visual matching is ready for dataset labelling.'
           : `SAM3 is not ready${input.samState ? ` (state: ${input.samState})` : ''}.`,
       },
       {

--- a/tests/unit/commercial-workflow-readiness.test.ts
+++ b/tests/unit/commercial-workflow-readiness.test.ts
@@ -1,17 +1,25 @@
 import { describe, expect, it } from 'vitest';
 import { summarizeCommercialWorkflowReadiness } from '@/lib/services/commercial-workflow-readiness';
 
+const baseInput = {
+  samConfigured: true,
+  samReady: true,
+  samState: 'ready',
+  samGpuAvailable: true,
+  samModelLoaded: true,
+  samConceptReady: false,
+  queueReady: true,
+  yoloReady: true,
+  yoloError: null,
+  roboflowConfigured: true,
+  roboflowModelCount: 1,
+};
+
 describe('commercial workflow readiness', () => {
   it('marks the full SAM-to-YOLO workflow ready when core services are healthy', () => {
     const summary = summarizeCommercialWorkflowReadiness({
-      samConfigured: true,
-      samReady: true,
+      ...baseInput,
       samState: 'running',
-      samGpuAvailable: true,
-      samModelLoaded: true,
-      queueReady: true,
-      yoloReady: true,
-      roboflowConfigured: true,
       roboflowModelCount: 2,
     });
 
@@ -26,17 +34,23 @@ describe('commercial workflow readiness', () => {
     ]);
   });
 
-  it('blocks SAM dataset runs when the EC2 host is stopped or the model is unloaded', () => {
+  it('treats primary SAM readiness as dataset-run ready', () => {
+    const summary = summarizeCommercialWorkflowReadiness(baseInput);
+
+    expect(summary.readyForSamDatasetRun).toBe(true);
+    expect(summary.checks.find((check) => check.key === 'sam')).toMatchObject({
+      label: 'SAM ready',
+      ready: true,
+    });
+  });
+
+  it('blocks SAM dataset runs when the EC2 host is stopped and no SAM concept service is ready', () => {
     const summary = summarizeCommercialWorkflowReadiness({
-      samConfigured: true,
+      ...baseInput,
       samReady: false,
       samState: 'stopped',
-      samGpuAvailable: true,
       samModelLoaded: false,
-      queueReady: true,
-      yoloReady: true,
-      roboflowConfigured: true,
-      roboflowModelCount: 1,
+      samConceptReady: false,
     });
 
     expect(summary.readyForSamDatasetRun).toBe(false);
@@ -44,6 +58,23 @@ describe('commercial workflow readiness', () => {
       label: 'SAM blocked',
       state: 'blocked',
       message: 'SAM3 is not ready (state: stopped).',
+    });
+  });
+
+  it('treats concept-ready SAM as dataset-run ready while the primary model is unloaded', () => {
+    const summary = summarizeCommercialWorkflowReadiness({
+      ...baseInput,
+      samReady: false,
+      samState: 'running',
+      samModelLoaded: false,
+      samConceptReady: true,
+    });
+
+    expect(summary.readyForSamDatasetRun).toBe(true);
+    expect(summary.checks.find((check) => check.key === 'sam')).toMatchObject({
+      label: 'SAM ready',
+      ready: true,
+      message: 'SAM3 v2 visual matching is ready via the concept service.',
     });
   });
 


### PR DESCRIPTION
## Summary
- show SAM3 visual matching readiness in the annotation UI even when the primary model is unloaded
- include concept-service readiness in Training Hub workflow readiness
- add readiness regression coverage for concept-ready SAM3 dataset runs

## Why
During Apply-to-All, SAM3 concept matching can be ready while the primary SAM health endpoint reports modelLoaded=false. That makes the UI/readiness surface look offline even though the visual matching path is usable.

## Verification
- npm run test:unit -- tests/unit/commercial-workflow-readiness.test.ts
- npm run lint
- npm run build