### PR TITLE
Fix SAM3 visual batch review asset scope

### DIFF
--- a/app/annotate/[assetId]/AnnotateClient.tsx
+++ b/app/annotate/[assetId]/AnnotateClient.tsx
@@ -590,25 +590,34 @@ export function AnnotateClient({ assetId }: AnnotateClientProps) {
         const status: SAM3StatusResponse = await response.json();
         let conceptStatus: SAM3ConceptStatusResponse | null = null;
 
-        try {
-          const conceptResponse = await fetch('/api/sam3/concept/status');
-          conceptStatus = await conceptResponse
-            .json()
-            .catch(() => null);
+        if (!useVisualCrops) {
+          try {
+            const conceptResponse = await fetch('/api/sam3/concept/status');
+            conceptStatus = await conceptResponse
+              .json()
+              .catch(() => null);
 
-          if (conceptStatus) {
-            setSam3ConceptStatus(conceptStatus);
-            if (
-              conceptStatus.configured &&
-              !conceptStatus.ready &&
-              !conceptWarmupTriggeredRef.current
-            ) {
-              conceptWarmupTriggeredRef.current = true;
-              fetch('/api/sam3/concept/warmup', { method: 'POST' }).catch((warmupError) => {
-                console.warn('[Annotate] Concept warmup request failed:', warmupError);
+            if (conceptStatus) {
+              setSam3ConceptStatus(conceptStatus);
+              if (
+                conceptStatus.configured &&
+                !conceptStatus.ready &&
+                !conceptWarmupTriggeredRef.current
+              ) {
+                conceptWarmupTriggeredRef.current = true;
+                fetch('/api/sam3/concept/warmup', { method: 'POST' }).catch((warmupError) => {
+                  console.warn('[Annotate] Concept warmup request failed:', warmupError);
+                });
+              }
+            } else {
+              setSam3ConceptStatus({
+                configured: false,
+                ready: false,
+                sam3Loaded: false,
+                dinoLoaded: false,
               });
             }
-          } else {
+          } catch {
             setSam3ConceptStatus({
               configured: false,
               ready: false,
@@ -616,17 +625,12 @@ export function AnnotateClient({ assetId }: AnnotateClientProps) {
               dinoLoaded: false,
             });
           }
-        } catch {
-          setSam3ConceptStatus({
-            configured: false,
-            ready: false,
-            sam3Loaded: false,
-            dinoLoaded: false,
-          });
+        } else {
+          setSam3ConceptStatus(null);
         }
 
-        const visualMatchingReady = useVisualCrops && conceptStatus?.ready === true;
-        const awsReadyForMode = status.aws.ready || visualMatchingReady;
+        const conceptReadyForMode = !useVisualCrops && conceptStatus?.ready === true;
+        const awsReadyForMode = status.aws.ready || conceptReadyForMode;
         const isAvailable = awsReadyForMode || status.roboflow.ready || status.preferredBackend !== 'none';
         const device = awsReadyForMode ? 'aws-gpu' : status.roboflow.ready ? 'roboflow-serverless' : null;
 

--- a/app/api/review/[sessionId]/items/route.ts
+++ b/app/api/review/[sessionId]/items/route.ts
@@ -293,20 +293,7 @@ export async function GET(
     }
 
     if (assetIds.length === 0) {
-      return NextResponse.json({ items: [] });
-    }
-
-    const existingAssets = await prisma.asset.findMany({
-      where: { id: { in: assetIds } },
-      select: { id: true },
-    });
-    const validAssetIds = new Set(existingAssets.map((asset) => asset.id));
-    const filteredAssetIds = assetIdFilter && validAssetIds.has(assetIdFilter)
-      ? [assetIdFilter]
-      : Array.from(validAssetIds);
-
-    if (filteredAssetIds.length === 0) {
-      return NextResponse.json({ items: [] });
+      return NextResponse.json({ items: [], assets: [] });
     }
 
     const assetSelect = {
@@ -327,6 +314,25 @@ export async function GET(
       lrfTargetLon: true,
       metadata: true,
     };
+
+    const existingAssets = await prisma.asset.findMany({
+      where: { id: { in: assetIds } },
+      select: assetSelect,
+    });
+    const assetOrder = new Map(assetIds.map((assetId, index) => [assetId, index]));
+    const validAssetIds = new Set(existingAssets.map((asset) => asset.id));
+    const filteredAssetIds = assetIdFilter && validAssetIds.has(assetIdFilter)
+      ? [assetIdFilter]
+      : assetIds.filter((assetId) => validAssetIds.has(assetId));
+    const filteredAssetIdSet = new Set(filteredAssetIds);
+    const reviewAssets = existingAssets
+      .filter((asset) => filteredAssetIdSet.has(asset.id))
+      .sort((left, right) => (assetOrder.get(left.id) ?? 0) - (assetOrder.get(right.id) ?? 0))
+      .map((asset) => toClientAsset(asset));
+
+    if (filteredAssetIds.length === 0) {
+      return NextResponse.json({ items: [], assets: [] });
+    }
 
     const manualAnnotationsPromise = !isBatchReview
       ? prisma.manualAnnotation.findMany({
@@ -645,7 +651,7 @@ export async function GET(
       assetIds,
     });
 
-    return NextResponse.json({ items: filteredItems, summary });
+    return NextResponse.json({ items: filteredItems, assets: reviewAssets, summary });
   } catch (error) {
     console.error('Error fetching review items:', error);
     return NextResponse.json(

--- a/app/api/review/route.ts
+++ b/app/api/review/route.ts
@@ -97,8 +97,10 @@ export async function POST(request: NextRequest) {
             id: true,
             kind: true,
             status: true,
+            totalImages: true,
+            assetIds: true,
             childBatchJobs: {
-              select: { id: true },
+              select: { id: true, assetIds: true },
               orderBy: [
                 { shardIndex: 'asc' },
                 { createdAt: 'asc' },
@@ -134,14 +136,41 @@ export async function POST(request: NextRequest) {
           )
         );
 
-        const pendingAssets = await prisma.pendingAnnotation.findMany({
-          where: {
-            batchJobId: { in: resolvedBatchJobIds.length > 0 ? resolvedBatchJobIds : ['__none__'] },
-          },
-          select: { assetId: true },
-          distinct: ['assetId'],
-        });
-        pendingAssets.forEach((entry) => assetIdSet.add(entry.assetId));
+        for (const batchJob of batchJobs) {
+          toStringArray(batchJob.assetIds).forEach((assetId) => assetIdSet.add(assetId));
+
+          if (batchJob.kind === SAM3_BATCH_JOB_KINDS.AGGREGATE) {
+            for (const childJob of batchJob.childBatchJobs) {
+              toStringArray(childJob.assetIds).forEach((assetId) => assetIdSet.add(assetId));
+            }
+          }
+        }
+
+        if (assetIdSet.size === 0 && batchJobs.some((batchJob) => batchJob.totalImages > 0)) {
+          const projectAssets = await prisma.asset.findMany({
+            where: { projectId },
+            select: { id: true },
+            orderBy: [
+              { uploadedAt: 'asc' },
+              { id: 'asc' },
+            ],
+          });
+          const requestedImageCounts = new Set(batchJobs.map((batchJob) => batchJob.totalImages));
+          if (requestedImageCounts.has(projectAssets.length)) {
+            projectAssets.forEach((asset) => assetIdSet.add(asset.id));
+          }
+        }
+
+        if (assetIdSet.size === 0) {
+          const pendingAssets = await prisma.pendingAnnotation.findMany({
+            where: {
+              batchJobId: { in: resolvedBatchJobIds.length > 0 ? resolvedBatchJobIds : ['__none__'] },
+            },
+            select: { assetId: true },
+            distinct: ['assetId'],
+          });
+          pendingAssets.forEach((entry) => assetIdSet.add(entry.assetId));
+        }
       }
 
       if (requestedInferenceJobIds.length > 0) {

--- a/app/api/sam3/v2/batch/route.ts
+++ b/app/api/sam3/v2/batch/route.ts
@@ -207,6 +207,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     ? body.assetIds
     : requestedAssets.map((asset) => asset.id);
   const exemplarsJson = body.exemplars as unknown as Prisma.InputJsonValue;
+  const assetIdsJson = assetIds as unknown as Prisma.InputJsonValue;
   const emptyStageLogJson = [] as unknown as Prisma.InputJsonValue;
   const batchJobBaseData = {
     projectId: body.projectId,
@@ -229,6 +230,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       data: {
         ...batchJobBaseData,
         kind: SAM3_BATCH_JOB_KINDS.AGGREGATE,
+        assetIds: assetIdsJson,
         totalImages: assetIds.length,
         shardCount: assetChunks.length,
       },
@@ -241,6 +243,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             ...batchJobBaseData,
             parentBatchJobId: parentBatchJob.id,
             kind: SAM3_BATCH_JOB_KINDS.SHARD,
+            assetIds: chunk as unknown as Prisma.InputJsonValue,
             shardIndex: index + 1,
             shardCount: assetChunks.length,
             totalImages: chunk.length,
@@ -315,6 +318,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     data: {
       ...batchJobBaseData,
       kind: SAM3_BATCH_JOB_KINDS.SINGLE,
+      assetIds: assetIdsJson,
       totalImages: assetIds.length,
     },
   });

--- a/app/review/page.tsx
+++ b/app/review/page.tsx
@@ -9,7 +9,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Slider } from '@/components/ui/slider';
-import { ReviewViewer, type ReviewItem } from '@/components/review/ReviewViewer';
+import { ReviewViewer, type ReviewItem, type ReviewItemAsset } from '@/components/review/ReviewViewer';
 import { YOLOConfigModal, type YOLOTrainingConfig } from '@/components/review/YOLOConfigModal';
 import { AlertTriangle, Brain, Download, ExternalLink, ShieldCheck, Sparkles } from 'lucide-react';
 
@@ -49,6 +49,7 @@ function ReviewPageContent() {
 
   const [session, setSession] = useState<ReviewSession | null>(null);
   const [items, setItems] = useState<ReviewItem[]>([]);
+  const [assets, setAssets] = useState<ReviewItemAsset[]>([]);
   const [loading, setLoading] = useState(true);
   const [actionLoading, setActionLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -91,6 +92,7 @@ function ReviewPageContent() {
     }
     const data = await response.json();
     setItems(data.items || []);
+    setAssets(data.assets || []);
     if (data.summary) setSummary(data.summary);
   }, [sessionId]);
 
@@ -610,7 +612,7 @@ function ReviewPageContent() {
           </div>
         )}
 
-        <ReviewViewer items={filteredItems} onAction={handleAction} onEdit={handleEdit} />
+        <ReviewViewer assets={assets} items={filteredItems} onAction={handleAction} onEdit={handleEdit} />
 
         {/* Next Steps Card - shown when there are accepted items */}
         {(summary?.acceptedCount ?? 0) > 0 && (

--- a/components/review/ReviewViewer.tsx
+++ b/components/review/ReviewViewer.tsx
@@ -72,13 +72,17 @@ export interface ReviewItem {
 
 interface ReviewViewerProps {
   items: ReviewItem[];
+  assets?: ReviewItemAsset[];
   onAction: (item: ReviewItem, action: 'accept' | 'reject' | 'correct', correctedClass?: string) => Promise<void>;
   onEdit: (item: ReviewItem) => void;
 }
 
-export function ReviewViewer({ items, onAction, onEdit }: ReviewViewerProps) {
+export function ReviewViewer({ items, assets = [], onAction, onEdit }: ReviewViewerProps) {
   const groupedAssets = useMemo(() => {
     const map = new Map<string, { asset: ReviewItemAsset; items: ReviewItem[] }>();
+    for (const asset of assets) {
+      map.set(asset.id, { asset, items: [] });
+    }
     for (const item of items) {
       if (!map.has(item.assetId)) {
         map.set(item.assetId, { asset: item.asset, items: [] });
@@ -86,7 +90,7 @@ export function ReviewViewer({ items, onAction, onEdit }: ReviewViewerProps) {
       map.get(item.assetId)!.items.push(item);
     }
     return Array.from(map.values());
-  }, [items]);
+  }, [assets, items]);
 
   const [currentIndex, setCurrentIndex] = useState(0);
   const [corrections, setCorrections] = useState<Record<string, string>>({});
@@ -281,10 +285,9 @@ export function ReviewViewer({ items, onAction, onEdit }: ReviewViewerProps) {
                       {item.status === 'accepted' && <CheckCircle2 className="h-4 w-4 text-green-500" />}
                       {item.status === 'rejected' && <XCircle className="h-4 w-4 text-red-500" />}
                       {item.warnings.length > 0 && (
-                        <AlertTriangle
-                          className="h-4 w-4 text-amber-500"
-                          title={warningText}
-                        />
+                        <span title={warningText}>
+                          <AlertTriangle className="h-4 w-4 text-amber-500" />
+                        </span>
                       )}
                     </div>
                   </div>

--- a/lib/services/review-session-assets.ts
+++ b/lib/services/review-session-assets.ts
@@ -31,6 +31,10 @@ export async function resolveReviewSessionAssetIds(
     return storedAssetIds;
   }
 
+  if (storedAssetIds.length > 0) {
+    return storedAssetIds;
+  }
+
   const batchJobIds = toStringArray(session.batchJobIds);
   if (batchJobIds.length === 0) {
     return storedAssetIds;

--- a/lib/services/sam3-batch-v2.ts
+++ b/lib/services/sam3-batch-v2.ts
@@ -1390,9 +1390,6 @@ export class Sam3BatchV2Service {
     });
 
     let conceptExemplarId: string | null = null;
-    let visualMatchExemplarId: string | null = null;
-    let visualMatchInitialized = false;
-    let sourceMatchResult: AssetInferenceResult | null = null;
     if (prepared.mode === 'concept_propagation') {
       const warmup = await this.awsSam3Service.warmupConceptService();
       if (!warmup.success) {
@@ -1473,36 +1470,8 @@ export class Sam3BatchV2Service {
         if (prepared.mode === 'visual_crop_match') {
           if (isSourceAsset) {
             result = await this.runSourceBoxMatch(asset, imageBuffer, prepared);
-            sourceMatchResult = result;
           } else {
             result = await this.runVisualCropMatch(asset, imageBuffer, prepared);
-
-            if (
-              result.outcome === 'inference_error' ||
-              result.outcome === 'oom' ||
-              result.outcome === 'prepare_error'
-            ) {
-              if (!visualMatchInitialized) {
-                visualMatchExemplarId = await this.initializeVisualMatchExemplar(
-                  prepared,
-                  sourceMatchResult
-                );
-                visualMatchInitialized = true;
-              }
-
-              if (visualMatchExemplarId) {
-                console.warn(
-                  `[SAM3 V2] Visual crop matching failed for ${asset.id}; trying concept fallback.`
-                );
-                result = await this.runVisualConceptMatch(
-                  asset,
-                  imageBuffer,
-                  visualMatchExemplarId,
-                  prepared.textPrompt
-                );
-              }
-            }
-
           }
         } else {
           result = await this.runConceptPropagation(asset, imageBuffer, conceptExemplarId, prepared.weedType);

--- a/prisma/migrations/20260518170000_add_batch_job_asset_ids/migration.sql
+++ b/prisma/migrations/20260518170000_add_batch_job_asset_ids/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `BatchJob`
+    ADD COLUMN `assetIds` JSON NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -477,6 +477,7 @@ model BatchJob {
   version              Int?
   kind                 String  @default("SINGLE")
   mode                 String?
+  assetIds             Json? // String[] of asset IDs covered by this batch job
   stageLog             Json?
   shardIndex           Int?
   shardCount           Int?

--- a/tests/unit/review-session-assets.test.ts
+++ b/tests/unit/review-session-assets.test.ts
@@ -21,7 +21,23 @@ describe('review-session-assets', () => {
     expect(findMany).not.toHaveBeenCalled();
   });
 
-  it('merges dynamically discovered batch assets into early-created batch review sessions', async () => {
+  it('keeps stored batch review assets even when only one asset has pending annotations', async () => {
+    const findMany = vi.fn();
+
+    const assetIds = await resolveReviewSessionAssetIds(
+      { pendingAnnotation: { findMany } },
+      {
+        workflowType: 'batch_review',
+        assetIds: ['asset-1', 'asset-2', 'asset-3'],
+        batchJobIds: ['batch-1'],
+      }
+    );
+
+    expect(findMany).not.toHaveBeenCalled();
+    expect(assetIds).toEqual(['asset-1', 'asset-2', 'asset-3']);
+  });
+
+  it('falls back to pending asset ids when an old batch session has no stored asset snapshot', async () => {
     const findMany = vi.fn().mockResolvedValue([
       { assetId: 'asset-2' },
       { assetId: 'asset-5' },
@@ -32,7 +48,7 @@ describe('review-session-assets', () => {
       { pendingAnnotation: { findMany } },
       {
         workflowType: 'batch_review',
-        assetIds: ['asset-2'],
+        assetIds: [],
         batchJobIds: ['batch-1'],
       }
     );
@@ -44,7 +60,7 @@ describe('review-session-assets', () => {
       select: { assetId: true },
       distinct: ['assetId'],
     });
-    expect(assetIds).toEqual(['asset-2', 'asset-1', 'asset-5']);
+    expect(assetIds).toEqual(['asset-1', 'asset-2', 'asset-5']);
   });
 
   it('falls back to stored asset ids when a batch session has no pending annotations yet', async () => {

--- a/tests/unit/sam3-batch-v2.test.ts
+++ b/tests/unit/sam3-batch-v2.test.ts
@@ -751,70 +751,35 @@ describe('sam3-batch-v2', () => {
     });
   });
 
-  it('keeps operator source boxes as the visual-match anchor when source detections drift', async () => {
+  it('does not fall back to concept matching when visual crop matching fails for target assets', async () => {
     let stageLog: unknown[] = [];
-    const segment = vi
-      .fn()
-      .mockResolvedValueOnce({
-        success: true,
-        response: {
-          detections: [
-            {
-              bbox: [5, 5, 15, 15],
-              confidence: 0.9,
-              polygon: [
-                [5, 5],
-                [15, 5],
-                [15, 15],
-                [5, 15],
-              ],
-            },
-          ],
-          count: 1,
-        },
-      })
-      .mockResolvedValueOnce({
-        success: true,
-        response: {
-          detections: [
-            {
-              bbox: [20, 25, 40, 45],
-              confidence: 0.93,
-              polygon: [
-                [21, 25],
-                [39, 25],
-                [39, 44],
-                [21, 44],
-              ],
-            },
-          ],
-          count: 1,
-        },
-      });
-    const createConceptExemplar = vi.fn().mockResolvedValue({
+    const segment = vi.fn().mockResolvedValue({
       success: true,
-      data: { exemplarId: 'visual-exemplar-1' },
-    });
-    const applyConceptExemplar = vi.fn().mockResolvedValue({
-      success: true,
-      data: {
+      response: {
         detections: [
           {
-            bbox: [20, 25, 40, 45],
-            confidence: 0.82,
-            similarity: 0.88,
+            bbox: [5, 5, 15, 15],
+            confidence: 0.9,
             polygon: [
-              [20, 25],
-              [40, 25],
-              [40, 45],
-              [20, 45],
+              [5, 5],
+              [15, 5],
+              [15, 15],
+              [5, 15],
             ],
-            class_name: 'object',
           },
         ],
-        processingTimeMs: 12,
+        count: 1,
       },
     });
+    const segmentWithExemplars = vi.fn().mockResolvedValue({
+      success: false,
+      response: null,
+      errorCode: 'API_ERROR',
+      error: 'Visual crop endpoint failed',
+    });
+    const warmupConceptService = vi.fn();
+    const createConceptExemplar = vi.fn();
+    const applyConceptExemplar = vi.fn();
     const prismaMock = {
       batchJob: {
         findUnique: vi.fn().mockImplementation(async ({ select }) => {
@@ -892,11 +857,8 @@ describe('sam3-batch-v2', () => {
           scaling: { scaleFactor: 1 },
         })),
         segment,
-        segmentWithExemplars: vi.fn(),
-        warmupConceptService: vi.fn().mockResolvedValue({
-          success: true,
-          data: { sam3Loaded: true, dinoLoaded: true },
-        }),
+        segmentWithExemplars,
+        warmupConceptService,
         createConceptExemplar,
         applyConceptExemplar,
       },
@@ -925,51 +887,26 @@ describe('sam3-batch-v2', () => {
       updateProgress: vi.fn().mockResolvedValue(undefined),
     });
 
-    expect(result.terminalState).toBe('completed');
-    expect(segment).toHaveBeenCalledTimes(2);
-    expect(segment).toHaveBeenNthCalledWith(
-      2,
+    expect(result.terminalState).toBe('completed_partial');
+    expect(result.processedImages).toBe(2);
+    expect(result.failedAssets).toBe(1);
+    expect(segmentWithExemplars).toHaveBeenCalledTimes(1);
+    expect(segmentWithExemplars).toHaveBeenCalledWith(
       expect.objectContaining({
-        boxes: [{ x1: 20, y1: 25, x2: 40, y2: 45 }],
+        exemplarCrops: ['abc123'],
         className: 'Pine Sapling',
       })
     );
-    expect(createConceptExemplar).toHaveBeenCalledTimes(1);
-    expect(createConceptExemplar).toHaveBeenCalledWith(
+    expect(segment).toHaveBeenCalledTimes(1);
+    expect(segment).toHaveBeenCalledWith(
       expect.objectContaining({
         boxes: [{ x1: 100, y1: 100, x2: 150, y2: 160 }],
         className: 'Pine Sapling',
-        imageId: 'asset-source',
       })
     );
-    expect(applyConceptExemplar).toHaveBeenCalledTimes(2);
-    expect(applyConceptExemplar).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        options: expect.objectContaining({
-          returnPolygons: true,
-          similarityThreshold: 0.65,
-          topK: 120,
-          minBoxSize: 16,
-          maxBoxSize: 600,
-          nmsThreshold: 0.5,
-        }),
-      })
-    );
-    expect(applyConceptExemplar).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        options: expect.objectContaining({
-          returnPolygons: true,
-          similarityThreshold: 0.5,
-          topK: 40,
-          minBoxSize: 16,
-          maxBoxSize: 600,
-          nmsThreshold: 0.5,
-        }),
-      })
-    );
-    expect((service as any).awsSam3Service.segmentWithExemplars).not.toHaveBeenCalled();
+    expect(warmupConceptService).not.toHaveBeenCalled();
+    expect(createConceptExemplar).not.toHaveBeenCalled();
+    expect(applyConceptExemplar).not.toHaveBeenCalled();
   });
 
   it('configures the v2 BullMQ queue with global concurrency 1', async () => {


### PR DESCRIPTION
## Summary
- keep commercial SAM3 v2 Apply-to-All visual-crop batches on the SAM3 visual path instead of falling back to DINO/concept matching
- store BatchJob assetIds for single, aggregate, and shard jobs so review sessions know the full processed asset set
- show all batch assets in review, including images with zero pending detections

## Verification
- npm run test:unit -- tests/unit/review-session-assets.test.ts tests/unit/sam3-batch-v2.test.ts
- npm run lint
- npm run build

## Notes
- Adds Prisma migration 20260518170000_add_batch_job_asset_ids; the Docker entrypoint runs prisma migrate deploy.