### PR TITLE
Wire upload auto inference to pine YOLO model

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -10,7 +10,10 @@ import {
   ROBOFLOW_MODELS,
   roboflowService,
 } from "@/lib/services/roboflow";
-import { formatModelId } from "@/lib/services/yolo";
+import {
+  isPineSaplingYoloModelId,
+  resolveYoloServiceModelName,
+} from "@/lib/services/yolo";
 import { processInferenceJob } from "@/lib/services/inference";
 import { checkRedisConnection } from "@/lib/queue/redis";
 import { enqueueInferenceJob } from "@/lib/queue/inference-queue";
@@ -271,6 +274,9 @@ export async function POST(request: NextRequest) {
           processedImages?: number;
           detectionsFound?: number;
           skippedImages?: number;
+          modelName?: string;
+          backend?: string;
+          source?: string;
           error?: string;
         }
       | undefined;
@@ -888,8 +894,10 @@ export async function POST(request: NextRequest) {
             error: `Active YOLO model status ${model.status} is not ready for inference.`,
           };
         } else {
-          const modelName = formatModelId(model.name, model.version);
-          const backendPreference = (projectSettings.inferenceBackend || 'AUTO').toLowerCase();
+          const modelName = resolveYoloServiceModelName(model);
+          const backendPreference = isPineSaplingYoloModelId(model.id)
+            ? "local"
+            : (projectSettings.inferenceBackend || "AUTO").toLowerCase();
           const processingJob = await prisma.processingJob.create({
             data: {
               projectId,
@@ -925,7 +933,7 @@ export async function POST(request: NextRequest) {
               skippedImages: autoInferenceSkipped,
               duplicateImages: 0,
               skippedReason: "missing_gps_or_dimensions",
-              backend: backendPreference as 'local' | 'roboflow' | 'auto',
+              backend: backendPreference as "local" | "roboflow" | "auto",
             });
 
             autoInferenceSummary = {
@@ -936,6 +944,9 @@ export async function POST(request: NextRequest) {
               processedImages: result.processedImages,
               detectionsFound: result.detectionsFound,
               skippedImages: autoInferenceSkipped,
+              modelName,
+              backend: backendPreference,
+              source: "auto_upload",
             };
           } else {
             const redisAvailable = await checkRedisConnection();
@@ -962,7 +973,7 @@ export async function POST(request: NextRequest) {
                 assetIds: autoInferenceAssetIds,
                 confidence: AUTO_INFERENCE_CONFIDENCE,
                 saveDetections: true,
-                backend: backendPreference as 'local' | 'roboflow' | 'auto',
+                backend: backendPreference as "local" | "roboflow" | "auto",
               });
               autoInferenceSummary = {
                 started: true,
@@ -970,6 +981,9 @@ export async function POST(request: NextRequest) {
                 jobId: processingJob.id,
                 totalImages: autoInferenceAssetIds.length,
                 skippedImages: autoInferenceSkipped,
+                modelName,
+                backend: backendPreference,
+                source: "auto_upload",
               };
             }
           }

--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -396,6 +396,35 @@ function UploadPageContent() {
                     </div>
                   </div>
 
+                  {uploadResponse.autoInference?.started && (
+                    <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-900">
+                      YOLO inference{" "}
+                      {uploadResponse.autoInference.status === "queued"
+                        ? "has been queued"
+                        : "completed"}{" "}
+                      for {uploadResponse.autoInference.totalImages?.toLocaleString() || 0}{" "}
+                      uploaded images.
+                      {typeof uploadResponse.autoInference.detectionsFound === "number"
+                        ? ` ${uploadResponse.autoInference.detectionsFound.toLocaleString()} pine sapling candidates were saved.`
+                        : ""}
+                      {uploadResponse.autoInference.skippedImages
+                        ? ` ${uploadResponse.autoInference.skippedImages.toLocaleString()} images were skipped because they are missing GPS coordinates or image dimensions.`
+                        : ""}
+                      {uploadResponse.autoInference.jobId
+                        ? ` Job ID: ${uploadResponse.autoInference.jobId}.`
+                        : ""}
+                    </div>
+                  )}
+
+                  {uploadResponse.autoInference &&
+                    !uploadResponse.autoInference.started &&
+                    uploadResponse.autoInference.error && (
+                      <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+                        Uploads completed, but YOLO auto-inference did not start:{" "}
+                        {uploadResponse.autoInference.error}
+                      </div>
+                    )}
+
                   {uploadResponse.roboflowDetection?.started && (
                     <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 text-sm text-blue-900">
                       Background AI detection has been queued for{" "}

--- a/components/UppyUploader.tsx
+++ b/components/UppyUploader.tsx
@@ -36,6 +36,13 @@ export interface QueuedDetectionSummary {
   source?: string;
 }
 
+export interface AutoInferenceSummary extends QueuedDetectionSummary {
+  processedImages?: number;
+  detectionsFound?: number;
+  modelName?: string;
+  backend?: string;
+}
+
 export interface UploadApiResponse {
   message: string;
   files: ProcessedUploadFile[];
@@ -45,7 +52,7 @@ export interface UploadApiResponse {
     withWarnings: number;
     warningTypes: string[];
   };
-  autoInference?: Record<string, unknown>;
+  autoInference?: AutoInferenceSummary;
   roboflowDetection?: QueuedDetectionSummary;
 }
 


### PR DESCRIPTION
## Summary
- route upload-time auto inference through the shared YOLO service model resolver
- force the pinned pine sapling model onto the local YOLO backend during upload auto inference
- return typed auto-inference metadata and show upload success/failure feedback for YOLO auto inference

## Verification
- npm run lint -- --file app/api/upload/route.ts --file app/upload/page.tsx --file components/UppyUploader.tsx
- npm run build
- npm run test:unit -- tests/unit/yolo-training-service.test.ts