### PR TITLE
Add high-recall inference mode for assisted labelling

### DIFF
--- a/app/api/inference/run/route.ts
+++ b/app/api/inference/run/route.ts
@@ -16,6 +16,61 @@ import {
 import { S3Service } from '@/lib/services/s3';
 
 const MAX_SYNC_IMAGES = 50;
+const STANDARD_INFERENCE_CONFIDENCE = 0.25;
+const HIGH_RECALL_INFERENCE_CONFIDENCE = 0.1;
+
+type InferenceMode = 'standard' | 'high_recall' | 'custom';
+
+function clampConfidence(value: unknown, fallback = STANDARD_INFERENCE_CONFIDENCE): number {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(0, Math.min(1, parsed));
+}
+
+function resolveInferenceMode(input: {
+  inferenceMode?: unknown;
+  confidence?: unknown;
+}): { mode: InferenceMode; label: string; confidence: number } {
+  const requestedMode = typeof input.inferenceMode === 'string'
+    ? input.inferenceMode
+    : null;
+  const hasExplicitConfidence = typeof input.confidence !== 'undefined';
+
+  if (requestedMode === 'high_recall') {
+    return {
+      mode: 'high_recall',
+      label: 'High recall assisted labelling',
+      confidence: HIGH_RECALL_INFERENCE_CONFIDENCE,
+    };
+  }
+
+  if (requestedMode === 'standard') {
+    return {
+      mode: 'standard',
+      label: 'Standard QA',
+      confidence: STANDARD_INFERENCE_CONFIDENCE,
+    };
+  }
+
+  if (requestedMode && requestedMode !== 'custom') {
+    throw new Error('Invalid inferenceMode. Use standard, high_recall, or custom.');
+  }
+
+  const confidence = clampConfidence(input.confidence);
+  if (requestedMode === 'custom' || hasExplicitConfidence) {
+    return {
+      mode: 'custom',
+      label: 'Custom confidence',
+      confidence,
+    };
+  }
+
+  return {
+    mode: 'standard',
+    label: 'Standard QA',
+    confidence: STANDARD_INFERENCE_CONFIDENCE,
+  };
+}
 
 function parseS3Path(path: string): { bucket: string; keyPrefix: string } | null {
   if (!path.startsWith('s3://')) return null;
@@ -73,10 +128,24 @@ export async function POST(request: NextRequest) {
       modelId: requestedModelId,
       projectId,
       assetIds,
-      confidence = 0.25,
       saveDetections = true,
       preview = false,
     } = body;
+    let inferenceSelection: ReturnType<typeof resolveInferenceMode>;
+    try {
+      inferenceSelection = resolveInferenceMode({
+        inferenceMode: body.inferenceMode,
+        confidence: body.confidence,
+      });
+    } catch (error) {
+      return NextResponse.json(
+        { error: error instanceof Error ? error.message : 'Invalid inference mode' },
+        { status: 400 }
+      );
+    }
+    const confidence = inferenceSelection.confidence;
+    const inferenceMode = inferenceSelection.mode;
+    const inferenceModeLabel = inferenceSelection.label;
 
     if (!projectId) {
       return NextResponse.json(
@@ -214,6 +283,9 @@ export async function POST(request: NextRequest) {
         skippedImages,
         skippedReason: 'missing_gps_or_dimensions',
         duplicateImages,
+        confidence,
+        inferenceMode,
+        inferenceModeLabel,
       });
     }
 
@@ -253,6 +325,8 @@ export async function POST(request: NextRequest) {
           modelId: effectiveModelId,
           modelName,
           confidence,
+          inferenceMode,
+          inferenceModeLabel,
           saveDetections,
           totalImages,
           processedImages: 0,
@@ -273,6 +347,8 @@ export async function POST(request: NextRequest) {
         modelName,
         assetIds: assetIdList,
         confidence,
+        inferenceMode,
+        inferenceModeLabel,
         saveDetections,
         skippedImages,
         duplicateImages,
@@ -291,6 +367,9 @@ export async function POST(request: NextRequest) {
             skippedReason: 'missing_gps_or_dimensions',
             duplicateImages,
             detectionsFound: result.detectionsFound,
+            confidence,
+            inferenceMode,
+            inferenceModeLabel,
             tiling: result.tiling,
           },
           { status: 502 }
@@ -306,6 +385,9 @@ export async function POST(request: NextRequest) {
         skippedReason: 'missing_gps_or_dimensions',
         duplicateImages,
         detectionsFound: result.detectionsFound,
+        confidence,
+        inferenceMode,
+        inferenceModeLabel,
         errors: result.errors.slice(0, 10),
         tiling: result.tiling,
       });
@@ -336,6 +418,8 @@ export async function POST(request: NextRequest) {
       projectId,
       assetIds: assetIdList,
       confidence,
+      inferenceMode,
+      inferenceModeLabel,
       saveDetections,
       backend: backendPreference as 'local' | 'roboflow' | 'auto',
     });
@@ -344,6 +428,9 @@ export async function POST(request: NextRequest) {
       jobId: processingJob.id,
       totalImages,
       status: 'queued',
+      confidence,
+      inferenceMode,
+      inferenceModeLabel,
       skippedImages,
       skippedReason: 'missing_gps_or_dimensions',
       duplicateImages,

--- a/components/training/training-client.tsx
+++ b/components/training/training-client.tsx
@@ -125,6 +125,8 @@ interface InferenceJob {
     modelId?: string;
     modelName?: string;
     confidence?: number;
+    inferenceMode?: InferenceMode;
+    inferenceModeLabel?: string;
     totalImages?: number;
     processedImages?: number;
     detectionsFound?: number;
@@ -153,6 +155,7 @@ interface HealthResponse {
 }
 
 type AugmentationPreset = "none" | "light" | "medium" | "heavy" | "agricultural";
+type InferenceMode = "standard" | "high_recall" | "custom";
 
 interface AugmentationConfig {
   horizontalFlip: boolean;
@@ -212,6 +215,26 @@ const INFERENCE_STATUS_STYLES: Record<string, string> = {
   FAILED: "bg-red-100 text-red-700",
   CANCELLED: "bg-gray-100 text-gray-600",
 };
+
+const INFERENCE_PRESETS: Array<{
+  mode: InferenceMode;
+  label: string;
+  confidence: number;
+  description: string;
+}> = [
+  {
+    mode: "standard",
+    label: "Standard QA",
+    confidence: 0.25,
+    description: "Balanced candidate set for normal review.",
+  },
+  {
+    mode: "high_recall",
+    label: "High recall assisted labelling",
+    confidence: 0.1,
+    description: "Find more saplings; expect more false positives to reject.",
+  },
+];
 
 const AUGMENTATION_PRESET_DEFAULTS: Record<AugmentationPreset, AugmentationConfig> = {
   none: {
@@ -278,6 +301,9 @@ const formatMetric = (value?: number | null) =>
 const formatPercentMetric = (value?: number | null) =>
   typeof value === "number" && Number.isFinite(value) ? `${(value * 100).toFixed(1)}%` : "--";
 
+const formatInferenceConfidence = (value?: number | null) =>
+  typeof value === "number" && Number.isFinite(value) ? `${Math.round(value * 100)}%` : "--";
+
 const formatDate = (value?: string | null) => {
   if (!value) return "--";
   const parsed = new Date(value);
@@ -301,6 +327,18 @@ const toPercentValue = (value?: number | null) =>
   typeof value === "number" && Number.isFinite(value)
     ? Math.min(100, Math.max(0, value * 100))
     : 0;
+
+const getInferenceModeLabel = (config?: InferenceJob["config"]) => {
+  if (typeof config?.inferenceModeLabel === "string") return config.inferenceModeLabel;
+  const preset = INFERENCE_PRESETS.find((entry) => entry.mode === config?.inferenceMode);
+  if (preset) return preset.label;
+  if (typeof config?.confidence === "number") {
+    const confidence = Math.round(config.confidence * 100);
+    if (confidence === 25) return "Standard QA";
+    if (confidence === 10) return "High recall assisted labelling";
+  }
+  return "Custom confidence";
+};
 
 const cloneAugmentationConfig = (config: AugmentationConfig): AugmentationConfig => ({ ...config });
 
@@ -558,6 +596,7 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
   const [inferenceForm, setInferenceForm] = useState({
     projectId: "",
     confidence: 0.25,
+    inferenceMode: "standard" as InferenceMode,
   });
   const [settingsProjectId, setSettingsProjectId] = useState("");
   const [savingAutoInference, setSavingAutoInference] = useState(false);
@@ -617,6 +656,10 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
   const activeInferenceIds = useMemo(
     () => activeInferenceJobs.map((job) => job.id).join(","),
     [activeInferenceJobs]
+  );
+  const selectedInferencePreset = useMemo(
+    () => INFERENCE_PRESETS.find((preset) => preset.mode === inferenceForm.inferenceMode),
+    [inferenceForm.inferenceMode]
   );
 
   const selectedDataset = useMemo(
@@ -919,6 +962,7 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
           modelId: selectedInferenceModel.id,
           projectId: inferenceForm.projectId,
           confidence: inferenceForm.confidence,
+          inferenceMode: inferenceForm.inferenceMode,
           saveDetections: true,
           preview: true,
         }),
@@ -938,7 +982,13 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
     } finally {
       setInferencePreviewLoading(false);
     }
-  }, [selectedInferenceModel, inferenceForm.projectId, inferenceForm.confidence, readJsonResponse]);
+  }, [
+    selectedInferenceModel,
+    inferenceForm.projectId,
+    inferenceForm.confidence,
+    inferenceForm.inferenceMode,
+    readJsonResponse,
+  ]);
 
   useEffect(() => {
     if (!createDatasetOpen) return;
@@ -1190,6 +1240,7 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
           modelId: selectedInferenceModel.id,
           projectId: inferenceForm.projectId,
           confidence: inferenceForm.confidence,
+          inferenceMode: inferenceForm.inferenceMode,
           saveDetections: true,
         }),
       });
@@ -1197,7 +1248,15 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
       if (!response.ok) {
         throw new Error((data?.error as string) || "Failed to start inference");
       }
-      setNotice("Inference job started. Results will appear in review.");
+      const label =
+        typeof data.inferenceModeLabel === "string"
+          ? data.inferenceModeLabel
+          : selectedInferencePreset?.label || "Inference";
+      const resolvedConfidence =
+        typeof data.confidence === "number" ? data.confidence : inferenceForm.confidence;
+      setNotice(
+        `${label} inference started at ${Math.round(resolvedConfidence * 100)}%. Results will appear in review.`
+      );
       setRunInferenceOpen(false);
       await loadInferenceJobs();
     } catch (err) {
@@ -2150,7 +2209,40 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
                 </div>
 
                 <div className="space-y-2">
-                  <Label>Confidence threshold</Label>
+                  <Label>Inference mode</Label>
+                  <div className="grid gap-3 md:grid-cols-2">
+                    {INFERENCE_PRESETS.map((preset) => (
+                      <button
+                        key={preset.mode}
+                        type="button"
+                        onClick={() =>
+                          setInferenceForm((prev) => ({
+                            ...prev,
+                            inferenceMode: preset.mode,
+                            confidence: preset.confidence,
+                          }))
+                        }
+                        className={`rounded-lg border px-4 py-3 text-left transition ${
+                          inferenceForm.inferenceMode === preset.mode
+                            ? "border-emerald-500 bg-emerald-50 text-emerald-950"
+                            : "border-gray-200 bg-white text-gray-700 hover:border-emerald-200"
+                        }`}
+                      >
+                        <span className="block text-sm font-semibold">{preset.label}</span>
+                        <span className="mt-1 block text-xs text-gray-600">
+                          {formatInferenceConfidence(preset.confidence)} - {preset.description}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                  <p className="text-xs text-gray-500">
+                    High recall is for assisted labelling only. Reviewers should reject false positives
+                    before accepted labels are used for YOLO training or spray exports.
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <Label>Inference confidence</Label>
                   <div className="flex items-center gap-3">
                     <Slider
                       min={0.05}
@@ -2160,6 +2252,7 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
                       onValueChange={(value) =>
                         setInferenceForm((prev) => ({
                           ...prev,
+                          inferenceMode: "custom",
                           confidence: value[0] ?? prev.confidence,
                         }))
                       }
@@ -2174,11 +2267,17 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
                       onChange={(event) =>
                         setInferenceForm((prev) => ({
                           ...prev,
+                          inferenceMode: "custom",
                           confidence: clampNumber(Number(event.target.value), 0, 1),
                         }))
                       }
                     />
                   </div>
+                  <p className="text-xs text-gray-500">
+                    Current save-time threshold: {formatInferenceConfidence(inferenceForm.confidence)}
+                    {inferenceForm.inferenceMode === "custom" ? " (custom)" : ""}. The review slider
+                    can only filter detections saved above this threshold.
+                  </p>
                 </div>
 
                 <Card className="border-dashed border-gray-200">
@@ -2190,7 +2289,7 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
                         : "Counts exclude images already processed by this model."}
                     </CardDescription>
                   </CardHeader>
-                  <CardContent className="grid gap-3 md:grid-cols-3 text-sm">
+                  <CardContent className="grid gap-3 md:grid-cols-4 text-sm">
                     <div className="rounded-md bg-white p-3 border border-gray-100">
                       <p className="text-xs text-gray-500">Eligible images</p>
                       <p className="text-lg font-semibold">
@@ -2207,6 +2306,15 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
                       <p className="text-xs text-gray-500">Duplicates</p>
                       <p className="text-lg font-semibold">
                         {inferencePreview ? inferencePreview.duplicateImages : "--"}
+                      </p>
+                    </div>
+                    <div className="rounded-md bg-white p-3 border border-gray-100">
+                      <p className="text-xs text-gray-500">Save threshold</p>
+                      <p className="text-lg font-semibold">
+                        {formatInferenceConfidence(inferenceForm.confidence)}
+                      </p>
+                      <p className="text-xs text-gray-500">
+                        {selectedInferencePreset?.label || "Custom"}
                       </p>
                     </div>
                   </CardContent>
@@ -2491,6 +2599,9 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
                                 <p className="text-xs text-gray-500">
                                   {getInferenceModelLabel(job)}
                                 </p>
+                                <p className="text-xs text-gray-500">
+                                  {getInferenceModeLabel(job.config)} - {formatInferenceConfidence(job.config?.confidence)}
+                                </p>
                               </div>
                               <Badge
                                 className={
@@ -2554,6 +2665,9 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
                                 </p>
                                 <p className="text-xs text-gray-500">
                                   {getInferenceModelLabel(job)}
+                                </p>
+                                <p className="text-xs text-gray-500">
+                                  {getInferenceModeLabel(job.config)} - {formatInferenceConfidence(job.config?.confidence)}
                                 </p>
                               </div>
                               <Badge

--- a/lib/queue/inference-queue.ts
+++ b/lib/queue/inference-queue.ts
@@ -14,6 +14,8 @@ export interface InferenceJobData {
   projectId: string;
   assetIds: string[];
   confidence: number;
+  inferenceMode?: string;
+  inferenceModeLabel?: string;
   saveDetections: boolean;
   backend?: 'local' | 'roboflow' | 'auto';
 }

--- a/lib/services/inference.ts
+++ b/lib/services/inference.ts
@@ -47,6 +47,8 @@ export interface InferenceJobConfig {
   modelId: string;
   modelName: string;
   confidence: number;
+  inferenceMode?: string;
+  inferenceModeLabel?: string;
   saveDetections: boolean;
   totalImages: number;
   processedImages: number;
@@ -136,6 +138,8 @@ export async function processInferenceJob(options: {
   modelName: string;
   assetIds: string[];
   confidence: number;
+  inferenceMode?: string;
+  inferenceModeLabel?: string;
   saveDetections: boolean;
   skippedImages: number;
   duplicateImages: number;
@@ -150,6 +154,8 @@ export async function processInferenceJob(options: {
     modelName,
     assetIds,
     confidence,
+    inferenceMode,
+    inferenceModeLabel,
     saveDetections,
     skippedImages,
     duplicateImages,
@@ -177,6 +183,8 @@ export async function processInferenceJob(options: {
         modelId,
         modelName,
         confidence,
+        inferenceMode,
+        inferenceModeLabel,
         saveDetections,
         totalImages,
         processedImages,
@@ -413,6 +421,8 @@ export async function processInferenceJob(options: {
       modelId,
       modelName,
       confidence,
+      inferenceMode,
+      inferenceModeLabel,
       saveDetections,
       totalImages,
       processedImages,

--- a/workers/inference-worker.ts
+++ b/workers/inference-worker.ts
@@ -47,6 +47,18 @@ async function handleInferenceJob(
     modelName: job.data.modelName,
     assetIds: job.data.assetIds,
     confidence: job.data.confidence,
+    inferenceMode:
+      typeof job.data.inferenceMode === 'string'
+        ? job.data.inferenceMode
+        : typeof config.inferenceMode === 'string'
+          ? config.inferenceMode
+          : undefined,
+    inferenceModeLabel:
+      typeof job.data.inferenceModeLabel === 'string'
+        ? job.data.inferenceModeLabel
+        : typeof config.inferenceModeLabel === 'string'
+          ? config.inferenceModeLabel
+          : undefined,
     saveDetections: job.data.saveDetections,
     skippedImages,
     duplicateImages,


### PR DESCRIPTION
## Summary
- Adds an explicit High recall assisted labelling inference mode that resolves to a true save-time confidence threshold of 0.10.
- Preserves standard QA at 0.25 and keeps custom confidence support for existing API callers.
- Persists inference mode/label metadata through sync and queued inference jobs so review sessions and job cards show what threshold produced the candidates.
- Updates the Training UI to make high-recall review-only behaviour clear before operators run detections.

## Verification
- npm run lint -- --file components/training/training-client.tsx --file app/api/inference/run/route.ts --file lib/services/inference.ts --file lib/queue/inference-queue.ts --file workers/inference-worker.ts
- npm run test:unit -- tests/unit/yolo-tiling.test.ts tests/unit/pine-sapling-count.test.ts
- npm run build
- npm run lint (passes with existing unrelated warnings)

## Diagnostic result
No-save diagnostic on AG-3 session cmpxlz6j50005lg3ryl23yqur at 0.10 confidence returned 1,095 merged detections across the same 10 images, compared with the current 831 at 0.25.