### PR TITLE
Queue project YOLO inference runs

### DIFF
--- a/app/api/inference/run/route.ts
+++ b/app/api/inference/run/route.ts
@@ -15,7 +15,7 @@ import {
 } from '@/lib/services/yolo';
 import { S3Service } from '@/lib/services/s3';
 
-const MAX_SYNC_IMAGES = 50;
+const DEFAULT_MAX_SYNC_IMAGES = 1;
 const STANDARD_INFERENCE_CONFIDENCE = 0.25;
 const HIGH_RECALL_INFERENCE_CONFIDENCE = 0.1;
 
@@ -25,6 +25,24 @@ function clampConfidence(value: unknown, fallback = STANDARD_INFERENCE_CONFIDENC
   const parsed = typeof value === 'number' ? value : Number(value);
   if (!Number.isFinite(parsed)) return fallback;
   return Math.max(0, Math.min(1, parsed));
+}
+
+function resolveMaxSyncImages(): number {
+  const parsed = Number.parseInt(process.env.YOLO_MAX_SYNC_IMAGES || '', 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_MAX_SYNC_IMAGES;
+}
+
+export function shouldRunInferenceSynchronously(input: {
+  totalImages: number;
+  explicitAssetSelection: boolean;
+  maxSyncImages?: number;
+}): boolean {
+  const maxSyncImages = input.maxSyncImages ?? DEFAULT_MAX_SYNC_IMAGES;
+  return (
+    input.explicitAssetSelection &&
+    input.totalImages > 0 &&
+    input.totalImages <= maxSyncImages
+  );
 }
 
 function resolveInferenceMode(input: {
@@ -385,7 +403,13 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    if (totalImages <= MAX_SYNC_IMAGES) {
+    const runSynchronously = shouldRunInferenceSynchronously({
+      totalImages,
+      explicitAssetSelection: Array.isArray(assetIds),
+      maxSyncImages: resolveMaxSyncImages(),
+    });
+
+    if (runSynchronously) {
       const result = await processInferenceJob({
         jobId: processingJob.id,
         projectId,
@@ -462,7 +486,7 @@ export async function POST(request: NextRequest) {
 
       return NextResponse.json(
         {
-          error: 'Batch too large for synchronous processing. Please select 50 or fewer images.',
+          error: 'Inference queue unavailable. Project-level YOLO runs are processed asynchronously to avoid web request timeouts.',
         },
         { status: 503 }
       );

--- a/tests/unit/inference-run-route.test.ts
+++ b/tests/unit/inference-run-route.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { shouldRunInferenceSynchronously } from '@/app/api/inference/run/route';
+
+describe('inference run route sync policy', () => {
+  it('queues project-level runs even when the project has a small image count', () => {
+    expect(
+      shouldRunInferenceSynchronously({
+        totalImages: 10,
+        explicitAssetSelection: false,
+        maxSyncImages: 50,
+      })
+    ).toBe(false);
+  });
+
+  it('preserves synchronous processing for one explicit asset', () => {
+    expect(
+      shouldRunInferenceSynchronously({
+        totalImages: 1,
+        explicitAssetSelection: true,
+        maxSyncImages: 1,
+      })
+    ).toBe(true);
+  });
+
+  it('queues multi-asset explicit runs by default', () => {
+    expect(
+      shouldRunInferenceSynchronously({
+        totalImages: 2,
+        explicitAssetSelection: true,
+        maxSyncImages: 1,
+      })
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes the AG-3 inference rerun path where a 10-image tiled YOLO project run could exceed the web/load-balancer timeout and return invalid JSON (504).
- Keeps synchronous inference only for one explicitly selected asset, preserving single-image label assist behavior.
- Sends project-level and multi-asset YOLO inference through the existing BullMQ inference worker.

## Verification
- npm run test:unit -- tests/unit/inference-run-route.test.ts
- npm run lint

## Notes
- Production YOLO EC2 host was stopped during investigation; started i-04a662566087d9c4f and verified /health reports healthy with gpu_available=true.