### PR TITLE
Preserve SAM3 concept candidates when refinement fails

### DIFF
--- a/lib/services/sam3-batch-v2.ts
+++ b/lib/services/sam3-batch-v2.ts
@@ -446,6 +446,8 @@ interface ConceptRefinementResult {
   candidateCount: number;
   refinementBoxCount: number;
   refinementDetectionCount: number;
+  usedCandidateFallback?: boolean;
+  backendWarning?: string;
 }
 
 interface ConceptExemplarRef {
@@ -1746,7 +1748,8 @@ export class Sam3BatchV2Service {
       assetId: asset.id,
       detections: refinement.detections,
       outcome: refinement.detections.length > 0 ? 'success' : 'zero_detections',
-      backendMode: 'concept_refined',
+      backendMode: refinement.usedCandidateFallback ? 'concept_candidates_unrefined' : 'concept_refined',
+      backendWarning: refinement.backendWarning,
       candidateCount: refinement.candidateCount,
       refinementBoxCount: refinement.refinementBoxCount,
       refinementDetectionCount: refinement.refinementDetectionCount,
@@ -1832,7 +1835,10 @@ export class Sam3BatchV2Service {
       assetId: asset.id,
       detections: refinement.detections,
       outcome: refinement.detections.length > 0 ? 'success' : 'zero_detections',
-      backendMode: 'concept_ensemble_refined',
+      backendMode: refinement.usedCandidateFallback
+        ? 'concept_ensemble_candidates_unrefined'
+        : 'concept_ensemble_refined',
+      backendWarning: refinement.backendWarning,
       candidateCount: refinement.candidateCount,
       refinementBoxCount: refinement.refinementBoxCount,
       refinementDetectionCount: refinement.refinementDetectionCount,
@@ -2020,34 +2026,62 @@ export class Sam3BatchV2Service {
       };
     }
 
-    await this.ensureSam3ReadyForBoxRefinement(asset.id);
+    let resized: Awaited<ReturnType<AwsSam3Like['resizeImage']>>;
+    let boxes: BoxCoordinate[];
 
-    const resized = await this.awsSam3Service.resizeImage(imageBuffer);
-    const boxes = candidates
-      .map((candidate) => bboxToBoxCoordinate(candidate.bbox, resized.scaling.scaleFactor))
-      .filter(isValidBox);
-
-    if (boxes.length === 0) {
-      throw createNamedError(
-        'InferenceFailureError',
-        `SAM3 box refinement could not build valid boxes for ${asset.id}.`,
-        'SAM3_REFINEMENT_INVALID_BOXES'
+    try {
+      await this.ensureSam3ReadyForBoxRefinement(asset.id);
+      resized = await this.awsSam3Service.resizeImage(imageBuffer);
+      boxes = candidates
+        .map((candidate) => bboxToBoxCoordinate(candidate.bbox, resized.scaling.scaleFactor))
+        .filter(isValidBox);
+    } catch (error) {
+      return this.buildConceptCandidateFallbackResult(
+        asset.id,
+        candidates,
+        0,
+        0,
+        error instanceof Error ? error.message : 'SAM3 box refinement could not prepare candidates.'
       );
     }
 
-    const result = await this.awsSam3Service.segment({
-      image: resized.buffer.toString('base64'),
-      boxes,
-      className,
-      returnPolygons: true,
-    });
+    if (boxes.length === 0) {
+      return this.buildConceptCandidateFallbackResult(
+        asset.id,
+        candidates,
+        0,
+        0,
+        'SAM3 box refinement could not build valid boxes.'
+      );
+    }
+
+    let result: Awaited<ReturnType<AwsSam3Like['segment']>>;
+
+    try {
+      result = await this.awsSam3Service.segment({
+        image: resized.buffer.toString('base64'),
+        boxes,
+        className,
+        returnPolygons: true,
+      });
+    } catch (error) {
+      return this.buildConceptCandidateFallbackResult(
+        asset.id,
+        candidates,
+        boxes.length,
+        0,
+        error instanceof Error ? error.message : 'SAM3 box refinement request failed.'
+      );
+    }
 
     if (!result.success || !result.response || result.response.detections.length === 0) {
       const message = result.error || 'SAM3 box refinement returned no detections.';
-      throw createNamedError(
-        'InferenceFailureError',
-        `SAM3 box refinement failed for ${asset.id}: ${message}`,
-        result.errorCode || 'SAM3_REFINEMENT_FAILED'
+      return this.buildConceptCandidateFallbackResult(
+        asset.id,
+        candidates,
+        boxes.length,
+        result.response?.detections.length ?? 0,
+        message
       );
     }
 
@@ -2103,6 +2137,30 @@ export class Sam3BatchV2Service {
       candidateCount: candidates.length,
       refinementBoxCount: boxes.length,
       refinementDetectionCount: result.response.detections.length,
+    };
+  }
+
+  private buildConceptCandidateFallbackResult(
+    assetId: string,
+    candidates: SAM3ConceptDetection[],
+    refinementBoxCount: number,
+    refinementDetectionCount: number,
+    reason: string
+  ): ConceptRefinementResult {
+    const detections = candidates.map(mapConceptDetectionToAssetDetection);
+    const backendWarning =
+      `SAM3 box refinement failed for ${assetId}; saved ${detections.length} ` +
+      `unrefined concept candidate(s) as pending review items: ${reason}`;
+
+    console.warn(`[SAM3 V2] ${backendWarning}`);
+
+    return {
+      detections,
+      candidateCount: candidates.length,
+      refinementBoxCount,
+      refinementDetectionCount,
+      usedCandidateFallback: true,
+      backendWarning,
     };
   }
 

--- a/tests/unit/sam3-batch-v2.test.ts
+++ b/tests/unit/sam3-batch-v2.test.ts
@@ -730,6 +730,94 @@ describe('sam3-batch-v2', () => {
     });
   });
 
+  it('saves concept candidate polygons for review when box refinement fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const candidates = Array.from({ length: 50 }, (_, index) =>
+      makeConceptDetection(index, 0.84)
+    );
+    const applyConceptExemplar = vi.fn().mockResolvedValue({
+      success: true,
+      data: {
+        detections: candidates,
+        processingTimeMs: 8,
+      },
+    });
+    const segment = vi.fn().mockResolvedValue({
+      success: false,
+      response: null,
+      error: 'SAM3 API error: 500 - Internal Server Error',
+      errorCode: 'API_ERROR',
+    });
+    const service = new Sam3BatchV2Service({
+      prisma: {} as never,
+      awsSam3Service: {
+        applyConceptExemplar,
+        refreshStatus: vi.fn().mockResolvedValue({
+          modelLoaded: true,
+          instanceState: 'ready',
+          ipAddress: '127.0.0.1',
+        }),
+        isReady: vi.fn().mockReturnValue(true),
+        resizeImage: vi.fn().mockImplementation(async (imageBuffer: Buffer) => ({
+          buffer: imageBuffer,
+          scaling: { scaleFactor: 1 },
+        })),
+        segment,
+      } as any,
+      acquireGpuLock: vi.fn(),
+      refreshGpuLock: vi.fn(),
+      releaseGpuLock: vi.fn(),
+      sleep: vi.fn(),
+      now: () => new Date('2026-03-31T00:00:00.000Z'),
+    });
+
+    const result = await (service as any).runConceptPropagation(
+      {
+        id: 'asset-target',
+        storageUrl: 'http://localhost/asset-target.jpg',
+        s3Key: null,
+        s3Bucket: null,
+        storageType: 'local',
+        imageWidth: 4000,
+        imageHeight: 3000,
+      },
+      Buffer.from('target-image'),
+      'concept-exemplar-1',
+      'Pine Sapling'
+    );
+
+    expect(segment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        boxes: expect.arrayContaining([{ x1: 0, y1: 10, x2: 6, y2: 18 }]),
+        returnPolygons: true,
+      })
+    );
+    expect(result).toMatchObject({
+      assetId: 'asset-target',
+      outcome: 'success',
+      backendMode: 'concept_ensemble_candidates_unrefined',
+      backendWarning: expect.stringContaining('saved 50 unrefined concept candidate(s)'),
+      candidateCount: 50,
+      refinementBoxCount: 50,
+      refinementDetectionCount: 0,
+    });
+    expect(result.detections).toHaveLength(50);
+    expect(result.detections[0]).toMatchObject({
+      bbox: [0, 10, 6, 18],
+      polygon: [
+        [0, 10],
+        [6, 10],
+        [6, 18],
+        [0, 18],
+      ],
+      confidence: 0.84,
+      similarity: 0.84,
+    });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('saved 50 unrefined concept candidate(s)')
+    );
+  });
+
   it('fails loudly when target refinement drifts away from candidates', async () => {
     const candidate = {
       bbox: [20, 25, 40, 45],


### PR DESCRIPTION
## Summary
- Preserve SAM3 concept/visual candidate polygons as pending review items when final SAM3 box refinement fails.
- Mark fallback results clearly with `concept_ensemble_candidates_unrefined` / `concept_candidates_unrefined` and a `backendWarning` so operators and diagnostics can see refinement did not complete.
- Add a unit test for the production failure mode Manas hit: concept candidates exist, `/segment` returns a 500-style failure, and the review queue still receives pending candidate polygons instead of zero annotations.

## Why
Manas's latest AG-3 run showed every target asset failed after candidate generation because SAM3 `/segment` refinement returned `500 Internal Server Error`. The existing fail-loud guard prevented poor silent fallbacks, but in this case it also discarded usable candidate polygons that should enter QA review.

## Verification
- `npm run test:unit -- tests/unit/sam3-batch-v2.test.ts`
- `npm run lint -- --file lib/services/sam3-batch-v2.ts`

Note: targeted lint including `tests/unit/sam3-batch-v2.test.ts` is still blocked by pre-existing `no-explicit-any` usage throughout that test file.
