### PR TITLE
Add pine sapling YOLO inference endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,9 +23,16 @@ ROBOFLOW_TRAINING_PROJECT="your-training-project"  # Project to push training da
 # YOLO_SERVICE_URL is optional when using SAM3 EC2 auto-discovery.
 # If unset, the app uses SAM3_EC2_INSTANCE_ID to discover the host and YOLO_PORT.
 YOLO_SERVICE_URL="http://localhost:8001"
+YOLO_INFERENCE_URL="http://localhost:8001"
 YOLO_PORT="8001"
 # YOLO_DISCOVERY_TTL_MS="60000"
 # YOLO_SERVICE_API_KEY=""
+
+# Deployed pine sapling YOLO11n-seg model used by server-side inference/counting.
+# Production currently points YOLO_SERVICE_URL and YOLO_INFERENCE_URL at http://13.54.121.111:8001.
+PINE_SAPLING_YOLO_MODEL_ID="cmpp43ahk0001n5wgzn77vjrf"
+PINE_SAPLING_PROJECT_ID="cmo6ng4fp0001pm2zbo3341te"
+PINE_SAPLING_YOLO_MODEL_NAME="pine-saplings-yolo11n-seg-glasshouse-v1"
 
 # Map services
 MAPBOX_ACCESS_TOKEN="your-mapbox-token"

--- a/app/api/inference/pine-saplings/count/route.ts
+++ b/app/api/inference/pine-saplings/count/route.ts
@@ -1,0 +1,108 @@
+/**
+ * Pine Sapling Count API Route
+ *
+ * GET /api/inference/pine-saplings/count - Count stored georeferenced detections
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
+import prisma from '@/lib/db';
+import { checkProjectAccess } from '@/lib/auth/api-auth';
+import { clusterPineSaplingDetections } from '@/lib/services/pine-sapling-count';
+import {
+  PINE_SAPLING_CLASS_NAME,
+  PINE_SAPLING_PROJECT_ID,
+  PINE_SAPLING_YOLO_MODEL_ID,
+} from '@/lib/services/yolo';
+
+const MAX_RETURNED_CLUSTERS = 500;
+
+function parseBoolean(value: string | null): boolean {
+  if (!value) {
+    return false;
+  }
+  return ['1', 'true', 'yes'].includes(value.toLowerCase());
+}
+
+function parseClusterRadiusMeters(value: string | null): number {
+  if (!value) {
+    return 0;
+  }
+
+  const radius = Number.parseFloat(value);
+  if (!Number.isFinite(radius) || radius < 0) {
+    return 0;
+  }
+
+  return Math.min(radius, 50);
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const projectId = searchParams.get('projectId') || PINE_SAPLING_PROJECT_ID;
+    const modelId = searchParams.get('modelId') || PINE_SAPLING_YOLO_MODEL_ID;
+    const reviewedOnly = parseBoolean(searchParams.get('reviewedOnly'));
+    const clusterRadiusMeters = parseClusterRadiusMeters(
+      searchParams.get('clusterRadiusMeters')
+    );
+
+    const projectAccess = await checkProjectAccess(projectId);
+    if (!projectAccess.authenticated) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    if (!projectAccess.hasAccess) {
+      return NextResponse.json(
+        { error: projectAccess.error || 'Access denied' },
+        { status: 403 }
+      );
+    }
+
+    const where: Prisma.DetectionWhereInput = {
+      customModelId: modelId,
+      className: PINE_SAPLING_CLASS_NAME,
+      rejected: false,
+      centerLat: { not: null },
+      centerLon: { not: null },
+      asset: { projectId },
+      ...(reviewedOnly
+        ? {
+            OR: [{ verified: true }, { userCorrected: true }],
+          }
+        : {}),
+    };
+
+    const detections = await prisma.detection.findMany({
+      where,
+      select: {
+        id: true,
+        assetId: true,
+        centerLat: true,
+        centerLon: true,
+        confidence: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    const clusters = clusterPineSaplingDetections(detections, clusterRadiusMeters);
+
+    return NextResponse.json({
+      projectId,
+      modelId,
+      className: PINE_SAPLING_CLASS_NAME,
+      reviewedOnly,
+      clusterRadiusMeters,
+      storedDetections: detections.length,
+      georeferencedDetections: detections.length,
+      count: clusters.length,
+      clustersReturned: Math.min(clusters.length, MAX_RETURNED_CLUSTERS),
+      clustersTruncated: clusters.length > MAX_RETURNED_CLUSTERS,
+      clusters: clusters.slice(0, MAX_RETURNED_CLUSTERS),
+    });
+  } catch (error) {
+    console.error('Error counting pine saplings:', error);
+    return NextResponse.json(
+      { error: 'Failed to count pine saplings' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/inference/run/route.ts
+++ b/app/api/inference/run/route.ts
@@ -9,7 +9,10 @@ import { getAuthenticatedUser, checkProjectAccess } from '@/lib/auth/api-auth';
 import { checkRedisConnection } from '@/lib/queue/redis';
 import { enqueueInferenceJob } from '@/lib/queue/inference-queue';
 import { processInferenceJob } from '@/lib/services/inference';
-import { formatModelId } from '@/lib/services/yolo';
+import {
+  isPineSaplingYoloModelId,
+  resolveYoloServiceModelName,
+} from '@/lib/services/yolo';
 import { S3Service } from '@/lib/services/s3';
 
 const MAX_SYNC_IMAGES = 50;
@@ -101,8 +104,6 @@ export async function POST(request: NextRequest) {
       where: { id: projectId },
       select: { inferenceBackend: true, activeModelId: true },
     });
-    const backendPreference = (project?.inferenceBackend || 'AUTO').toLowerCase();
-
     const effectiveModelId = requestedModelId || project?.activeModelId;
     if (!effectiveModelId) {
       return NextResponse.json(
@@ -131,6 +132,10 @@ export async function POST(request: NextRequest) {
     if (!model) {
       return NextResponse.json({ error: 'Model not found' }, { status: 404 });
     }
+
+    const backendPreference = isPineSaplingYoloModelId(effectiveModelId)
+      ? 'local'
+      : (project?.inferenceBackend || 'AUTO').toLowerCase();
 
     if (['TRAINING', 'ARCHIVED', 'FAILED'].includes(model.status)) {
       return NextResponse.json(
@@ -225,7 +230,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (!preview) {
+    if (!preview && !isPineSaplingYoloModelId(effectiveModelId)) {
       const weightsReady = await ensureCanonicalWeights(model);
       if (!weightsReady.ok) {
         console.error('Failed to prepare model weights:', weightsReady.error);
@@ -236,7 +241,7 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    const modelName = formatModelId(model.name, model.version);
+    const modelName = resolveYoloServiceModelName(model);
 
     const processingJob = await prisma.processingJob.create({
       data: {

--- a/app/api/training/models/[id]/activate/route.ts
+++ b/app/api/training/models/[id]/activate/route.ts
@@ -6,7 +6,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/db';
 import { getAuthenticatedUser, checkProjectAccess } from '@/lib/auth/api-auth';
-import { formatModelId } from '@/lib/services/yolo';
+import { resolveYoloServiceModelName } from '@/lib/services/yolo';
 import { yoloInferenceClient } from '@/lib/services/yolo-inference';
 import { sam3Orchestrator } from '@/lib/services/sam3-orchestrator';
 import { ModelStatus } from '@prisma/client';
@@ -53,7 +53,7 @@ export async function POST(
       return NextResponse.json({ error: 'Model not found' }, { status: 404 });
     }
 
-    const modelId = formatModelId(model.name, model.version);
+    const modelId = resolveYoloServiceModelName(model);
 
     try {
       const gpuResult = await sam3Orchestrator.ensureGPUAvailable();

--- a/docs/PINE_SAPLING_YOLO_INFERENCE.md
+++ b/docs/PINE_SAPLING_YOLO_INFERENCE.md
@@ -1,0 +1,93 @@
+# Pine Sapling YOLO Inference
+
+## Purpose
+
+The deployed pine sapling YOLO11n-seg model is exposed through AgriDrone server
+routes for v1 pine sapling detection and counting. The v1 app integration uses
+bounding boxes and georeferenced box centres only. Segmentation masks and review
+polygons are a follow-up.
+
+## Runtime Configuration
+
+Set these server-side environment variables in production:
+
+```env
+YOLO_SERVICE_URL=http://13.54.121.111:8001
+YOLO_INFERENCE_URL=http://13.54.121.111:8001
+PINE_SAPLING_YOLO_MODEL_ID=cmpp43ahk0001n5wgzn77vjrf
+PINE_SAPLING_PROJECT_ID=cmo6ng4fp0001pm2zbo3341te
+PINE_SAPLING_YOLO_MODEL_NAME=pine-saplings-yolo11n-seg-glasshouse-v1
+```
+
+Do not call the EC2 service directly from browser code. Browser/UI code should
+call AgriDrone API routes only.
+
+## Health Check
+
+```http
+GET /api/inference/health
+```
+
+This checks the configured local YOLO inference service through the server. The
+EC2 raw health endpoint is `GET http://13.54.121.111:8001/health`.
+
+## Preview A Project Run
+
+```http
+POST /api/inference/run
+Content-Type: application/json
+```
+
+```json
+{
+  "projectId": "cmo6ng4fp0001pm2zbo3341te",
+  "modelId": "cmpp43ahk0001n5wgzn77vjrf",
+  "confidence": 0.25,
+  "saveDetections": true,
+  "preview": true
+}
+```
+
+Preview returns eligible image counts without creating detections.
+
+## Run A Small Selected Asset Test
+
+```json
+{
+  "projectId": "cmo6ng4fp0001pm2zbo3341te",
+  "modelId": "cmpp43ahk0001n5wgzn77vjrf",
+  "assetIds": ["asset-id-1"],
+  "confidence": 0.25,
+  "saveDetections": true,
+  "preview": false
+}
+```
+
+For selected tests, use one to five assets first. Successful runs create
+`Detection` rows with `customModelId = cmpp43ahk0001n5wgzn77vjrf`,
+`className = Pine Sapling`, a bounding box, and `centerLat`/`centerLon` where
+the asset has sufficient georeferencing metadata.
+
+## Count Stored Pine Saplings
+
+```http
+GET /api/inference/pine-saplings/count?projectId=cmo6ng4fp0001pm2zbo3341te
+```
+
+Optional parameters:
+
+- `modelId`: defaults to `cmpp43ahk0001n5wgzn77vjrf`.
+- `reviewedOnly=true`: count only verified or user-corrected detections.
+- `clusterRadiusMeters=1.5`: cluster nearby georeferenced centres to reduce
+  double-counting across overlapping drone images.
+
+With `clusterRadiusMeters=0`, each stored georeferenced detection counts as one
+sapling candidate.
+
+## Follow-Up: Segmentation Masks
+
+The deployed model is segmentation-capable, but the current YOLO FastAPI service
+returns only `bbox`. To expose masks later, patch `/opt/sam3-api/yolo_service.py`
+to include `polygon?: number[][]` on each detection and return
+`result.masks.xy[i]`. Then update AgriDrone persistence/review overlays to store
+and render polygons.

--- a/lib/services/pine-sapling-count.ts
+++ b/lib/services/pine-sapling-count.ts
@@ -1,0 +1,108 @@
+export interface PineSaplingCountDetection {
+  id: string;
+  assetId: string;
+  centerLat: number | null;
+  centerLon: number | null;
+  confidence: number | null;
+}
+
+export interface PineSaplingCluster {
+  id: string;
+  count: number;
+  centerLat: number;
+  centerLon: number;
+  maxConfidence: number | null;
+  detectionIds: string[];
+  assetIds: string[];
+}
+
+const EARTH_RADIUS_METERS = 6371008.8;
+
+function toRadians(value: number): number {
+  return (value * Math.PI) / 180;
+}
+
+export function distanceMeters(
+  first: { lat: number; lon: number },
+  second: { lat: number; lon: number }
+): number {
+  const lat1 = toRadians(first.lat);
+  const lat2 = toRadians(second.lat);
+  const deltaLat = toRadians(second.lat - first.lat);
+  const deltaLon = toRadians(second.lon - first.lon);
+
+  const a =
+    Math.sin(deltaLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(deltaLon / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+  return EARTH_RADIUS_METERS * c;
+}
+
+export function clusterPineSaplingDetections(
+  detections: PineSaplingCountDetection[],
+  radiusMeters: number
+): PineSaplingCluster[] {
+  const geoDetections = detections.filter(
+    (detection): detection is PineSaplingCountDetection & { centerLat: number; centerLon: number } =>
+      typeof detection.centerLat === 'number' &&
+      Number.isFinite(detection.centerLat) &&
+      typeof detection.centerLon === 'number' &&
+      Number.isFinite(detection.centerLon)
+  );
+
+  if (!Number.isFinite(radiusMeters) || radiusMeters <= 0) {
+    return geoDetections.map((detection) => ({
+      id: detection.id,
+      count: 1,
+      centerLat: detection.centerLat,
+      centerLon: detection.centerLon,
+      maxConfidence: detection.confidence,
+      detectionIds: [detection.id],
+      assetIds: [detection.assetId],
+    }));
+  }
+
+  const clusters: PineSaplingCluster[] = [];
+
+  for (const detection of geoDetections) {
+    const matchingCluster = clusters.find(
+      (cluster) =>
+        distanceMeters(
+          { lat: detection.centerLat, lon: detection.centerLon },
+          { lat: cluster.centerLat, lon: cluster.centerLon }
+        ) <= radiusMeters
+    );
+
+    if (!matchingCluster) {
+      clusters.push({
+        id: detection.id,
+        count: 1,
+        centerLat: detection.centerLat,
+        centerLon: detection.centerLon,
+        maxConfidence: detection.confidence,
+        detectionIds: [detection.id],
+        assetIds: [detection.assetId],
+      });
+      continue;
+    }
+
+    const nextCount = matchingCluster.count + 1;
+    matchingCluster.centerLat =
+      (matchingCluster.centerLat * matchingCluster.count + detection.centerLat) / nextCount;
+    matchingCluster.centerLon =
+      (matchingCluster.centerLon * matchingCluster.count + detection.centerLon) / nextCount;
+    matchingCluster.count = nextCount;
+    if (matchingCluster.maxConfidence == null) {
+      matchingCluster.maxConfidence = detection.confidence;
+    } else if (detection.confidence != null) {
+      matchingCluster.maxConfidence = Math.max(matchingCluster.maxConfidence, detection.confidence);
+    }
+    matchingCluster.detectionIds.push(detection.id);
+    if (!matchingCluster.assetIds.includes(detection.assetId)) {
+      matchingCluster.assetIds.push(detection.assetId);
+    }
+  }
+
+  return clusters;
+}

--- a/lib/services/yolo.ts
+++ b/lib/services/yolo.ts
@@ -11,6 +11,14 @@ const YOLO_DISCOVERY_TTL_MS = Number.parseInt(
   10
 );
 
+export const PINE_SAPLING_YOLO_MODEL_ID =
+  process.env.PINE_SAPLING_YOLO_MODEL_ID || 'cmpp43ahk0001n5wgzn77vjrf';
+export const PINE_SAPLING_PROJECT_ID =
+  process.env.PINE_SAPLING_PROJECT_ID || 'cmo6ng4fp0001pm2zbo3341te';
+export const PINE_SAPLING_YOLO_MODEL_NAME =
+  process.env.PINE_SAPLING_YOLO_MODEL_NAME || 'pine-saplings-yolo11n-seg-glasshouse-v1';
+export const PINE_SAPLING_CLASS_NAME = 'Pine Sapling';
+
 export interface TrainingConfig {
   dataset_s3_path: string;
   model_name: string;
@@ -577,6 +585,22 @@ export default YOLOService;
 
 export function formatModelId(name: string, version: number): string {
   return `${name}-v${version}`;
+}
+
+export function isPineSaplingYoloModelId(modelId: string | null | undefined): boolean {
+  return modelId === PINE_SAPLING_YOLO_MODEL_ID;
+}
+
+export function resolveYoloServiceModelName(model: {
+  id?: string | null;
+  name: string;
+  version: number;
+}): string {
+  if (isPineSaplingYoloModelId(model.id)) {
+    return PINE_SAPLING_YOLO_MODEL_NAME;
+  }
+
+  return formatModelId(model.name, model.version);
 }
 
 export function parseModelId(modelId: string): { name: string; version?: number } {

--- a/tests/unit/pine-sapling-count.test.ts
+++ b/tests/unit/pine-sapling-count.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clusterPineSaplingDetections,
+  distanceMeters,
+} from '@/lib/services/pine-sapling-count';
+
+describe('pine sapling count clustering', () => {
+  it('counts each georeferenced detection separately when clustering is disabled', () => {
+    const clusters = clusterPineSaplingDetections(
+      [
+        {
+          id: 'det-1',
+          assetId: 'asset-1',
+          centerLat: -27.1,
+          centerLon: 153.1,
+          confidence: 0.91,
+        },
+        {
+          id: 'det-2',
+          assetId: 'asset-2',
+          centerLat: -27.10001,
+          centerLon: 153.10001,
+          confidence: 0.87,
+        },
+      ],
+      0
+    );
+
+    expect(clusters).toHaveLength(2);
+    expect(clusters.map((cluster) => cluster.count)).toEqual([1, 1]);
+  });
+
+  it('clusters nearby detections and keeps distant detections separate', () => {
+    const first = { lat: -27.1, lon: 153.1 };
+    const nearby = { lat: -27.100002, lon: 153.100002 };
+    const distant = { lat: -27.1002, lon: 153.1002 };
+
+    expect(distanceMeters(first, nearby)).toBeLessThan(1);
+    expect(distanceMeters(first, distant)).toBeGreaterThan(10);
+
+    const clusters = clusterPineSaplingDetections(
+      [
+        {
+          id: 'det-1',
+          assetId: 'asset-1',
+          centerLat: first.lat,
+          centerLon: first.lon,
+          confidence: 0.82,
+        },
+        {
+          id: 'det-2',
+          assetId: 'asset-2',
+          centerLat: nearby.lat,
+          centerLon: nearby.lon,
+          confidence: 0.94,
+        },
+        {
+          id: 'det-3',
+          assetId: 'asset-3',
+          centerLat: distant.lat,
+          centerLon: distant.lon,
+          confidence: 0.71,
+        },
+      ],
+      1
+    );
+
+    expect(clusters).toHaveLength(2);
+    expect(clusters[0]).toMatchObject({
+      count: 2,
+      maxConfidence: 0.94,
+      detectionIds: ['det-1', 'det-2'],
+      assetIds: ['asset-1', 'asset-2'],
+    });
+    expect(clusters[1]).toMatchObject({
+      count: 1,
+      detectionIds: ['det-3'],
+    });
+  });
+
+  it('ignores detections without finite georeferenced centres', () => {
+    const clusters = clusterPineSaplingDetections(
+      [
+        {
+          id: 'det-1',
+          assetId: 'asset-1',
+          centerLat: null,
+          centerLon: 153.1,
+          confidence: 0.91,
+        },
+        {
+          id: 'det-2',
+          assetId: 'asset-2',
+          centerLat: -27.1,
+          centerLon: Number.NaN,
+          confidence: 0.87,
+        },
+      ],
+      0
+    );
+
+    expect(clusters).toEqual([]);
+  });
+});

--- a/tests/unit/yolo-training-service.test.ts
+++ b/tests/unit/yolo-training-service.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { YOLOService } from '@/lib/services/yolo';
+import {
+  PINE_SAPLING_YOLO_MODEL_ID,
+  PINE_SAPLING_YOLO_MODEL_NAME,
+  YOLOService,
+  resolveYoloServiceModelName,
+} from '@/lib/services/yolo';
 
 describe('yolo training service', () => {
   const originalFetch = global.fetch;
@@ -72,5 +77,25 @@ describe('yolo training service', () => {
       statusCode: 503,
       message: 'Failed to connect to YOLO service: connect ECONNREFUSED',
     });
+  });
+
+  it('maps the deployed pine sapling DB model to the registered YOLO service model name', () => {
+    expect(
+      resolveYoloServiceModelName({
+        id: PINE_SAPLING_YOLO_MODEL_ID,
+        name: 'Test Pine Saplings',
+        version: 1,
+      })
+    ).toBe(PINE_SAPLING_YOLO_MODEL_NAME);
+  });
+
+  it('keeps the generic name-version mapping for other YOLO models', () => {
+    expect(
+      resolveYoloServiceModelName({
+        id: 'other-model',
+        name: 'lantana',
+        version: 3,
+      })
+    ).toBe('lantana-v3');
   });
 });


### PR DESCRIPTION
## Summary
- map the deployed Glasshouse pine sapling DB model to the registered YOLO service model name
- keep pine sapling inference on the local YOLO backend and skip unnecessary weight-copy prep for the pinned deployed model
- add a server-side pine sapling count endpoint with optional geospatial centre clustering
- document the health, preview, selected-asset run, and count endpoints

## Verification
- npm run test:unit -- tests/unit/yolo-training-service.test.ts tests/unit/pine-sapling-count.test.ts
- npm run lint -- --file lib/services/yolo.ts --file lib/services/pine-sapling-count.ts --file app/api/inference/run/route.ts --file app/api/inference/pine-saplings/count/route.ts --file 'app/api/training/models/[id]/activate/route.ts' --file tests/unit/yolo-training-service.test.ts --file tests/unit/pine-sapling-count.test.ts
- npm run build
- curl http://13.54.121.111:8001/health
- curl http://13.54.121.111:8001/api/v1/models