### PR TITLE
Add tiled YOLO inference for large drone imagery

### DIFF
--- a/app/api/inference/run/route.ts
+++ b/app/api/inference/run/route.ts
@@ -291,6 +291,7 @@ export async function POST(request: NextRequest) {
             skippedReason: 'missing_gps_or_dimensions',
             duplicateImages,
             detectionsFound: result.detectionsFound,
+            tiling: result.tiling,
           },
           { status: 502 }
         );
@@ -306,6 +307,7 @@ export async function POST(request: NextRequest) {
         duplicateImages,
         detectionsFound: result.detectionsFound,
         errors: result.errors.slice(0, 10),
+        tiling: result.tiling,
       });
     }
 

--- a/lib/services/inference.ts
+++ b/lib/services/inference.ts
@@ -4,7 +4,10 @@
  * Runs model inference for a batch of assets and optionally saves detections.
  */
 import prisma from '@/lib/db';
-import { yoloInferenceService, type InferenceBackend } from '@/lib/services/yolo-inference';
+import {
+  yoloInferenceService,
+  type InferenceBackend,
+} from '@/lib/services/yolo-inference';
 import { S3Service } from '@/lib/services/s3';
 import { normalizeDetectionType } from '@/lib/utils/detection-types';
 import { fetchImageSafely } from '@/lib/utils/security';
@@ -33,6 +36,13 @@ interface InferenceAsset {
   metadata?: unknown | null;
 }
 
+export interface InferenceTilingSummary {
+  tiledImages: number;
+  tilesProcessed: number;
+  rawDetections: number;
+  mergedDetections: number;
+}
+
 export interface InferenceJobConfig {
   modelId: string;
   modelName: string;
@@ -46,6 +56,7 @@ export interface InferenceJobConfig {
   skippedReason?: string;
   errors?: string[];
   backend?: InferenceBackend;
+  tiling?: InferenceTilingSummary;
 }
 
 export interface InferenceResult {
@@ -54,10 +65,21 @@ export interface InferenceResult {
   skippedImages: number;
   duplicateImages: number;
   errors: string[];
+  tiling?: InferenceTilingSummary;
 }
 
 const DEFAULT_ALTITUDE = 100;
 const DEFAULT_BATCH_SIZE = 10;
+const DEFAULT_YOLO_GPU_LOCK_TTL_MS = 30 * 60 * 1000;
+
+function readPositiveIntegerEnv(name: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[name] || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function buildTilingSummary(stats: InferenceTilingSummary): InferenceTilingSummary | undefined {
+  return stats.tiledImages > 0 ? { ...stats } : undefined;
+}
 
 function toCenterBox(bbox: [number, number, number, number]) {
   const [x1, y1, x2, y2] = bbox;
@@ -139,6 +161,10 @@ export async function processInferenceJob(options: {
   const totalImages = assetIds.length;
   let processedImages = 0;
   let detectionsFound = 0;
+  let tiledImages = 0;
+  let tilesProcessed = 0;
+  let rawTileDetections = 0;
+  let mergedTileDetections = 0;
   const errors: string[] = [];
 
   await prisma.processingJob.update({
@@ -163,8 +189,9 @@ export async function processInferenceJob(options: {
   });
 
   let effectiveBackend = backend;
+  const gpuLockTtlMs = readPositiveIntegerEnv('YOLO_GPU_LOCK_TTL_MS', DEFAULT_YOLO_GPU_LOCK_TTL_MS);
   const gpuLock = backend !== 'roboflow'
-    ? await acquireGpuLock('yolo-inference')
+    ? await acquireGpuLock('yolo-inference', gpuLockTtlMs)
     : { acquired: true, token: null };
 
   if (backend !== 'roboflow' && !gpuLock.acquired) {
@@ -230,6 +257,12 @@ export async function processInferenceJob(options: {
         skippedImages,
         duplicateImages,
         errors,
+        tiling: buildTilingSummary({
+          tiledImages,
+          tilesProcessed,
+          rawDetections: rawTileDetections,
+          mergedDetections: mergedTileDetections,
+        }),
       };
     }
 
@@ -284,10 +317,18 @@ export async function processInferenceJob(options: {
           s3Path,
           imageBase64,
           imageUrl,
+          imageWidth: asset.imageWidth,
+          imageHeight: asset.imageHeight,
           modelName,
           confidence,
           backend: effectiveBackend,
         });
+        if (response.tiling?.enabled) {
+          tiledImages += 1;
+          tilesProcessed += response.tiling.tileCount ?? 0;
+          rawTileDetections += response.tiling.rawDetections ?? 0;
+          mergedTileDetections += response.tiling.mergedDetections ?? 0;
+        }
 
         const detectionsToCreate: Array<Record<string, unknown>> = [];
 
@@ -343,6 +384,7 @@ export async function processInferenceJob(options: {
                 modelName,
                 geoMethod: resolved.method,
                 backend: response.backend,
+                ...(response.tiling ? { tiling: response.tiling } : {}),
               },
               customModelId: modelId,
             });
@@ -357,6 +399,9 @@ export async function processInferenceJob(options: {
         }
 
         processedImages += 1;
+        if (gpuLock.token) {
+          await refreshGpuLock(gpuLock.token, gpuLockTtlMs);
+        }
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error';
         errors.push(`Asset ${asset.id}: ${message}`);
@@ -377,11 +422,17 @@ export async function processInferenceJob(options: {
       skippedReason,
       errors: errors.slice(0, 10),
       backend: effectiveBackend,
+      tiling: buildTilingSummary({
+        tiledImages,
+        tilesProcessed,
+        rawDetections: rawTileDetections,
+        mergedDetections: mergedTileDetections,
+      }),
     };
 
       await updateJobProgress(jobId, config, progress);
       if (gpuLock.token) {
-        await refreshGpuLock(gpuLock.token);
+        await refreshGpuLock(gpuLock.token, gpuLockTtlMs);
       }
     }
   } finally {
@@ -406,5 +457,11 @@ export async function processInferenceJob(options: {
     skippedImages,
     duplicateImages,
     errors,
+    tiling: buildTilingSummary({
+      tiledImages,
+      tilesProcessed,
+      rawDetections: rawTileDetections,
+      mergedDetections: mergedTileDetections,
+    }),
   };
 }

--- a/lib/services/yolo-inference.ts
+++ b/lib/services/yolo-inference.ts
@@ -1,6 +1,15 @@
 import YOLOService, { yoloService } from '@/lib/services/yolo';
 import { roboflowService, ROBOFLOW_MODELS, ModelType } from '@/lib/services/roboflow';
 import { fetchImageSafely } from '@/lib/utils/security';
+import {
+  buildYoloTilePlan,
+  mergeYoloDetectionsWithNms,
+  offsetDetectionToImage,
+  shouldTileYoloImage,
+  type YoloDetectionLike,
+  type YoloTile,
+} from '@/lib/utils/yolo-tiling';
+import sharp from 'sharp';
 
 export type InferenceBackend = 'local' | 'roboflow' | 'auto';
 
@@ -11,13 +20,28 @@ export interface DetectionRequest {
   s3Path?: string | null;
   imageBase64?: string;
   imageUrl?: string;
+  imageWidth?: number | null;
+  imageHeight?: number | null;
   roboflowModels?: ModelType[];
+}
+
+export interface YoloTilingSummary {
+  enabled: boolean;
+  imageWidth?: number;
+  imageHeight?: number;
+  tileSize?: number;
+  overlap?: number;
+  tileCount?: number;
+  rawDetections?: number;
+  mergedDetections?: number;
+  nmsIouThreshold?: number;
 }
 
 export interface DetectionResult {
   detections: Array<{ class: string; confidence: number; bbox: [number, number, number, number] }>;
   backend: 'local' | 'roboflow';
   inferenceTimeMs?: number;
+  tiling?: YoloTilingSummary;
 }
 
 const inferenceBaseUrl =
@@ -32,6 +56,37 @@ const yoloInferenceClient = inferenceBaseUrl
       apiKey: process.env.YOLO_SERVICE_API_KEY,
     })
   : yoloService;
+
+const DEFAULT_TILE_SIZE = 1536;
+const DEFAULT_TILE_OVERLAP = 512;
+const DEFAULT_TILE_MIN_DIMENSION = 2048;
+const DEFAULT_TILE_NMS_IOU = 0.45;
+const DEFAULT_TILE_MAX_TILES = 80;
+
+function readPositiveIntegerEnv(name: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[name] || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function readNumberEnv(name: string, fallback: number): number {
+  const parsed = Number.parseFloat(process.env[name] || '');
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function readTilingConfig() {
+  const tileSize = readPositiveIntegerEnv('YOLO_TILE_SIZE', DEFAULT_TILE_SIZE);
+  return {
+    enabled: process.env.YOLO_TILING_ENABLED !== 'false',
+    tileSize,
+    overlap: Math.min(
+      tileSize - 1,
+      readPositiveIntegerEnv('YOLO_TILE_OVERLAP', DEFAULT_TILE_OVERLAP)
+    ),
+    minDimension: readPositiveIntegerEnv('YOLO_TILE_MIN_DIMENSION', DEFAULT_TILE_MIN_DIMENSION),
+    nmsIouThreshold: Math.max(0, Math.min(1, readNumberEnv('YOLO_TILE_NMS_IOU', DEFAULT_TILE_NMS_IOU))),
+    maxTiles: readPositiveIntegerEnv('YOLO_TILE_MAX_TILES', DEFAULT_TILE_MAX_TILES),
+  };
+}
 
 function getDefaultRoboflowModels(): ModelType[] {
   return Object.entries(ROBOFLOW_MODELS)
@@ -56,6 +111,33 @@ async function ensureBase64Image(request: DetectionRequest): Promise<string> {
   return buffer.toString('base64');
 }
 
+function normalizeBase64Image(imageBase64: string): string {
+  const [, payload] = imageBase64.match(/^data:image\/[^;]+;base64,(.+)$/) || [];
+  return payload || imageBase64;
+}
+
+function imageBufferFromBase64(imageBase64: string): Buffer {
+  return Buffer.from(normalizeBase64Image(imageBase64), 'base64');
+}
+
+async function getRequestImageBuffer(request: DetectionRequest): Promise<Buffer | null> {
+  if (request.imageBase64) {
+    return imageBufferFromBase64(request.imageBase64);
+  }
+  if (!request.imageUrl) {
+    return null;
+  }
+  return fetchImageSafely(request.imageUrl, 'YOLO tiled inference image');
+}
+
+function mapLocalDetections(detections: YoloDetectionLike[]) {
+  return detections.map((detection) => ({
+    class: detection.class,
+    confidence: detection.confidence,
+    bbox: detection.bbox,
+  }));
+}
+
 class YOLOInferenceService {
   async detect(request: DetectionRequest): Promise<DetectionResult> {
     const backend = request.backend || 'auto';
@@ -77,26 +159,152 @@ class YOLOInferenceService {
   }
 
   private async detectLocal(request: DetectionRequest): Promise<DetectionResult> {
-    if (!request.s3Path && !request.imageBase64) {
-      throw new Error('Local inference requires s3Path or imageBase64');
+    if (!request.s3Path && !request.imageBase64 && !request.imageUrl) {
+      throw new Error('Local inference requires s3Path, imageBase64, or imageUrl');
+    }
+
+    const tilingConfig = readTilingConfig();
+    let imageBuffer: Buffer | null = null;
+    let imageWidth = request.imageWidth ?? null;
+    let imageHeight = request.imageHeight ?? null;
+    const knownSizeIsLarge = imageWidth != null && imageHeight != null && shouldTileYoloImage(
+      imageWidth,
+      imageHeight,
+      {
+        enabled: tilingConfig.enabled,
+        minDimension: tilingConfig.minDimension,
+        tileSize: tilingConfig.tileSize,
+      }
+    );
+    const needsImagePayload = Boolean(!request.s3Path && !request.imageBase64 && request.imageUrl);
+    const shouldInspectImage = needsImagePayload || Boolean(
+      tilingConfig.enabled &&
+      (request.imageBase64 || request.imageUrl) &&
+      (knownSizeIsLarge || imageWidth == null || imageHeight == null || !request.s3Path)
+    );
+
+    if (shouldInspectImage) {
+      imageBuffer = await getRequestImageBuffer(request);
+      if (imageBuffer) {
+        const metadata = await sharp(imageBuffer).metadata();
+        imageWidth = imageWidth ?? metadata.width ?? null;
+        imageHeight = imageHeight ?? metadata.height ?? null;
+      }
+    }
+
+    if (
+      imageBuffer &&
+      imageWidth != null &&
+      imageHeight != null &&
+      shouldTileYoloImage(imageWidth, imageHeight, {
+        enabled: tilingConfig.enabled,
+        minDimension: tilingConfig.minDimension,
+        tileSize: tilingConfig.tileSize,
+      })
+    ) {
+      return this.detectLocalTiled(
+        request,
+        imageBuffer,
+        imageWidth,
+        imageHeight,
+        tilingConfig
+      );
     }
 
     const response = await yoloInferenceClient.detect({
       s3_path: request.s3Path ?? undefined,
-      image: request.imageBase64,
+      image: request.imageBase64 ?? (imageBuffer ? imageBuffer.toString('base64') : undefined),
       model: request.modelName,
       confidence: request.confidence,
     });
 
     return {
-      detections: response.detections.map((d) => ({
-        class: d.class,
-        confidence: d.confidence,
-        bbox: d.bbox,
-      })),
+      detections: mapLocalDetections(response.detections),
       backend: 'local',
       inferenceTimeMs: response.inference_time_ms,
+      tiling: {
+        enabled: false,
+        imageWidth: imageWidth ?? undefined,
+        imageHeight: imageHeight ?? undefined,
+      },
     };
+  }
+
+  private async detectLocalTiled(
+    request: DetectionRequest,
+    imageBuffer: Buffer,
+    imageWidth: number,
+    imageHeight: number,
+    config: ReturnType<typeof readTilingConfig>
+  ): Promise<DetectionResult> {
+    const startedAt = Date.now();
+    const tiles = buildYoloTilePlan(imageWidth, imageHeight, {
+      tileSize: config.tileSize,
+      overlap: config.overlap,
+    });
+    if (tiles.length > config.maxTiles) {
+      throw new Error(
+        `YOLO tiled inference would create ${tiles.length} tiles, exceeding YOLO_TILE_MAX_TILES=${config.maxTiles}`
+      );
+    }
+
+    const rawDetections: YoloDetectionLike[] = [];
+    for (const tile of tiles) {
+      const tileDetections = await this.detectTile(request, imageBuffer, tile);
+      for (const detection of tileDetections) {
+        const offsetDetection = offsetDetectionToImage(detection, tile, imageWidth, imageHeight);
+        if (offsetDetection) {
+          rawDetections.push(offsetDetection);
+        }
+      }
+    }
+
+    const mergedDetections = mergeYoloDetectionsWithNms(rawDetections, config.nmsIouThreshold);
+
+    return {
+      detections: mapLocalDetections(mergedDetections),
+      backend: 'local',
+      inferenceTimeMs: Date.now() - startedAt,
+      tiling: {
+        enabled: true,
+        imageWidth,
+        imageHeight,
+        tileSize: config.tileSize,
+        overlap: config.overlap,
+        tileCount: tiles.length,
+        rawDetections: rawDetections.length,
+        mergedDetections: mergedDetections.length,
+        nmsIouThreshold: config.nmsIouThreshold,
+      },
+    };
+  }
+
+  private async detectTile(
+    request: DetectionRequest,
+    imageBuffer: Buffer,
+    tile: YoloTile
+  ): Promise<YoloDetectionLike[]> {
+    const tileBuffer = await sharp(imageBuffer)
+      .extract({
+        left: tile.x,
+        top: tile.y,
+        width: tile.width,
+        height: tile.height,
+      })
+      .jpeg({ quality: 90 })
+      .toBuffer();
+
+    const response = await yoloInferenceClient.detect({
+      image: tileBuffer.toString('base64'),
+      model: request.modelName,
+      confidence: request.confidence,
+    });
+
+    return response.detections.map((detection) => ({
+      class: detection.class,
+      confidence: detection.confidence,
+      bbox: detection.bbox,
+    }));
   }
 
   private async detectRoboflow(request: DetectionRequest): Promise<DetectionResult> {

--- a/lib/utils/yolo-tiling.ts
+++ b/lib/utils/yolo-tiling.ts
@@ -1,0 +1,151 @@
+export type YoloBBox = [number, number, number, number];
+
+export interface YoloTile {
+  index: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface YoloTileOptions {
+  tileSize: number;
+  overlap: number;
+}
+
+export interface YoloDetectionLike {
+  class: string;
+  confidence: number;
+  bbox: YoloBBox;
+}
+
+function axisStarts(length: number, tileSize: number, stride: number): number[] {
+  if (!Number.isFinite(length) || length <= 0) return [];
+  if (length <= tileSize) return [0];
+
+  const starts: number[] = [];
+  for (let start = 0; start + tileSize < length; start += stride) {
+    starts.push(start);
+  }
+
+  const finalStart = Math.max(0, length - tileSize);
+  if (starts[starts.length - 1] !== finalStart) {
+    starts.push(finalStart);
+  }
+
+  return starts;
+}
+
+export function buildYoloTilePlan(
+  imageWidth: number,
+  imageHeight: number,
+  options: YoloTileOptions
+): YoloTile[] {
+  const tileSize = Math.max(1, Math.floor(options.tileSize));
+  const overlap = Math.max(0, Math.floor(options.overlap));
+  const stride = Math.max(1, tileSize - Math.min(overlap, tileSize - 1));
+  const xStarts = axisStarts(Math.floor(imageWidth), tileSize, stride);
+  const yStarts = axisStarts(Math.floor(imageHeight), tileSize, stride);
+  const tiles: YoloTile[] = [];
+
+  for (const y of yStarts) {
+    for (const x of xStarts) {
+      tiles.push({
+        index: tiles.length,
+        x,
+        y,
+        width: Math.min(tileSize, Math.floor(imageWidth) - x),
+        height: Math.min(tileSize, Math.floor(imageHeight) - y),
+      });
+    }
+  }
+
+  return tiles;
+}
+
+export function shouldTileYoloImage(
+  imageWidth: number,
+  imageHeight: number,
+  options: { enabled: boolean; minDimension: number; tileSize: number }
+): boolean {
+  if (!options.enabled) return false;
+  if (!Number.isFinite(imageWidth) || !Number.isFinite(imageHeight)) return false;
+  if (imageWidth <= 0 || imageHeight <= 0) return false;
+  return Math.max(imageWidth, imageHeight) >= Math.max(options.minDimension, options.tileSize + 1);
+}
+
+export function offsetDetectionToImage(
+  detection: YoloDetectionLike,
+  tile: YoloTile,
+  imageWidth: number,
+  imageHeight: number
+): YoloDetectionLike | null {
+  const [x1, y1, x2, y2] = detection.bbox;
+  if ([x1, y1, x2, y2].some((value) => !Number.isFinite(value))) {
+    return null;
+  }
+
+  const clipped: YoloBBox = [
+    Math.max(0, Math.min(imageWidth, x1 + tile.x)),
+    Math.max(0, Math.min(imageHeight, y1 + tile.y)),
+    Math.max(0, Math.min(imageWidth, x2 + tile.x)),
+    Math.max(0, Math.min(imageHeight, y2 + tile.y)),
+  ];
+
+  if (clipped[2] <= clipped[0] || clipped[3] <= clipped[1]) {
+    return null;
+  }
+
+  return {
+    class: detection.class,
+    confidence: detection.confidence,
+    bbox: clipped,
+  };
+}
+
+export function calculateBBoxIoU(a: YoloBBox, b: YoloBBox): number {
+  const x1 = Math.max(a[0], b[0]);
+  const y1 = Math.max(a[1], b[1]);
+  const x2 = Math.min(a[2], b[2]);
+  const y2 = Math.min(a[3], b[3]);
+  const intersectionWidth = Math.max(0, x2 - x1);
+  const intersectionHeight = Math.max(0, y2 - y1);
+  const intersectionArea = intersectionWidth * intersectionHeight;
+  if (intersectionArea <= 0) return 0;
+
+  const areaA = Math.max(0, a[2] - a[0]) * Math.max(0, a[3] - a[1]);
+  const areaB = Math.max(0, b[2] - b[0]) * Math.max(0, b[3] - b[1]);
+  const unionArea = areaA + areaB - intersectionArea;
+  return unionArea > 0 ? intersectionArea / unionArea : 0;
+}
+
+export function mergeYoloDetectionsWithNms<T extends YoloDetectionLike>(
+  detections: T[],
+  iouThreshold: number
+): T[] {
+  const threshold = Math.max(0, Math.min(1, iouThreshold));
+  const sorted = [...detections]
+    .filter((detection) => {
+      const [x1, y1, x2, y2] = detection.bbox;
+      return (
+        Number.isFinite(detection.confidence) &&
+        [x1, y1, x2, y2].every(Number.isFinite) &&
+        x2 > x1 &&
+        y2 > y1
+      );
+    })
+    .sort((a, b) => b.confidence - a.confidence);
+
+  const kept: T[] = [];
+  for (const candidate of sorted) {
+    const overlapsExisting = kept.some((existing) => (
+      existing.class === candidate.class &&
+      calculateBBoxIoU(existing.bbox, candidate.bbox) >= threshold
+    ));
+    if (!overlapsExisting) {
+      kept.push(candidate);
+    }
+  }
+
+  return kept;
+}

--- a/tests/unit/yolo-tiling.test.ts
+++ b/tests/unit/yolo-tiling.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildYoloTilePlan,
+  calculateBBoxIoU,
+  mergeYoloDetectionsWithNms,
+  offsetDetectionToImage,
+  shouldTileYoloImage,
+} from '@/lib/utils/yolo-tiling';
+
+describe('YOLO tiled inference utilities', () => {
+  it('builds a deterministic 40-tile plan for DJI 8192x5460 images', () => {
+    const tiles = buildYoloTilePlan(8192, 5460, {
+      tileSize: 1536,
+      overlap: 512,
+    });
+
+    expect(tiles).toHaveLength(40);
+    expect(tiles[0]).toMatchObject({ index: 0, x: 0, y: 0, width: 1536, height: 1536 });
+    expect(tiles[7]).toMatchObject({ index: 7, x: 6656, y: 0, width: 1536, height: 1536 });
+    expect(tiles[32]).toMatchObject({ index: 32, x: 0, y: 3924, width: 1536, height: 1536 });
+    expect(tiles[39]).toMatchObject({ index: 39, x: 6656, y: 3924, width: 1536, height: 1536 });
+  });
+
+  it('only tiles images larger than the configured threshold', () => {
+    expect(shouldTileYoloImage(1536, 1536, {
+      enabled: true,
+      minDimension: 2048,
+      tileSize: 1536,
+    })).toBe(false);
+
+    expect(shouldTileYoloImage(8192, 5460, {
+      enabled: true,
+      minDimension: 2048,
+      tileSize: 1536,
+    })).toBe(true);
+
+    expect(shouldTileYoloImage(8192, 5460, {
+      enabled: false,
+      minDimension: 2048,
+      tileSize: 1536,
+    })).toBe(false);
+  });
+
+  it('offsets tile-local detections back into full-image coordinates', () => {
+    const detection = offsetDetectionToImage(
+      {
+        class: 'Pine-Saplings',
+        confidence: 0.92,
+        bbox: [100, 200, 180, 280],
+      },
+      { index: 12, x: 2048, y: 1024, width: 1536, height: 1536 },
+      8192,
+      5460
+    );
+
+    expect(detection).toEqual({
+      class: 'Pine-Saplings',
+      confidence: 0.92,
+      bbox: [2148, 1224, 2228, 1304],
+    });
+  });
+
+  it('clips offset detections to the full-image boundary', () => {
+    const detection = offsetDetectionToImage(
+      {
+        class: 'Pine-Saplings',
+        confidence: 0.88,
+        bbox: [1500, 1500, 1700, 1700],
+      },
+      { index: 39, x: 6656, y: 3924, width: 1536, height: 1536 },
+      8192,
+      5460
+    );
+
+    expect(detection?.bbox).toEqual([8156, 5424, 8192, 5460]);
+  });
+
+  it('merges duplicate same-class overlap boxes while preserving distinct candidates', () => {
+    const merged = mergeYoloDetectionsWithNms(
+      [
+        { class: 'Pine-Saplings', confidence: 0.91, bbox: [100, 100, 180, 180] },
+        { class: 'Pine-Saplings', confidence: 0.77, bbox: [106, 106, 186, 186] },
+        { class: 'Pine-Saplings', confidence: 0.72, bbox: [350, 350, 420, 420] },
+        { class: 'Wattle', confidence: 0.71, bbox: [104, 104, 184, 184] },
+      ],
+      0.45
+    );
+
+    expect(merged).toHaveLength(3);
+    expect(merged.map((detection) => detection.confidence)).toEqual([0.91, 0.72, 0.71]);
+    expect(calculateBBoxIoU([100, 100, 180, 180], [106, 106, 186, 186])).toBeGreaterThan(0.45);
+  });
+});


### PR DESCRIPTION
## Summary
- Add server-side tiled YOLO inference for large drone images in the `/api/inference/run` path.
- Offset tile detections back into full-image coordinates and merge overlaps with class-aware NMS.
- Persist tiling diagnostics in detection/job metadata and return tiling summaries for synchronous runs.
- Extend the YOLO GPU lock TTL so tiled runs do not lose the lock mid-image.

## Root cause
The pine sapling YOLO model returns zero detections on full 8192x5460 drone images, but the same image produces detections when cropped/tiled. The app was faithfully sending whole images to the GPU, so the model quality appeared worse than it was.

## Verification
- `npm run test:unit -- tests/unit/yolo-tiling.test.ts tests/unit/pine-sapling-count.test.ts`
- `npx eslint app/api/inference/run/route.ts lib/utils/yolo-tiling.ts lib/services/yolo-inference.ts lib/services/inference.ts tests/unit/yolo-tiling.test.ts`
- `npm run lint` passes with three unrelated existing warnings.
- `npm run build`

## Notes
- Default tiling is enabled with `YOLO_TILE_SIZE=1536`, `YOLO_TILE_OVERLAP=512`, `YOLO_TILE_NMS_IOU=0.45`, and `YOLO_TILE_MAX_TILES=80`.
- Direct local S3 smoke against Manas's HQP image was blocked by AWS `403` from local profiles, but previous direct GPU crop/tile testing on `DJI_20260409104655_0459.JPG` showed 112 raw tile detections merged to 68 detections on that one image.
