### PR TITLE
Fix SAM3 apply-all target matching

### DIFF
--- a/lib/services/aws-sam3.ts
+++ b/lib/services/aws-sam3.ts
@@ -1205,12 +1205,12 @@ class AWSSAM3Service {
       return null;
     }
 
-    if (this.modelLoaded) {
-      const unloadResult = await this.unloadModel(30000);
-      if (!unloadResult.success) {
-        console.warn(`[AWS-SAM3] Failed to unload primary model before concept work: ${unloadResult.message}`);
-      }
-    }
+    // if (this.modelLoaded) {
+    //   const unloadResult = await this.unloadModel(30000);
+    //   if (!unloadResult.success) {
+    //     console.warn(`[AWS-SAM3] Failed to unload primary model before concept work: ${unloadResult.message}`);
+    //   }
+    // }
 
     return baseUrl;
   }

--- a/lib/services/sam3-batch-v2.ts
+++ b/lib/services/sam3-batch-v2.ts
@@ -1475,24 +1475,34 @@ export class Sam3BatchV2Service {
             result = await this.runSourceBoxMatch(asset, imageBuffer, prepared);
             sourceMatchResult = result;
           } else {
-            if (!visualMatchInitialized) {
-              visualMatchExemplarId = await this.initializeVisualMatchExemplar(
-                prepared,
-                sourceMatchResult
-              );
-              visualMatchInitialized = true;
+            result = await this.runVisualCropMatch(asset, imageBuffer, prepared);
+
+            if (
+              result.outcome === 'inference_error' ||
+              result.outcome === 'oom' ||
+              result.outcome === 'prepare_error'
+            ) {
+              if (!visualMatchInitialized) {
+                visualMatchExemplarId = await this.initializeVisualMatchExemplar(
+                  prepared,
+                  sourceMatchResult
+                );
+                visualMatchInitialized = true;
+              }
+
+              if (visualMatchExemplarId) {
+                console.warn(
+                  `[SAM3 V2] Visual crop matching failed for ${asset.id}; trying concept fallback.`
+                );
+                result = await this.runVisualConceptMatch(
+                  asset,
+                  imageBuffer,
+                  visualMatchExemplarId,
+                  prepared.textPrompt
+                );
+              }
             }
 
-            if (visualMatchExemplarId) {
-              result = await this.runVisualConceptMatch(
-                asset,
-                imageBuffer,
-                visualMatchExemplarId,
-                prepared.textPrompt
-              );
-            } else {
-              result = await this.runVisualCropMatch(asset, imageBuffer, prepared);
-            }
           }
         } else {
           result = await this.runConceptPropagation(asset, imageBuffer, conceptExemplarId, prepared.weedType);

--- a/lib/services/sam3-concept.ts
+++ b/lib/services/sam3-concept.ts
@@ -98,26 +98,8 @@ class SAM3ConceptService {
   }
 
   private async ensureGpuCapacity(): Promise<void> {
-    if (!awsSam3Service.isConfigured()) {
-      return;
-    }
-
-    try {
-      const status = await awsSam3Service.refreshStatus();
-      if (status.instanceState === 'stopped' || !status.modelLoaded) {
-        return;
-      }
-
-      console.log('[SAM3 Concept] Unloading AWS SAM3 model on :8000 before concept operation');
-      const unloadResult = await awsSam3Service.unloadModel(30000);
-      if (!unloadResult.success) {
-        console.warn(`[SAM3 Concept] Failed to unload AWS SAM3 model: ${unloadResult.message}`);
-      } else {
-        console.log('[SAM3 Concept] AWS SAM3 model unloaded to free GPU for concept service');
-      }
-    } catch (error) {
-      console.warn('[SAM3 Concept] Failed to prepare GPU capacity:', error);
-    }
+    // Keep this hook so concept calls remain valid, but do not unload the
+    // primary SAM3 model during annotation/batch propagation.
   }
 
   private buildHeaders(): Record<string, string> {


### PR DESCRIPTION
Route multi-image visual crop batches through direct crop matching for target assets before falling back to concept matching. This keeps non-source images aligned with the exemplar crops instead of relying on concept propagation first, which made the source image look correct while later images drifted.

Keep the concept capacity hook callable as a no-op so concept warmup/create/apply paths do not throw after disabling automatic primary SAM3 model unloads. Also prevents concept preparation from unloading the primary SAM3 model during annotation and batch propagation.

Verification: ran a focused TypeScript scan for SAM3 files; touched files no longer report ensureGpuCapacity errors. Existing dependency/type errors remain outside this change, including @aws-sdk/client-ec2 resolution.