### PR TITLE
Implement AG-12 upload run review flow

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -53,6 +53,7 @@ const requestSchema = z.object({
   flightSession: z.string().optional(),
   cameraFov: z.number().min(1).max(180).optional(),
   cameraProfileId: z.string().optional(),
+  runActiveModel: z.boolean().optional().default(false),
   disableAutoInference: z.boolean().optional().default(false),
 });
 
@@ -164,6 +165,7 @@ export async function POST(request: NextRequest) {
       flightSession,
       cameraFov,
       cameraProfileId,
+      runActiveModel,
       disableAutoInference,
     } = parsed.data;
 
@@ -195,6 +197,11 @@ export async function POST(request: NextRequest) {
     if (!projectSettings) {
       return NextResponse.json({ error: "Project not found" }, { status: 404 });
     }
+
+    const activeModelInferenceRequested =
+      !disableAutoInference &&
+      (projectSettings.autoInferenceEnabled || runActiveModel);
+    const activeModelId = projectSettings.activeModelId;
 
     const explicitCameraProfileId = cameraProfileId || null;
     const effectiveCameraProfileId =
@@ -274,6 +281,8 @@ export async function POST(request: NextRequest) {
           processedImages?: number;
           detectionsFound?: number;
           skippedImages?: number;
+          duplicateImages?: number;
+          skippedReason?: string;
           modelName?: string;
           backend?: string;
           source?: string;
@@ -754,7 +763,7 @@ export async function POST(request: NextRequest) {
           return { asset, detections };
         });
 
-        if (projectSettings.autoInferenceEnabled && projectSettings.activeModelId) {
+        if (activeModelInferenceRequested && activeModelId) {
           if (
             extractedData.gpsLatitude != null &&
             extractedData.gpsLongitude != null &&
@@ -863,16 +872,37 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    if (
-      !disableAutoInference &&
-      projectSettings.autoInferenceEnabled &&
-      projectSettings.activeModelId &&
+    if (activeModelInferenceRequested && !activeModelId) {
+      autoInferenceSummary = {
+        started: false,
+        error: "No active YOLO model is set for this project.",
+        source: "auto_upload",
+      };
+    } else if (
+      activeModelInferenceRequested &&
+      activeModelId &&
+      autoInferenceAssetIds.length === 0
+    ) {
+      autoInferenceSummary = {
+        started: false,
+        error:
+          autoInferenceSkipped > 0
+            ? "No uploaded images were eligible for active-model inference because GPS coordinates or image dimensions are missing."
+            : "No uploaded images were eligible for active-model inference.",
+        totalImages: 0,
+        skippedImages: autoInferenceSkipped,
+        skippedReason: autoInferenceSkipped > 0 ? "missing_gps_or_dimensions" : undefined,
+        source: "auto_upload",
+      };
+    } else if (
+      activeModelInferenceRequested &&
+      activeModelId &&
       autoInferenceAssetIds.length > 0
     ) {
       try {
         const model = await prisma.trainedModel.findFirst({
           where: {
-            id: projectSettings.activeModelId,
+            id: activeModelId,
             teamId: projectSettings.teamId,
           },
           select: {
@@ -887,11 +917,13 @@ export async function POST(request: NextRequest) {
           autoInferenceSummary = {
             started: false,
             error: "Active YOLO model not found for this project.",
+            source: "auto_upload",
           };
         } else if (!["READY", "ACTIVE"].includes(model.status)) {
           autoInferenceSummary = {
             started: false,
             error: `Active YOLO model status ${model.status} is not ready for inference.`,
+            source: "auto_upload",
           };
         } else {
           const modelName = resolveYoloServiceModelName(model);
@@ -944,6 +976,8 @@ export async function POST(request: NextRequest) {
               processedImages: result.processedImages,
               detectionsFound: result.detectionsFound,
               skippedImages: autoInferenceSkipped,
+              duplicateImages: 0,
+              skippedReason: "missing_gps_or_dimensions",
               modelName,
               backend: backendPreference,
               source: "auto_upload",
@@ -963,6 +997,7 @@ export async function POST(request: NextRequest) {
                 started: false,
                 error:
                   "Redis unavailable - batch too large for auto inference.",
+                source: "auto_upload",
               };
             } else {
               await enqueueInferenceJob({
@@ -981,6 +1016,8 @@ export async function POST(request: NextRequest) {
                 jobId: processingJob.id,
                 totalImages: autoInferenceAssetIds.length,
                 skippedImages: autoInferenceSkipped,
+                duplicateImages: 0,
+                skippedReason: "missing_gps_or_dimensions",
                 modelName,
                 backend: backendPreference,
                 source: "auto_upload",
@@ -994,6 +1031,7 @@ export async function POST(request: NextRequest) {
         autoInferenceSummary = {
           started: false,
           error: message,
+          source: "auto_upload",
         };
       }
     }

--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useState, Suspense } from "react";
+import { useCallback, useEffect, useMemo, useState, Suspense } from "react";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   Card,
   CardContent,
@@ -21,7 +21,21 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { AlertCircle, Brain, Upload, Map, Images, Tags, ArrowRight, CheckCircle2 } from "lucide-react";
+import {
+  AlertCircle,
+  ArrowRight,
+  Brain,
+  CheckCircle2,
+  Clock,
+  Eye,
+  Images,
+  Loader2,
+  Map,
+  Settings,
+  ShieldCheck,
+  Tags,
+  Upload,
+} from "lucide-react";
 import { UppyUploader, type UploadApiResponse } from "@/components/UppyUploader";
 import { ModelSelector, type RoboflowModel } from "@/components/detection/ModelSelector";
 
@@ -31,6 +45,10 @@ interface Project {
   location: string | null;
   purpose: string;
   cameraProfileId?: string | null;
+  activeModelId?: string | null;
+  autoInferenceEnabled?: boolean;
+  inferenceBackend?: "LOCAL" | "ROBOFLOW" | "AUTO" | null;
+  _count?: { assets: number };
 }
 
 interface CameraProfile {
@@ -46,12 +64,41 @@ interface CameraProfile {
   opticalCenterY?: number | null;
 }
 
+interface TrainedModel {
+  id: string;
+  name: string;
+  version: number;
+  displayName?: string | null;
+  status: string;
+  isActive?: boolean;
+  classes?: string[];
+  mAP50?: number | null;
+}
+
+type UploadMode = "upload-only" | "run-active";
+
+const READY_MODEL_STATUSES = new Set(["READY", "ACTIVE"]);
+
+function getModelLabel(model: TrainedModel | null): string {
+  if (!model) return "No active model";
+  const name = model.displayName || model.name;
+  return /yolo/i.test(name) ? `${name} v${model.version}` : `${name} YOLO11 v${model.version}`;
+}
+
+function getAutoInferenceJobIds(response: UploadApiResponse | null): string[] {
+  const summary = response?.autoInference;
+  if (!summary) return [];
+  if (summary.jobIds && summary.jobIds.length > 0) return summary.jobIds;
+  return summary.jobId ? [summary.jobId] : [];
+}
+
 async function getApiErrorMessage(response: Response, fallback: string): Promise<string> {
   const data = (await response.json().catch(() => null)) as { error?: string } | null;
   return data?.error || fallback;
 }
 
 function UploadPageContent() {
+  const router = useRouter();
   const searchParams = useSearchParams();
   const projectParam = searchParams.get("project");
   const [projects, setProjects] = useState<Project[]>([]);
@@ -60,11 +107,17 @@ function UploadPageContent() {
   const [cameraProfiles, setCameraProfiles] = useState<CameraProfile[]>([]);
   const [selectedCameraProfileId, setSelectedCameraProfileId] = useState<string>("none");
   const [cameraFovInput, setCameraFovInput] = useState<string>("");
-  const [runDetection, setRunDetection] = useState<boolean>(true);
+  const [uploadMode, setUploadMode] = useState<UploadMode>("upload-only");
+  const [runDetection, setRunDetection] = useState<boolean>(false);
   const [selectedModelIds, setSelectedModelIds] = useState<string[]>([]);
   const [availableModels, setAvailableModels] = useState<RoboflowModel[]>([]);
+  const [activeModel, setActiveModel] = useState<TrainedModel | null>(null);
+  const [activeModelLoading, setActiveModelLoading] = useState<boolean>(false);
+  const [activeModelError, setActiveModelError] = useState<string | null>(null);
   const [processing, setProcessing] = useState<boolean>(false);
   const [processingError, setProcessingError] = useState<string | null>(null);
+  const [reviewStarting, setReviewStarting] = useState<boolean>(false);
+  const [reviewError, setReviewError] = useState<string | null>(null);
   const [projectsError, setProjectsError] = useState<string | null>(null);
   const [modelsError, setModelsError] = useState<string | null>(null);
   const [cameraProfilesError, setCameraProfilesError] = useState<string | null>(null);
@@ -77,6 +130,18 @@ function UploadPageContent() {
     cameraFovInput.trim().length > 0 && Number.isFinite(parsedCameraFov)
       ? parsedCameraFov
       : undefined;
+  const selectedProjectData = useMemo(
+    () => projects.find((project) => project.id === selectedProject) || null,
+    [projects, selectedProject]
+  );
+  const activeModelReady = Boolean(
+    activeModel && READY_MODEL_STATUSES.has(activeModel.status)
+  );
+  const runActiveModel = uploadMode === "run-active" && !runDetection;
+  const selectedModelsData = availableModels.filter((model) =>
+    selectedModelIds.includes(model.id)
+  );
+  const advancedDetectionReady = !runDetection || selectedModelsData.length > 0;
 
   useEffect(() => {
     const loadProjects = async () => {
@@ -137,10 +202,66 @@ function UploadPageContent() {
     }
   }, [projects, selectedProject]);
 
-  // Get selected models data for the UppyUploader
-  const selectedModelsData = availableModels.filter((m) =>
-    selectedModelIds.includes(m.id)
-  );
+  useEffect(() => {
+    setActiveModel(null);
+    setActiveModelError(null);
+
+    if (!selectedProjectData) {
+      setUploadMode("upload-only");
+      setActiveModelLoading(false);
+      return;
+    }
+
+    if (!selectedProjectData.activeModelId) {
+      setUploadMode("upload-only");
+      setActiveModelLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+
+    const loadActiveModel = async () => {
+      setActiveModelLoading(true);
+      try {
+        const response = await fetch(
+          `/api/training/models?projectId=${encodeURIComponent(selectedProjectData.id)}&limit=50`,
+          { signal: controller.signal }
+        );
+        if (!response.ok) {
+          throw new Error(await getApiErrorMessage(response, "Failed to load active model"));
+        }
+
+        const data = await response.json();
+        const models = Array.isArray(data.models) ? (data.models as TrainedModel[]) : [];
+        const activeModelId =
+          typeof data.activeModelId === "string"
+            ? data.activeModelId
+            : selectedProjectData.activeModelId;
+        const nextActiveModel =
+          models.find((model) => model.id === activeModelId || model.isActive) || null;
+
+        setActiveModel(nextActiveModel);
+        setUploadMode(
+          selectedProjectData.autoInferenceEnabled && nextActiveModel
+            ? "run-active"
+            : "upload-only"
+        );
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") return;
+        console.error("Failed to load active model:", error);
+        setActiveModelError(
+          error instanceof Error ? error.message : "Unable to load the active model."
+        );
+        setUploadMode("upload-only");
+      } finally {
+        setActiveModelLoading(false);
+      }
+    };
+
+    void loadActiveModel();
+
+    return () => controller.abort();
+  }, [selectedProjectData]);
 
   const handleProcessingStart = useCallback(() => {
     setProcessing(true);
@@ -167,20 +288,102 @@ function UploadPageContent() {
     setModelsError(message);
   }, []);
 
+  const handleAdvancedFallbackChange = useCallback((checked: boolean) => {
+    setRunDetection(checked);
+    if (checked) {
+      setUploadMode("upload-only");
+    }
+  }, []);
+
+  const handleStartReview = useCallback(async () => {
+    const inferenceJobIds = getAutoInferenceJobIds(uploadResponse);
+    if (!selectedProject || inferenceJobIds.length === 0) return;
+
+    setReviewStarting(true);
+    setReviewError(null);
+    try {
+      const response = await fetch("/api/review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          projectId: selectedProject,
+          workflowType: "yolo_inference",
+          targetType: "both",
+          inferenceJobIds,
+          confidenceThreshold: 0.25,
+        }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(data?.error || "Failed to create review session");
+      }
+
+      const sessionId = data?.session?.id;
+      if (!sessionId) {
+        throw new Error("Review session missing from response");
+      }
+
+      router.push(`/review?sessionId=${sessionId}`);
+    } catch (error) {
+      setReviewError(
+        error instanceof Error ? error.message : "Failed to open review."
+      );
+    } finally {
+      setReviewStarting(false);
+    }
+  }, [router, selectedProject, uploadResponse]);
+
+  const uploadDisabled =
+    !selectedProject ||
+    (runActiveModel && !activeModelReady) ||
+    !advancedDetectionReady;
+  const activeModelName = getModelLabel(activeModel);
+  const autoInferenceJobIds = getAutoInferenceJobIds(uploadResponse);
+  const autoInference = uploadResponse?.autoInference;
+  const successfulUploadCount =
+    uploadResponse?.files.filter((file) => file.success !== false).length || 0;
+
   return (
     <div className="p-6 lg:p-8">
       <div className="mx-auto max-w-5xl space-y-6">
           <Card>
-            <CardHeader>
-              <CardTitle className="text-2xl">Upload Drone Images</CardTitle>
-              <CardDescription>
-                Upload imagery directly from the browser to S3, then run EXIF
-                parsing and optional AI detection on the backend.
-              </CardDescription>
+            <CardHeader className="space-y-4">
+              <div>
+                <CardTitle className="text-2xl">Upload, Run Model, Review</CardTitle>
+                <CardDescription>
+                  Upload imagery safely first, then optionally run the project&apos;s active
+                  detection model and send candidates to review.
+                </CardDescription>
+              </div>
+              <div className="grid gap-2 sm:grid-cols-3">
+                {[
+                  { label: "Upload", icon: Upload },
+                  { label: "Run model", icon: Brain },
+                  { label: "Review", icon: Eye },
+                ].map((step, index) => {
+                  const StepIcon = step.icon;
+                  return (
+                    <div
+                      key={step.label}
+                      className="flex items-center gap-3 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2"
+                    >
+                      <div className="flex h-8 w-8 items-center justify-center rounded-full bg-white text-slate-700">
+                        <StepIcon className="h-4 w-4" />
+                      </div>
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                          Step {index + 1}
+                        </p>
+                        <p className="text-sm font-medium text-slate-900">{step.label}</p>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
             </CardHeader>
 
             <CardContent className="space-y-6">
-              {(projectsError || modelsError || cameraProfilesError) && (
+              {(projectsError || modelsError || cameraProfilesError || activeModelError || reviewError) && (
                 <div className="space-y-2">
                   {projectsError && (
                     <div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800">
@@ -198,6 +401,18 @@ function UploadPageContent() {
                     <div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800">
                       <AlertCircle className="h-4 w-4" />
                       <span>{cameraProfilesError}</span>
+                    </div>
+                  )}
+                  {activeModelError && (
+                    <div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+                      <AlertCircle className="h-4 w-4" />
+                      <span>{activeModelError}</span>
+                    </div>
+                  )}
+                  {reviewError && (
+                    <div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+                      <AlertCircle className="h-4 w-4" />
+                      <span>{reviewError}</span>
                     </div>
                   )}
                 </div>
@@ -298,32 +513,101 @@ function UploadPageContent() {
                 </div>
 
                 <div className="space-y-4">
-                  <div className="flex items-center space-x-2 rounded-lg border border-green-200 bg-green-50 p-4">
-                    <Checkbox
-                      id="runDetection"
-                      checked={runDetection}
-                      onCheckedChange={(checked) =>
-                        setRunDetection(Boolean(checked))
-                      }
-                    />
-                    <Label
-                      htmlFor="runDetection"
-                      className="flex cursor-pointer items-center"
-                    >
-                      <Brain className="mr-2 h-4 w-4 text-green-600" />
-                      Run AI weed detection after upload
-                    </Label>
+                  <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-semibold text-slate-900">Active detection model</p>
+                        <p className="mt-1 text-sm text-slate-600">{activeModelName}</p>
+                        <p className="mt-1 text-xs text-slate-500">
+                          Backend: {selectedProjectData?.inferenceBackend || "AUTO"}
+                        </p>
+                      </div>
+                      {activeModelLoading ? (
+                        <Loader2 className="h-4 w-4 animate-spin text-slate-400" />
+                      ) : (
+                        <ShieldCheck
+                          className={`h-5 w-5 ${activeModelReady ? "text-emerald-600" : "text-slate-300"}`}
+                        />
+                      )}
+                    </div>
+                    {!activeModelReady && selectedProjectData?.activeModelId ? (
+                      <p className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+                        The active model is not ready for inference yet.
+                      </p>
+                    ) : null}
+                    {!selectedProjectData?.activeModelId ? (
+                      <p className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+                        Set an active YOLO model in Training before running inference after upload.
+                      </p>
+                    ) : null}
                   </div>
 
-                  {runDetection && (
-                    <ModelSelector
-                      selectedModels={selectedModelIds}
-                      onSelectionChange={setSelectedModelIds}
-                      onModelsLoaded={handleModelsLoaded}
-                      onLoadError={handleModelsError}
-                      disabled={!selectedProject}
-                    />
-                  )}
+                  <div className="rounded-lg border border-slate-200 bg-white p-4">
+                    <Label className="text-sm font-semibold text-slate-900">Upload action</Label>
+                    <div className="mt-3 grid gap-2">
+                      <Button
+                        type="button"
+                        variant={uploadMode === "upload-only" ? "default" : "outline"}
+                        className="justify-start"
+                        onClick={() => setUploadMode("upload-only")}
+                      >
+                        <Upload className="mr-2 h-4 w-4" />
+                        Upload only
+                      </Button>
+                      <Button
+                        type="button"
+                        variant={uploadMode === "run-active" ? "default" : "outline"}
+                        className="justify-start"
+                        onClick={() => {
+                          setRunDetection(false);
+                          setUploadMode("run-active");
+                        }}
+                        disabled={!selectedProjectData?.activeModelId}
+                      >
+                        <Brain className="mr-2 h-4 w-4" />
+                        Run active model after upload
+                      </Button>
+                    </div>
+                    <p className="mt-3 text-xs text-slate-500">
+                      Upload always completes first. Model runs are retryable and detections stay
+                      pending until review accepts them.
+                    </p>
+                  </div>
+
+                  <details className="rounded-lg border border-slate-200 bg-white">
+                    <summary className="flex cursor-pointer items-center gap-2 p-4 text-sm font-semibold text-slate-900 hover:bg-slate-50">
+                      <Settings className="h-4 w-4 text-slate-500" />
+                      Advanced model fallback
+                    </summary>
+                    <div className="space-y-4 border-t border-slate-200 p-4">
+                      <div className="flex items-center space-x-2 rounded-lg border border-slate-200 bg-slate-50 p-3">
+                        <Checkbox
+                          id="runDetection"
+                          checked={runDetection}
+                          onCheckedChange={(checked) =>
+                            handleAdvancedFallbackChange(Boolean(checked))
+                          }
+                        />
+                        <Label
+                          htmlFor="runDetection"
+                          className="flex cursor-pointer items-center text-sm"
+                        >
+                          <Brain className="mr-2 h-4 w-4 text-slate-600" />
+                          Use Roboflow/dynamic models for this upload
+                        </Label>
+                      </div>
+
+                      {runDetection && (
+                        <ModelSelector
+                          selectedModels={selectedModelIds}
+                          onSelectionChange={setSelectedModelIds}
+                          onModelsLoaded={handleModelsLoaded}
+                          onLoadError={handleModelsError}
+                          disabled={!selectedProject}
+                        />
+                      )}
+                    </div>
+                  </details>
                 </div>
               </section>
 
@@ -331,6 +615,20 @@ function UploadPageContent() {
                 <div className="flex items-center space-x-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
                   <AlertCircle className="h-4 w-4 flex-shrink-0" />
                   <span>Select a project to enable uploads.</span>
+                </div>
+              )}
+
+              {runActiveModel && !activeModelReady && selectedProject && (
+                <div className="flex items-center space-x-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+                  <AlertCircle className="h-4 w-4 flex-shrink-0" />
+                  <span>The active model must be ready before it can run after upload.</span>
+                </div>
+              )}
+
+              {!advancedDetectionReady && (
+                <div className="flex items-center space-x-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+                  <AlertCircle className="h-4 w-4 flex-shrink-0" />
+                  <span>Select a fallback model or turn off the advanced fallback.</span>
                 </div>
               )}
 
@@ -343,15 +641,17 @@ function UploadPageContent() {
                     </h3>
                     <p className="text-sm text-gray-500">
                       Files are sent straight to S3 using multipart uploads, then
-                      processed server-side.
+                      finalized server-side.
                     </p>
                     <p className="text-xs text-gray-400">
-                      Step 1 uploads to S3; Step 2 runs EXIF + detection after the upload finishes.
+                      Step 1 uploads to S3; Step 2 reads EXIF; Step 3 runs the active model only
+                      when selected.
                     </p>
                   </div>
                 </div>
                 <UppyUploader
                   projectId={selectedProject || null}
+                  runActiveModel={runActiveModel}
                   runDetection={runDetection}
                   dynamicModels={selectedModelsData}
                   flightSession={flightSession}
@@ -359,7 +659,7 @@ function UploadPageContent() {
                   cameraProfileId={
                     selectedCameraProfileId !== "none" ? selectedCameraProfileId : undefined
                   }
-                  disabled={!selectedProject}
+                  disabled={uploadDisabled}
                   onProcessingStart={handleProcessingStart}
                   onProcessingComplete={handleProcessingComplete}
                   onProcessingError={handleProcessingError}
@@ -368,8 +668,8 @@ function UploadPageContent() {
 
               {processing && (
                 <div className="rounded-lg border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800">
-                  Step 2 of 2: Processing uploaded files… EXIF parsing and detection may take a
-                  moment.
+                  Processing uploaded files... upload finalization runs first; model inference starts
+                  only after the uploaded assets are saved.
                 </div>
               )}
 
@@ -390,40 +690,82 @@ function UploadPageContent() {
                           Upload Complete!
                         </h3>
                         <p className="text-sm text-green-700">
-                          {uploadResponse.files.filter(f => f.success !== false).length} of {uploadResponse.files.length} images uploaded successfully
+                          {successfulUploadCount} of {uploadResponse.files.length} images uploaded successfully
                         </p>
                       </div>
                     </div>
                   </div>
 
-                  {uploadResponse.autoInference?.started && (
-                    <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-900">
-                      YOLO inference{" "}
-                      {uploadResponse.autoInference.status === "queued"
-                        ? "has been queued"
-                        : "completed"}{" "}
-                      for {uploadResponse.autoInference.totalImages?.toLocaleString() || 0}{" "}
-                      uploaded images.
-                      {typeof uploadResponse.autoInference.detectionsFound === "number"
-                        ? ` ${uploadResponse.autoInference.detectionsFound.toLocaleString()} pine sapling candidates were saved.`
-                        : ""}
-                      {uploadResponse.autoInference.skippedImages
-                        ? ` ${uploadResponse.autoInference.skippedImages.toLocaleString()} images were skipped because they are missing GPS coordinates or image dimensions.`
-                        : ""}
-                      {uploadResponse.autoInference.jobId
-                        ? ` Job ID: ${uploadResponse.autoInference.jobId}.`
-                        : ""}
+                  {autoInference && (
+                    <div
+                      className={`rounded-lg border p-4 text-sm ${
+                        autoInference.started
+                          ? "border-emerald-200 bg-emerald-50 text-emerald-900"
+                          : "border-amber-200 bg-amber-50 text-amber-900"
+                      }`}
+                    >
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div>
+                          <p className="font-semibold">
+                            {autoInference.started
+                              ? autoInference.status === "queued"
+                                ? "Active model queued"
+                                : "Active model completed"
+                              : "Active model not started"}
+                          </p>
+                          <p className="mt-1">
+                            {autoInference.error ||
+                              "YOLO boxes and georeferenced centres were saved as review-gated candidates."}
+                          </p>
+                        </div>
+                        {autoInference.status === "queued" ? (
+                          <Clock className="h-5 w-5" />
+                        ) : (
+                          <CheckCircle2 className="h-5 w-5" />
+                        )}
+                      </div>
+                      <div className="mt-4 grid gap-2 sm:grid-cols-3">
+                        <div className="rounded-md bg-white/70 p-3">
+                          <p className="text-xs font-medium uppercase text-slate-500">
+                            Images processed
+                          </p>
+                          <p className="mt-1 text-xl font-semibold">
+                            {(autoInference.processedImages ?? autoInference.totalImages ?? 0).toLocaleString()}
+                          </p>
+                        </div>
+                        <div className="rounded-md bg-white/70 p-3">
+                          <p className="text-xs font-medium uppercase text-slate-500">
+                            Skipped
+                          </p>
+                          <p className="mt-1 text-xl font-semibold">
+                            {(autoInference.skippedImages || 0).toLocaleString()}
+                          </p>
+                        </div>
+                        <div className="rounded-md bg-white/70 p-3">
+                          <p className="text-xs font-medium uppercase text-slate-500">
+                            Candidate detections
+                          </p>
+                          <p className="mt-1 text-xl font-semibold">
+                            {typeof autoInference.detectionsFound === "number"
+                              ? autoInference.detectionsFound.toLocaleString()
+                              : "--"}
+                          </p>
+                        </div>
+                      </div>
+                      {autoInferenceJobIds.length > 0 && (
+                        <p className="mt-3 text-xs">
+                          Job {autoInferenceJobIds.join(", ")}. Candidates are not approved until
+                          review accepts them.
+                        </p>
+                      )}
                     </div>
                   )}
 
-                  {uploadResponse.autoInference &&
-                    !uploadResponse.autoInference.started &&
-                    uploadResponse.autoInference.error && (
-                      <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
-                        Uploads completed, but YOLO auto-inference did not start:{" "}
-                        {uploadResponse.autoInference.error}
-                      </div>
-                    )}
+                  {!autoInference && (
+                    <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+                      Upload-only mode completed. No detection model was run for this upload.
+                    </div>
+                  )}
 
                   {uploadResponse.roboflowDetection?.started && (
                     <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 text-sm text-blue-900">
@@ -453,7 +795,42 @@ function UploadPageContent() {
                     <h3 className="mb-4 text-lg font-semibold text-gray-800">
                       What would you like to do next?
                     </h3>
-                    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                      {autoInferenceJobIds.length > 0 && autoInference?.status === "completed" && (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          className="h-auto w-full justify-start gap-3 border-2 border-amber-200 bg-white p-4 hover:border-amber-400 hover:bg-amber-50"
+                          onClick={handleStartReview}
+                          disabled={reviewStarting}
+                        >
+                          {reviewStarting ? (
+                            <Loader2 className="h-5 w-5 animate-spin text-amber-600" />
+                          ) : (
+                            <Eye className="h-5 w-5 text-amber-600" />
+                          )}
+                          <div className="text-left">
+                            <div className="font-semibold text-amber-700">Review candidates</div>
+                            <div className="text-xs text-gray-500">Accept, reject, or correct</div>
+                          </div>
+                          <ArrowRight className="ml-auto h-4 w-4 text-amber-400" />
+                        </Button>
+                      )}
+                      {autoInferenceJobIds.length > 0 && autoInference?.status === "queued" && (
+                        <Link href="/training#inference">
+                          <Button
+                            variant="outline"
+                            className="h-auto w-full justify-start gap-3 border-2 border-amber-200 bg-white p-4 hover:border-amber-400 hover:bg-amber-50"
+                          >
+                            <Clock className="h-5 w-5 text-amber-600" />
+                            <div className="text-left">
+                              <div className="font-semibold text-amber-700">Track model run</div>
+                              <div className="text-xs text-gray-500">Review when complete</div>
+                            </div>
+                            <ArrowRight className="ml-auto h-4 w-4 text-amber-400" />
+                          </Button>
+                        </Link>
+                      )}
                       <Link href={
                         uploadResponse.files.find(f => f.success !== false && f.id)?.id
                           ? `/annotate/${uploadResponse.files.find(f => f.success !== false && f.id)?.id}`
@@ -544,17 +921,15 @@ function UploadPageContent() {
               )}
 
               <section className="rounded-lg border border-blue-200 bg-blue-50 p-4 text-sm text-blue-900">
-                <h4 className="mb-2 font-semibold">Pro Tips</h4>
+                <h4 className="mb-2 font-semibold">Safe Upload Notes</h4>
                 <ul className="space-y-1">
                   <li>• Ensure your drone captures GPS metadata in each image.</li>
                   <li>• Keep uploads under 500MB per file for best performance.</li>
                   <li>
-                    • AI detection runs on the freshly downloaded S3 objects—no
-                    local storage required.
+                    • Active-model detections are review-gated and remain unapproved until accepted.
                   </li>
                   <li>
-                    • The upload summary above includes GPS metadata warnings and
-                    detection counts.
+                    • V1 displays YOLO boxes and georeferenced centres; segmentation polygons come later.
                   </li>
                 </ul>
               </section>

--- a/components/UppyUploader.tsx
+++ b/components/UppyUploader.tsx
@@ -30,8 +30,11 @@ export interface QueuedDetectionSummary {
   started: boolean;
   status?: string;
   jobId?: string;
+  jobIds?: string[];
   totalImages?: number;
   skippedImages?: number;
+  duplicateImages?: number;
+  skippedReason?: string;
   error?: string;
   source?: string;
 }
@@ -121,8 +124,47 @@ function buildUploadSummary(files: ProcessedUploadFile[]) {
   };
 }
 
+function aggregateAutoInferenceSummaries(
+  chunkResponses: UploadApiResponse[],
+): AutoInferenceSummary | undefined {
+  const summaries = chunkResponses
+    .map((chunkResponse) => chunkResponse.autoInference)
+    .filter((summary): summary is AutoInferenceSummary => Boolean(summary));
+
+  if (summaries.length === 0) return undefined;
+
+  const jobIds = summaries
+    .map((summary) => summary.jobId)
+    .filter((jobId): jobId is string => Boolean(jobId));
+  const errors = summaries
+    .map((summary) => summary.error)
+    .filter((error): error is string => Boolean(error));
+
+  return {
+    started: summaries.some((summary) => summary.started),
+    status: summaries.some((summary) => summary.status === "queued")
+      ? "queued"
+      : summaries.some((summary) => summary.status === "completed")
+        ? "completed"
+        : summaries.find((summary) => summary.status)?.status,
+    jobId: jobIds[0],
+    jobIds: jobIds.length > 0 ? jobIds : undefined,
+    totalImages: summaries.reduce((sum, summary) => sum + (summary.totalImages || 0), 0),
+    processedImages: summaries.reduce((sum, summary) => sum + (summary.processedImages || 0), 0),
+    detectionsFound: summaries.reduce((sum, summary) => sum + (summary.detectionsFound || 0), 0),
+    skippedImages: summaries.reduce((sum, summary) => sum + (summary.skippedImages || 0), 0),
+    duplicateImages: summaries.reduce((sum, summary) => sum + (summary.duplicateImages || 0), 0),
+    skippedReason: summaries.find((summary) => summary.skippedReason)?.skippedReason,
+    modelName: summaries.find((summary) => summary.modelName)?.modelName,
+    backend: summaries.find((summary) => summary.backend)?.backend,
+    source: summaries.find((summary) => summary.source)?.source,
+    error: errors.length > 0 ? errors.join("; ") : undefined,
+  };
+}
+
 interface UppyUploaderProps {
   projectId: string | null;
+  runActiveModel?: boolean;
   runDetection: boolean;
   detectionModels?: string[]; // Legacy: hardcoded model keys
   dynamicModels?: DynamicModel[]; // New: dynamic models from workspace
@@ -140,6 +182,7 @@ interface UppyUploaderProps {
  */
 export function UppyUploader({
   projectId,
+  runActiveModel,
   runDetection,
   detectionModels = [],
   dynamicModels = [],
@@ -155,6 +198,7 @@ export function UppyUploader({
   const uppyRef = useRef<Uppy | null>(null);
   const latestSettingsRef = useRef({
     projectId,
+    runActiveModel,
     runDetection,
     detectionModels,
     dynamicModels,
@@ -173,6 +217,7 @@ export function UppyUploader({
   useEffect(() => {
     latestSettingsRef.current = {
       projectId,
+      runActiveModel,
       runDetection,
       detectionModels,
       dynamicModels,
@@ -181,7 +226,7 @@ export function UppyUploader({
       cameraProfileId,
       disabled,
     };
-  }, [projectId, runDetection, detectionModels, dynamicModels, flightSession, cameraFov, cameraProfileId, disabled]);
+  }, [projectId, runActiveModel, runDetection, detectionModels, dynamicModels, flightSession, cameraFov, cameraProfileId, disabled]);
 
   useEffect(() => {
     callbacksRef.current = {
@@ -427,6 +472,7 @@ export function UppyUploader({
           settings.runDetection &&
           (filesPayload.length >= BULK_DETECTION_FILE_COUNT_THRESHOLD ||
             totalBytes >= BULK_DETECTION_TOTAL_BYTES_THRESHOLD);
+        const hasActiveModelOverride = typeof settings.runActiveModel === "boolean";
 
         const chunkedFiles = chunkArray(filesPayload, FINALIZATION_CHUNK_SIZE);
         const chunkResponses: UploadApiResponse[] = [];
@@ -450,7 +496,13 @@ export function UppyUploader({
               flightSession: settings.flightSession || undefined,
               cameraFov: settings.cameraFov,
               cameraProfileId: settings.cameraProfileId,
-              disableAutoInference: useQueuedRoboflowDetection,
+              runActiveModel:
+                hasActiveModelOverride && !useQueuedRoboflowDetection
+                  ? settings.runActiveModel
+                  : undefined,
+              disableAutoInference:
+                useQueuedRoboflowDetection ||
+                (hasActiveModelOverride && settings.runActiveModel === false),
             }),
           });
 
@@ -473,9 +525,7 @@ export function UppyUploader({
           message: `Processed ${aggregatedFiles.filter((file) => file.success !== false).length} of ${aggregatedFiles.length} files`,
           files: aggregatedFiles,
           summary: buildUploadSummary(aggregatedFiles),
-          autoInference:
-            chunkResponses.find((chunkResponse) => chunkResponse.autoInference)
-              ?.autoInference || undefined,
+          autoInference: aggregateAutoInferenceSummaries(chunkResponses),
         };
 
         if (useQueuedRoboflowDetection) {

--- a/components/training/training-workspace.tsx
+++ b/components/training/training-workspace.tsx
@@ -16,6 +16,7 @@ import {
   RefreshCw,
   Sparkles,
   Target,
+  Upload,
   Wand2,
 } from "lucide-react";
 
@@ -160,6 +161,40 @@ export function TrainingWorkspace() {
             {error}
           </div>
         ) : null}
+
+        <section className="rounded-lg border border-slate-200 bg-white p-5">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-slate-950">
+                Upload &gt; Run Model &gt; Review
+              </h2>
+              <p className="mt-1 max-w-3xl text-sm text-slate-600">
+                Select a project, upload images, optionally run the project&apos;s active YOLO model,
+                then review candidate detections before they count as accepted labels.
+              </p>
+            </div>
+            <Button asChild className="bg-gradient-to-r from-green-500 to-blue-500 text-white">
+              <Link href="/upload">
+                <Upload className="mr-2 h-4 w-4" />
+                Upload images
+              </Link>
+            </Button>
+          </div>
+          <div className="mt-4 grid gap-3 md:grid-cols-3">
+            <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
+              <p className="text-xs font-semibold uppercase text-slate-500">1. Upload</p>
+              <p className="mt-1 text-sm text-slate-700">S3 upload and asset creation complete first.</p>
+            </div>
+            <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
+              <p className="text-xs font-semibold uppercase text-slate-500">2. Run model</p>
+              <p className="mt-1 text-sm text-slate-700">Active project model runs as a retryable job.</p>
+            </div>
+            <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
+              <p className="text-xs font-semibold uppercase text-slate-500">3. Review</p>
+              <p className="mt-1 text-sm text-slate-700">YOLO boxes and centres remain pending until accepted.</p>
+            </div>
+          </div>
+        </section>
 
         <section className="grid gap-3 md:grid-cols-3">
           <Card>


### PR DESCRIPTION
## Summary
- Adds a Roboflow-style Upload > Run Model > Review entry point to Training Workspace.
- Updates /upload to show the selected project active YOLO model, choose Upload only vs Run active model after upload, and keep Roboflow/dynamic models behind an advanced fallback.
- Adds backwards-compatible /api/upload support for explicit per-upload active-model inference while preserving existing project auto-inference behavior for other callers.
- Aggregates upload/inference summaries and lets completed active-model jobs open a review session.

## Safety notes
- Upload finalization still completes before inference starts.
- Detections remain review-gated through existing review sessions; no auto-approval, export, model training, Roboflow mutation, or schema change.
- V1 remains YOLO boxes and georeferenced centres only.

## Validation
- npm run lint passes with existing unrelated warnings.
- npm run build passes. The project build still skips type/lint validation by config.
- npx tsc --noEmit --pretty false still fails on known repo-wide type backlog; checked touched-file findings and the relevant Uppy/upload type issues predate this patch.
- Browser sanity checked /training and /upload locally on port 3100; API data calls returned 401 without a signed-in dev session, so no upload/model mutation was performed.

Jira: AG-12