### PR TITLE
Fix inference reruns for draft detections

### DIFF
--- a/app/api/inference/run/route.ts
+++ b/app/api/inference/run/route.ts
@@ -131,6 +131,7 @@ export async function POST(request: NextRequest) {
       saveDetections = true,
       preview = false,
     } = body;
+    const replaceDraftDetections = body.replaceDraftDetections === true;
     let inferenceSelection: ReturnType<typeof resolveInferenceMode>;
     try {
       inferenceSelection = resolveInferenceMode({
@@ -235,20 +236,52 @@ export async function POST(request: NextRequest) {
       baseWhere.id = { in: assetIds };
     }
 
+    const anyModelDetectionFilter = { customModelId: effectiveModelId };
+    const reviewedModelDetectionFilter = {
+      customModelId: effectiveModelId,
+      OR: [
+        { verified: true },
+        { rejected: true },
+        { userCorrected: true },
+        { reviewedAt: { not: null } },
+      ],
+    };
+
     const duplicateImages = await prisma.asset.count({
       where: {
         ...baseWhere,
         detections: {
-          some: { customModelId: effectiveModelId },
+          some: anyModelDetectionFilter,
         },
       },
     });
 
+    const reviewedDuplicateImages = await prisma.asset.count({
+      where: {
+        ...baseWhere,
+        detections: {
+          some: reviewedModelDetectionFilter,
+        },
+      },
+    });
+
+    const replaceableDuplicateImages = Math.max(0, duplicateImages - reviewedDuplicateImages);
+
     const candidateWhere: Record<string, unknown> = {
       ...baseWhere,
-      detections: {
-        none: { customModelId: effectiveModelId },
-      },
+      ...(replaceDraftDetections
+        ? {
+            NOT: {
+              detections: {
+                some: reviewedModelDetectionFilter,
+              },
+            },
+          }
+        : {
+            detections: {
+              none: anyModelDetectionFilter,
+            },
+          }),
     };
 
     const skippedImages = await prisma.asset.count({
@@ -283,6 +316,9 @@ export async function POST(request: NextRequest) {
         skippedImages,
         skippedReason: 'missing_gps_or_dimensions',
         duplicateImages,
+        replaceDraftDetections,
+        replaceableDuplicateImages,
+        reviewedDuplicateImages,
         confidence,
         inferenceMode,
         inferenceModeLabel,
@@ -290,13 +326,20 @@ export async function POST(request: NextRequest) {
     }
 
     if (totalImages === 0) {
+      const rerunBlockedByDrafts =
+        duplicateImages > 0 && replaceableDuplicateImages > 0 && !replaceDraftDetections;
       return NextResponse.json(
         {
-          error: 'No eligible images to process',
+          error: rerunBlockedByDrafts
+            ? 'No eligible images to process. This project already has draft detections for this model; enable replaceDraftDetections to rerun unreviewed images.'
+            : 'No eligible images to process',
           totalImages,
           skippedImages,
           skippedReason: 'missing_gps_or_dimensions',
           duplicateImages,
+          replaceDraftDetections,
+          replaceableDuplicateImages,
+          reviewedDuplicateImages,
         },
         { status: 400 }
       );
@@ -328,12 +371,15 @@ export async function POST(request: NextRequest) {
           inferenceMode,
           inferenceModeLabel,
           saveDetections,
+          replaceDraftDetections,
           totalImages,
           processedImages: 0,
           detectionsFound: 0,
           skippedImages,
           skippedReason: 'missing_gps_or_dimensions',
           duplicateImages,
+          replaceableDuplicateImages,
+          reviewedDuplicateImages,
           backend: backendPreference,
         },
       },
@@ -350,8 +396,11 @@ export async function POST(request: NextRequest) {
         inferenceMode,
         inferenceModeLabel,
         saveDetections,
+        replaceDraftDetections,
         skippedImages,
         duplicateImages,
+        replaceableDuplicateImages,
+        reviewedDuplicateImages,
         skippedReason: 'missing_gps_or_dimensions',
         backend: backendPreference as 'local' | 'roboflow' | 'auto',
       });
@@ -366,7 +415,11 @@ export async function POST(request: NextRequest) {
             skippedImages,
             skippedReason: 'missing_gps_or_dimensions',
             duplicateImages,
+            replaceDraftDetections,
+            replaceableDuplicateImages,
+            reviewedDuplicateImages,
             detectionsFound: result.detectionsFound,
+            draftDetectionsReplaced: result.draftDetectionsReplaced,
             confidence,
             inferenceMode,
             inferenceModeLabel,
@@ -384,7 +437,11 @@ export async function POST(request: NextRequest) {
         skippedImages,
         skippedReason: 'missing_gps_or_dimensions',
         duplicateImages,
+        replaceDraftDetections,
+        replaceableDuplicateImages,
+        reviewedDuplicateImages,
         detectionsFound: result.detectionsFound,
+        draftDetectionsReplaced: result.draftDetectionsReplaced,
         confidence,
         inferenceMode,
         inferenceModeLabel,
@@ -421,6 +478,7 @@ export async function POST(request: NextRequest) {
       inferenceMode,
       inferenceModeLabel,
       saveDetections,
+      replaceDraftDetections,
       backend: backendPreference as 'local' | 'roboflow' | 'auto',
     });
 
@@ -434,6 +492,9 @@ export async function POST(request: NextRequest) {
       skippedImages,
       skippedReason: 'missing_gps_or_dimensions',
       duplicateImages,
+      replaceDraftDetections,
+      replaceableDuplicateImages,
+      reviewedDuplicateImages,
     });
   } catch (error) {
     console.error('Error starting inference:', error);

--- a/components/training/training-client.tsx
+++ b/components/training/training-client.tsx
@@ -132,6 +132,10 @@ interface InferenceJob {
     detectionsFound?: number;
     skippedImages?: number;
     duplicateImages?: number;
+    replaceDraftDetections?: boolean;
+    replaceableDuplicateImages?: number;
+    reviewedDuplicateImages?: number;
+    draftDetectionsReplaced?: number;
   };
 }
 
@@ -597,6 +601,7 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
     projectId: "",
     confidence: 0.25,
     inferenceMode: "standard" as InferenceMode,
+    replaceDraftDetections: false,
   });
   const [settingsProjectId, setSettingsProjectId] = useState("");
   const [savingAutoInference, setSavingAutoInference] = useState(false);
@@ -605,6 +610,9 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
     totalImages: number;
     skippedImages: number;
     duplicateImages: number;
+    replaceDraftDetections: boolean;
+    replaceableDuplicateImages: number;
+    reviewedDuplicateImages: number;
     skippedReason?: string;
   } | null>(null);
   const [inferencePreviewLoading, setInferencePreviewLoading] = useState(false);
@@ -660,6 +668,12 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
   const selectedInferencePreset = useMemo(
     () => INFERENCE_PRESETS.find((preset) => preset.mode === inferenceForm.inferenceMode),
     [inferenceForm.inferenceMode]
+  );
+  const hasReplaceableInferenceDrafts = Boolean(
+    inferencePreview && inferencePreview.replaceableDuplicateImages > 0
+  );
+  const hasProtectedInferenceReviews = Boolean(
+    inferencePreview && inferencePreview.reviewedDuplicateImages > 0
   );
 
   const selectedDataset = useMemo(
@@ -840,7 +854,7 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
         ...prev,
         [jobId]: {
           loading: false,
-          warning: data.warning,
+          warning: typeof data.warning === "string" ? data.warning : undefined,
           points,
         },
       }));
@@ -963,6 +977,7 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
           projectId: inferenceForm.projectId,
           confidence: inferenceForm.confidence,
           inferenceMode: inferenceForm.inferenceMode,
+          replaceDraftDetections: inferenceForm.replaceDraftDetections,
           saveDetections: true,
           preview: true,
         }),
@@ -975,6 +990,9 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
         totalImages: Number(data.totalImages || 0),
         skippedImages: Number(data.skippedImages || 0),
         duplicateImages: Number(data.duplicateImages || 0),
+        replaceDraftDetections: data.replaceDraftDetections === true,
+        replaceableDuplicateImages: Number(data.replaceableDuplicateImages || 0),
+        reviewedDuplicateImages: Number(data.reviewedDuplicateImages || 0),
         skippedReason: data.skippedReason as string | undefined,
       });
     } catch {
@@ -987,6 +1005,7 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
     inferenceForm.projectId,
     inferenceForm.confidence,
     inferenceForm.inferenceMode,
+    inferenceForm.replaceDraftDetections,
     readJsonResponse,
   ]);
 
@@ -1029,7 +1048,7 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
           jobIds.map(async (jobId) => {
             const response = await fetch(`/api/training/jobs/${jobId}`);
             if (!response.ok) return null;
-            return (await readJsonResponse(response, "Failed to poll training job")) as TrainingJob;
+            return (await readJsonResponse(response, "Failed to poll training job")) as unknown as TrainingJob;
           })
         );
         setJobs((prev) =>
@@ -1241,6 +1260,7 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
           projectId: inferenceForm.projectId,
           confidence: inferenceForm.confidence,
           inferenceMode: inferenceForm.inferenceMode,
+          replaceDraftDetections: inferenceForm.replaceDraftDetections,
           saveDetections: true,
         }),
       });
@@ -2192,7 +2212,11 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
                   <Select
                     value={inferenceForm.projectId}
                     onValueChange={(value) =>
-                      setInferenceForm((prev) => ({ ...prev, projectId: value }))
+                      setInferenceForm((prev) => ({
+                        ...prev,
+                        projectId: value,
+                        replaceDraftDetections: false,
+                      }))
                     }
                   >
                     <SelectTrigger id="inference-project">
@@ -2286,10 +2310,10 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
                     <CardDescription>
                       {inferencePreviewLoading
                         ? "Calculating eligible images..."
-                        : "Counts exclude images already processed by this model."}
+                        : "Reviewed decisions are protected. Draft-only detections can be replaced when you choose to rerun."}
                     </CardDescription>
                   </CardHeader>
-                  <CardContent className="grid gap-3 md:grid-cols-4 text-sm">
+                  <CardContent className="grid gap-3 md:grid-cols-5 text-sm">
                     <div className="rounded-md bg-white p-3 border border-gray-100">
                       <p className="text-xs text-gray-500">Eligible images</p>
                       <p className="text-lg font-semibold">
@@ -2309,6 +2333,12 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
                       </p>
                     </div>
                     <div className="rounded-md bg-white p-3 border border-gray-100">
+                      <p className="text-xs text-gray-500">Replaceable drafts</p>
+                      <p className="text-lg font-semibold">
+                        {inferencePreview ? inferencePreview.replaceableDuplicateImages : "--"}
+                      </p>
+                    </div>
+                    <div className="rounded-md bg-white p-3 border border-gray-100">
                       <p className="text-xs text-gray-500">Save threshold</p>
                       <p className="text-lg font-semibold">
                         {formatInferenceConfidence(inferenceForm.confidence)}
@@ -2319,6 +2349,50 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
                     </div>
                   </CardContent>
                 </Card>
+
+                {hasReplaceableInferenceDrafts && (
+                  <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+                    <div className="flex items-start gap-3">
+                      <Checkbox
+                        id="replace-draft-detections"
+                        checked={inferenceForm.replaceDraftDetections}
+                        onCheckedChange={(checked) =>
+                          setInferenceForm((prev) => ({
+                            ...prev,
+                            replaceDraftDetections: checked === true,
+                          }))
+                        }
+                      />
+                      <div className="space-y-1">
+                        <Label htmlFor="replace-draft-detections" className="font-semibold">
+                          Replace previous draft detections for this model
+                        </Label>
+                        <p className="text-xs">
+                          This reruns {inferencePreview?.replaceableDuplicateImages || 0} image(s)
+                          with unreviewed draft detections. Accepted, rejected, corrected, or
+                          reviewed detections are kept and will not be overwritten.
+                        </p>
+                        {hasProtectedInferenceReviews && (
+                          <p className="text-xs">
+                            {inferencePreview?.reviewedDuplicateImages || 0} image(s) already have
+                            reviewed decisions and are protected from rerun.
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {inferencePreview &&
+                  inferencePreview.totalImages === 0 &&
+                  hasReplaceableInferenceDrafts &&
+                  !inferenceForm.replaceDraftDetections && (
+                    <div className="rounded-lg border border-orange-200 bg-orange-50 px-3 py-2 text-sm text-orange-800">
+                      Start is unavailable because every eligible image already has draft
+                      detections. Tick the replacement option above to rerun the unreviewed drafts
+                      at the selected confidence.
+                    </div>
+                  )}
 
                 <DialogFooter>
                   <Button variant="outline" onClick={() => setRunInferenceOpen(false)}>
@@ -2819,6 +2893,10 @@ export default function TrainingPage({ workspaceMode = false }: TrainingClientPr
                         onClick={() => {
                           setSelectedInferenceModel(model);
                           setInferencePreview(null);
+                          setInferenceForm((prev) => ({
+                            ...prev,
+                            replaceDraftDetections: false,
+                          }));
                           setRunInferenceOpen(true);
                         }}
                         disabled={

--- a/lib/queue/inference-queue.ts
+++ b/lib/queue/inference-queue.ts
@@ -17,6 +17,7 @@ export interface InferenceJobData {
   inferenceMode?: string;
   inferenceModeLabel?: string;
   saveDetections: boolean;
+  replaceDraftDetections?: boolean;
   backend?: 'local' | 'roboflow' | 'auto';
 }
 
@@ -25,6 +26,7 @@ export interface InferenceJobResult {
   detectionsFound: number;
   skippedImages: number;
   duplicateImages: number;
+  draftDetectionsReplaced: number;
   errors: string[];
 }
 

--- a/lib/services/inference.ts
+++ b/lib/services/inference.ts
@@ -3,6 +3,7 @@
  *
  * Runs model inference for a batch of assets and optionally saves detections.
  */
+import type { Prisma } from '@prisma/client';
 import prisma from '@/lib/db';
 import {
   yoloInferenceService,
@@ -55,6 +56,10 @@ export interface InferenceJobConfig {
   detectionsFound: number;
   skippedImages: number;
   duplicateImages: number;
+  replaceDraftDetections?: boolean;
+  replaceableDuplicateImages?: number;
+  reviewedDuplicateImages?: number;
+  draftDetectionsReplaced?: number;
   skippedReason?: string;
   errors?: string[];
   backend?: InferenceBackend;
@@ -66,6 +71,7 @@ export interface InferenceResult {
   detectionsFound: number;
   skippedImages: number;
   duplicateImages: number;
+  draftDetectionsReplaced: number;
   errors: string[];
   tiling?: InferenceTilingSummary;
 }
@@ -126,9 +132,23 @@ async function updateJobProgress(
     where: { id: jobId },
     data: {
       progress,
-      config,
+      config: config as unknown as Prisma.InputJsonObject,
     },
   });
+}
+
+async function deleteDraftDetectionsForRerun(assetId: string, modelId: string): Promise<number> {
+  const deleted = await prisma.detection.deleteMany({
+    where: {
+      assetId,
+      customModelId: modelId,
+      verified: false,
+      rejected: false,
+      userCorrected: false,
+      reviewedAt: null,
+    },
+  });
+  return deleted.count;
 }
 
 export async function processInferenceJob(options: {
@@ -141,8 +161,11 @@ export async function processInferenceJob(options: {
   inferenceMode?: string;
   inferenceModeLabel?: string;
   saveDetections: boolean;
+  replaceDraftDetections?: boolean;
   skippedImages: number;
   duplicateImages: number;
+  replaceableDuplicateImages?: number;
+  reviewedDuplicateImages?: number;
   skippedReason?: string;
   batchSize?: number;
   backend?: InferenceBackend;
@@ -157,8 +180,11 @@ export async function processInferenceJob(options: {
     inferenceMode,
     inferenceModeLabel,
     saveDetections,
+    replaceDraftDetections = false,
     skippedImages,
     duplicateImages,
+    replaceableDuplicateImages = 0,
+    reviewedDuplicateImages = 0,
     skippedReason,
     batchSize = DEFAULT_BATCH_SIZE,
     backend = 'auto',
@@ -171,6 +197,7 @@ export async function processInferenceJob(options: {
   let tilesProcessed = 0;
   let rawTileDetections = 0;
   let mergedTileDetections = 0;
+  let draftDetectionsReplaced = 0;
   const errors: string[] = [];
 
   await prisma.processingJob.update({
@@ -186,13 +213,17 @@ export async function processInferenceJob(options: {
         inferenceMode,
         inferenceModeLabel,
         saveDetections,
+        replaceDraftDetections,
         totalImages,
         processedImages,
         detectionsFound,
         skippedImages,
         duplicateImages,
+        replaceableDuplicateImages,
+        reviewedDuplicateImages,
+        draftDetectionsReplaced,
         skippedReason,
-      } satisfies InferenceJobConfig,
+      } satisfies InferenceJobConfig as unknown as Prisma.InputJsonObject,
     },
   });
 
@@ -218,6 +249,7 @@ export async function processInferenceJob(options: {
         detectionsFound: 0,
         skippedImages,
         duplicateImages,
+        draftDetectionsReplaced,
         errors: ['GPU lock unavailable for local inference'],
       };
     }
@@ -244,6 +276,7 @@ export async function processInferenceJob(options: {
           detectionsFound: 0,
           skippedImages,
           duplicateImages,
+          draftDetectionsReplaced,
           errors: [`GPU not available: ${gpuResult.message}`],
         };
       }
@@ -264,6 +297,7 @@ export async function processInferenceJob(options: {
         detectionsFound,
         skippedImages,
         duplicateImages,
+        draftDetectionsReplaced,
         errors,
         tiling: buildTilingSummary({
           tiledImages,
@@ -338,7 +372,7 @@ export async function processInferenceJob(options: {
           mergedTileDetections += response.tiling.mergedDetections ?? 0;
         }
 
-        const detectionsToCreate: Array<Record<string, unknown>> = [];
+        const detectionsToCreate: Prisma.DetectionCreateManyInput[] = [];
 
         for (const detection of response.detections || []) {
           if (typeof detection.confidence === 'number' && detection.confidence < confidence) {
@@ -393,17 +427,22 @@ export async function processInferenceJob(options: {
                 geoMethod: resolved.method,
                 backend: response.backend,
                 ...(response.tiling ? { tiling: response.tiling } : {}),
-              },
+              } as unknown as Prisma.InputJsonObject,
               customModelId: modelId,
             });
           }
         }
 
         if (saveDetections && detectionsToCreate.length > 0) {
+          if (replaceDraftDetections) {
+            draftDetectionsReplaced += await deleteDraftDetectionsForRerun(asset.id, modelId);
+          }
           await prisma.detection.createMany({
             data: detectionsToCreate,
           });
           detectionsFound += detectionsToCreate.length;
+        } else if (saveDetections && replaceDraftDetections) {
+          draftDetectionsReplaced += await deleteDraftDetectionsForRerun(asset.id, modelId);
         }
 
         processedImages += 1;
@@ -424,11 +463,15 @@ export async function processInferenceJob(options: {
       inferenceMode,
       inferenceModeLabel,
       saveDetections,
+      replaceDraftDetections,
       totalImages,
       processedImages,
       detectionsFound,
       skippedImages,
       duplicateImages,
+      replaceableDuplicateImages,
+      reviewedDuplicateImages,
+      draftDetectionsReplaced,
       skippedReason,
       errors: errors.slice(0, 10),
       backend: effectiveBackend,
@@ -466,6 +509,7 @@ export async function processInferenceJob(options: {
     detectionsFound,
     skippedImages,
     duplicateImages,
+    draftDetectionsReplaced,
     errors,
     tiling: buildTilingSummary({
       tiledImages,

--- a/workers/inference-worker.ts
+++ b/workers/inference-worker.ts
@@ -32,6 +32,10 @@ async function handleInferenceJob(
   const config = parseConfig(storedJob?.config);
   const skippedImages = Number(config.skippedImages || 0);
   const duplicateImages = Number(config.duplicateImages || 0);
+  const replaceDraftDetections =
+    typeof job.data.replaceDraftDetections === 'boolean'
+      ? job.data.replaceDraftDetections
+      : config.replaceDraftDetections === true;
   const skippedReason = typeof config.skippedReason === 'string' ? config.skippedReason : undefined;
   const backend =
     typeof job.data.backend === 'string'
@@ -60,8 +64,11 @@ async function handleInferenceJob(
           ? config.inferenceModeLabel
           : undefined,
     saveDetections: job.data.saveDetections,
+    replaceDraftDetections,
     skippedImages,
     duplicateImages,
+    replaceableDuplicateImages: Number(config.replaceableDuplicateImages || 0),
+    reviewedDuplicateImages: Number(config.reviewedDuplicateImages || 0),
     skippedReason,
     backend: backend as 'local' | 'roboflow' | 'auto' | undefined,
   });
@@ -73,6 +80,7 @@ async function handleInferenceJob(
     detectionsFound: result.detectionsFound,
     skippedImages: result.skippedImages,
     duplicateImages: result.duplicateImages,
+    draftDetectionsReplaced: result.draftDetectionsReplaced,
     errors: result.errors,
   };
 }


### PR DESCRIPTION
## Summary
- Allow YOLO inference reruns to explicitly replace only unreviewed draft detections for the selected model.
- Preserve accepted, rejected, corrected, or reviewed detections so Manas' review decisions are not overwritten.
- Surface rerun state in the Training UI preview so the Start button explains why it is disabled and how to rerun safely.
- Carry the replacement flag through sync processing and queued worker jobs.

## Root cause
The high-recall mode was deployed, but the app excluded any image that already had detections for the same model. For the 10-image retest project, preview returned `0` eligible images because the earlier 25% run had already written draft detections, so the Start button stayed disabled even after changing confidence to 10%.

## Verification
- `npm run lint -- --file app/api/inference/run/route.ts --file lib/services/inference.ts --file lib/queue/inference-queue.ts --file workers/inference-worker.ts --file components/training/training-client.tsx`
- `npm run test:unit -- tests/unit/yolo-tiling.test.ts tests/unit/pine-sapling-count.test.ts`
- `npm run build`
- Filtered `npx tsc --noEmit --pretty false` output confirms the touched files no longer appear; full repo typecheck still has unrelated existing Next/Prisma errors.
