### PR TITLE
Fix AG-3 training schema drift and JSON errors

### DIFF
--- a/components/training/training-client.tsx
+++ b/components/training/training-client.tsx
@@ -780,9 +780,9 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
 
     try {
       const response = await fetch(`/api/training/jobs/${jobId}/metrics`);
-      const data = await response.json();
+      const data = await readJsonResponse(response, "Failed to load metrics history");
       if (!response.ok) {
-        throw new Error(data?.error || "Failed to load metrics history");
+        throw new Error((data?.error as string) || "Failed to load metrics history");
       }
 
       const history = Array.isArray(data.history)
@@ -811,7 +811,7 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
         },
       }));
     }
-  }, []);
+  }, [readJsonResponse]);
 
   const refreshAll = useCallback(async () => {
     setError(null);
@@ -881,11 +881,12 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
           minConfidence: datasetForm.minConfidence,
         }),
       });
-      const data = await response.json();
+      const data = await readJsonResponse(response, "Failed to load class options");
       if (!response.ok) {
-        throw new Error(data?.error || "Failed to load class options");
+        throw new Error((data?.error as string) || "Failed to load class options");
       }
-      const classes = data.preview?.availableClasses || [];
+      const previewData = data.preview as DatasetPreview | undefined;
+      const classes = previewData?.availableClasses || [];
       setAvailableClasses(classes);
       const classNames = classes.map((entry: { name: string }) => entry.name);
       setDatasetForm((prev) => {
@@ -904,6 +905,7 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
     datasetForm.includeAIDetections,
     datasetForm.includeManualAnnotations,
     datasetForm.minConfidence,
+    readJsonResponse,
   ]);
 
   const loadInferencePreview = useCallback(async () => {
@@ -921,22 +923,22 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
           preview: true,
         }),
       });
-      const data = await response.json();
+      const data = await readJsonResponse(response, "Failed to preview inference");
       if (!response.ok) {
-        throw new Error(data?.error || "Failed to preview inference");
+        throw new Error((data?.error as string) || "Failed to preview inference");
       }
       setInferencePreview({
-        totalImages: data.totalImages || 0,
-        skippedImages: data.skippedImages || 0,
-        duplicateImages: data.duplicateImages || 0,
-        skippedReason: data.skippedReason,
+        totalImages: Number(data.totalImages || 0),
+        skippedImages: Number(data.skippedImages || 0),
+        duplicateImages: Number(data.duplicateImages || 0),
+        skippedReason: data.skippedReason as string | undefined,
       });
     } catch {
       setInferencePreview(null);
     } finally {
       setInferencePreviewLoading(false);
     }
-  }, [selectedInferenceModel, inferenceForm.projectId, inferenceForm.confidence]);
+  }, [selectedInferenceModel, inferenceForm.projectId, inferenceForm.confidence, readJsonResponse]);
 
   useEffect(() => {
     if (!createDatasetOpen) return;
@@ -977,7 +979,7 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
           jobIds.map(async (jobId) => {
             const response = await fetch(`/api/training/jobs/${jobId}`);
             if (!response.ok) return null;
-            return (await response.json()) as TrainingJob;
+            return (await readJsonResponse(response, "Failed to poll training job")) as TrainingJob;
           })
         );
         setJobs((prev) =>
@@ -994,7 +996,7 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
     }, 5000);
 
     return () => clearInterval(interval);
-  }, [activeJobIds]);
+  }, [activeJobIds, readJsonResponse]);
 
   useEffect(() => {
     if (!activeJobIds) return;
@@ -1066,11 +1068,11 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
           minConfidence: datasetForm.minConfidence,
         }),
       });
-      const data = await response.json();
+      const data = await readJsonResponse(response, "Failed to preview dataset");
       if (!response.ok) {
-        throw new Error(data?.error || "Failed to preview dataset");
+        throw new Error((data?.error as string) || "Failed to preview dataset");
       }
-      setPreview(data.preview);
+      setPreview(data.preview as DatasetPreview);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to preview dataset");
       setPreview(null);
@@ -1115,9 +1117,9 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
               : datasetForm.augmentationConfig,
         }),
       });
-      const data = await response.json();
+      const data = await readJsonResponse(response, "Failed to create dataset");
       if (!response.ok) {
-        throw new Error(data?.error || "Failed to create dataset");
+        throw new Error((data?.error as string) || "Failed to create dataset");
       }
 
       setNotice("Dataset created and uploaded to S3.");
@@ -1158,9 +1160,9 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
             : {}),
         }),
       });
-      const data = await response.json();
+      const data = await readJsonResponse(response, "Failed to start training");
       if (!response.ok) {
-        throw new Error(data?.error || "Failed to start training");
+        throw new Error((data?.error as string) || "Failed to start training");
       }
       setNotice("Training job queued. Monitoring progress.");
       setStartTrainingOpen(false);
@@ -1191,9 +1193,9 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
           saveDetections: true,
         }),
       });
-      const data = await response.json();
+      const data = await readJsonResponse(response, "Failed to start inference");
       if (!response.ok) {
-        throw new Error(data?.error || "Failed to start inference");
+        throw new Error((data?.error as string) || "Failed to start inference");
       }
       setNotice("Inference job started. Results will appear in review.");
       setRunInferenceOpen(false);
@@ -1211,9 +1213,9 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
     setError(null);
     try {
       const response = await fetch(`/api/inference/${jobId}`, { method: "DELETE" });
-      const data = await response.json();
+      const data = await readJsonResponse(response, "Failed to cancel inference job");
       if (!response.ok) {
-        throw new Error(data?.error || "Failed to cancel inference job");
+        throw new Error((data?.error as string) || "Failed to cancel inference job");
       }
       await loadInferenceJobs();
       setNotice("Inference job cancelled.");
@@ -1230,9 +1232,9 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
     setError(null);
     try {
       const response = await fetch(`/api/training/jobs/${jobId}`, { method: "DELETE" });
-      const data = await response.json();
+      const data = await readJsonResponse(response, "Failed to cancel training job");
       if (!response.ok) {
-        throw new Error(data?.error || "Failed to cancel training job");
+        throw new Error((data?.error as string) || "Failed to cancel training job");
       }
       await loadJobs();
       setNotice("Training job cancelled.");
@@ -1256,9 +1258,11 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ projectId: settingsProjectId }),
       });
-      const data = await response.json();
+      const data = await readJsonResponse(response, "Failed to activate model");
       if (!response.ok) {
-        const message = data?.details ? `${data.error}: ${data.details}` : data?.error;
+        const error = data?.error as string | undefined;
+        const details = data?.details as string | undefined;
+        const message = details ? `${error}: ${details}` : error;
         throw new Error(message || "Failed to activate model");
       }
       await loadModels();
@@ -1293,17 +1297,18 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
           body: JSON.stringify({ autoInferenceEnabled: enabled }),
         }
       );
-      const data = await response.json();
+      const data = await readJsonResponse(response, "Failed to update settings");
       if (!response.ok) {
-        throw new Error(data?.error || "Failed to update settings");
+        throw new Error((data?.error as string) || "Failed to update settings");
       }
+      const projectUpdate = data.project as Partial<Project> | undefined;
       setProjects((prev) =>
         prev.map((project) =>
           project.id === settingsProjectId
             ? {
                 ...project,
-                autoInferenceEnabled: data.project?.autoInferenceEnabled,
-                activeModelId: data.project?.activeModelId ?? project.activeModelId,
+                autoInferenceEnabled: projectUpdate?.autoInferenceEnabled,
+                activeModelId: projectUpdate?.activeModelId ?? project.activeModelId,
               }
             : project
         )
@@ -1333,16 +1338,17 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ inferenceBackend: backend }),
       });
-      const data = await response.json();
+      const data = await readJsonResponse(response, "Failed to update inference backend");
       if (!response.ok) {
-        throw new Error(data?.error || "Failed to update inference backend");
+        throw new Error((data?.error as string) || "Failed to update inference backend");
       }
+      const projectUpdate = data.project as Partial<Project> | undefined;
       setProjects((prev) =>
         prev.map((project) =>
           project.id === settingsProjectId
             ? {
                 ...project,
-                inferenceBackend: data.project?.inferenceBackend ?? backend,
+                inferenceBackend: projectUpdate?.inferenceBackend ?? backend,
               }
             : project
         )
@@ -1360,11 +1366,11 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
     setError(null);
     try {
       const response = await fetch(`/api/training/models/${modelId}/download`);
-      const data = await response.json();
+      const data = await readJsonResponse(response, "Failed to download weights");
       if (!response.ok) {
-        throw new Error(data?.error || "Failed to download weights");
+        throw new Error((data?.error as string) || "Failed to download weights");
       }
-      if (data.url) {
+      if (typeof data.url === "string") {
         window.open(data.url, "_blank", "noopener,noreferrer");
       }
     } catch (err) {
@@ -1389,13 +1395,16 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
         }),
       });
 
-      const data = await response.json().catch(() => ({}));
+      const data = await readJsonResponse(response, "Failed to create review session");
       if (!response.ok) {
-        const message = data?.details ? `${data.error}: ${data.details}` : data?.error;
+        const error = data?.error as string | undefined;
+        const details = data?.details as string | undefined;
+        const message = details ? `${error}: ${details}` : error;
         throw new Error(message || "Failed to create review session");
       }
 
-      const sessionId = data.session?.id;
+      const session = data.session as { id?: string } | undefined;
+      const sessionId = session?.id;
       if (!sessionId) {
         throw new Error("Review session missing from response");
       }

--- a/prisma/migrations/20260603043000_backfill_training_schema_drift/migration.sql
+++ b/prisma/migrations/20260603043000_backfill_training_schema_drift/migration.sql
@@ -1,0 +1,151 @@
+-- Backfill training schema drift observed in production after the YOLO tiling deploy.
+-- Keep this migration idempotent because several training columns were added to
+-- schema.prisma after the original training table migration was already applied.
+
+SET @db := DATABASE();
+
+-- TrainingDataset.displayName
+SET @has_col := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'TrainingDataset' AND COLUMN_NAME = 'displayName'
+);
+SET @sql := IF(@has_col = 0, 'ALTER TABLE `TrainingDataset` ADD COLUMN `displayName` VARCHAR(191) NULL', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- TrainingDataset.snapshotAt
+SET @has_col := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'TrainingDataset' AND COLUMN_NAME = 'snapshotAt'
+);
+SET @sql := IF(@has_col = 0, 'ALTER TABLE `TrainingDataset` ADD COLUMN `snapshotAt` DATETIME(3) NULL', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- TrainingDataset.status
+SET @has_col := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'TrainingDataset' AND COLUMN_NAME = 'status'
+);
+SET @sql := IF(
+  @has_col = 0,
+  'ALTER TABLE `TrainingDataset` ADD COLUMN `status` ENUM(''CREATING'', ''READY'', ''TRAINING'', ''FAILED'', ''ARCHIVED'') NOT NULL DEFAULT ''READY''',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- TrainingDataset.preprocessingConfig
+SET @has_col := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'TrainingDataset' AND COLUMN_NAME = 'preprocessingConfig'
+);
+SET @sql := IF(@has_col = 0, 'ALTER TABLE `TrainingDataset` ADD COLUMN `preprocessingConfig` JSON NULL', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- TrainingDataset.annotationManifestS3Key
+SET @has_col := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'TrainingDataset' AND COLUMN_NAME = 'annotationManifestS3Key'
+);
+SET @sql := IF(@has_col = 0, 'ALTER TABLE `TrainingDataset` ADD COLUMN `annotationManifestS3Key` VARCHAR(191) NULL', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- TrainingDataset.annotationManifestChecksum
+SET @has_col := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'TrainingDataset' AND COLUMN_NAME = 'annotationManifestChecksum'
+);
+SET @sql := IF(@has_col = 0, 'ALTER TABLE `TrainingDataset` ADD COLUMN `annotationManifestChecksum` VARCHAR(191) NULL', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- TrainingDataset.annotationCount
+SET @has_col := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'TrainingDataset' AND COLUMN_NAME = 'annotationCount'
+);
+SET @sql := IF(@has_col = 0, 'ALTER TABLE `TrainingDataset` ADD COLUMN `annotationCount` INTEGER NULL', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- TrainingDataset.idempotencyKey
+SET @has_col := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'TrainingDataset' AND COLUMN_NAME = 'idempotencyKey'
+);
+SET @sql := IF(@has_col = 0, 'ALTER TABLE `TrainingDataset` ADD COLUMN `idempotencyKey` VARCHAR(191) NULL', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_idx := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'TrainingDataset' AND INDEX_NAME = 'TrainingDataset_idempotencyKey_key'
+);
+SET @sql := IF(
+  @has_idx = 0,
+  'CREATE UNIQUE INDEX `TrainingDataset_idempotencyKey_key` ON `TrainingDataset`(`idempotencyKey`)',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- TrainingDataset.creationFilters
+SET @has_col := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'TrainingDataset' AND COLUMN_NAME = 'creationFilters'
+);
+SET @sql := IF(@has_col = 0, 'ALTER TABLE `TrainingDataset` ADD COLUMN `creationFilters` JSON NULL', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- TrainingJob.checkpointModelId
+SET @has_col := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'TrainingJob' AND COLUMN_NAME = 'checkpointModelId'
+);
+SET @sql := IF(@has_col = 0, 'ALTER TABLE `TrainingJob` ADD COLUMN `checkpointModelId` VARCHAR(191) NULL', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_idx := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'TrainingJob' AND INDEX_NAME = 'TrainingJob_checkpointModelId_idx'
+);
+SET @sql := IF(
+  @has_idx = 0,
+  'CREATE INDEX `TrainingJob_checkpointModelId_idx` ON `TrainingJob`(`checkpointModelId`)',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_fk := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+  WHERE TABLE_SCHEMA = @db
+    AND TABLE_NAME = 'TrainingJob'
+    AND CONSTRAINT_NAME = 'TrainingJob_checkpointModelId_fkey'
+    AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+);
+SET @sql := IF(
+  @has_fk = 0,
+  'ALTER TABLE `TrainingJob` ADD CONSTRAINT `TrainingJob_checkpointModelId_fkey` FOREIGN KEY (`checkpointModelId`) REFERENCES `TrainedModel`(`id`) ON DELETE SET NULL ON UPDATE CASCADE',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
## Summary
- Add an idempotent Prisma migration to backfill training schema drift seen in production (`TrainingDataset.displayName` and related dataset-version fields, plus `TrainingJob.checkpointModelId`).
- Harden the training page fetch paths so HTML/error responses surface as actionable messages instead of `Unexpected token <` JSON parser failures.

## Production finding
- `codex-ai-ops` sees Elastic Beanstalk `AgriDrone` as `Ready/Green` on `AgriDrone-v283`.
- The YOLO GPU host `i-04a662566087d9c4f` is running and healthy.
- EB logs show Prisma P2022 errors because production DB is missing `TrainingDataset.displayName` and `TrainingJob.checkpointModelId`.

## Verification
- `npm run lint -- --file components/training/training-client.tsx`
- `DATABASE_URL=mysql://root:password@127.0.0.1:3306/agridrone_ci npx prisma validate`
- `npm run test:unit -- tests/unit/yolo-tiling.test.ts tests/unit/pine-sapling-count.test.ts`
- `npm run build`

## Notes
- The migration is intentionally idempotent so it can safely run against production drift where some columns may already exist.
- Deployment should run `npx prisma migrate deploy` via the existing Docker entrypoint.