### PR TITLE
Add YOLO EC2 runtime lifecycle guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,12 +20,16 @@ ROBOFLOW_PROJECT="your-project"
 ROBOFLOW_TRAINING_PROJECT="your-training-project"  # Project to push training data to
 
 # Self-hosted YOLO Training Service
-# YOLO_SERVICE_URL is optional when using SAM3 EC2 auto-discovery.
-# If unset, the app uses SAM3_EC2_INSTANCE_ID to discover the host and YOLO_PORT.
+# YOLO_SERVICE_URL/YOLO_INFERENCE_URL are optional when using YOLO EC2 lifecycle management.
+# Prefer YOLO_EC2_INSTANCE_ID in production so stop/start can discover the current public IP.
 YOLO_SERVICE_URL="http://localhost:8001"
 YOLO_INFERENCE_URL="http://localhost:8001"
+YOLO_EC2_INSTANCE_ID=""                # e.g., "i-04a662566087d9c4f"
+YOLO_EC2_REGION="ap-southeast-2"
 YOLO_PORT="8001"
 # YOLO_DISCOVERY_TTL_MS="60000"
+# YOLO_STARTUP_TIMEOUT_MS="300000"
+# YOLO_HEALTH_CHECK_INTERVAL_MS="5000"
 # YOLO_SERVICE_API_KEY=""
 
 # Deployed pine sapling YOLO11n-seg model used by server-side inference/counting.

--- a/app/api/inference/health/route.ts
+++ b/app/api/inference/health/route.ts
@@ -5,33 +5,7 @@
  */
 import { NextResponse } from 'next/server';
 import { getAuthenticatedUser } from '@/lib/auth/api-auth';
-
-function resolveInferenceBaseUrl() {
-  return (
-    process.env.YOLO_INFERENCE_URL ||
-    process.env.SAM3_SERVICE_URL ||
-    process.env.SAM3_API_URL ||
-    null
-  );
-}
-
-async function fetchWithTimeout(url: string, timeoutMs: number = 5000) {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const response = await fetch(url, { signal: controller.signal });
-    const text = await response.text();
-    let data: unknown = text;
-    try {
-      data = JSON.parse(text);
-    } catch {
-      // ignore JSON parse errors, return raw text
-    }
-    return { ok: response.ok, status: response.status, data };
-  } finally {
-    clearTimeout(timeoutId);
-  }
-}
+import { yoloRuntimeService } from '@/lib/services/yolo-runtime';
 
 export async function GET() {
   try {
@@ -40,51 +14,12 @@ export async function GET() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const baseUrl = resolveInferenceBaseUrl();
-    if (!baseUrl) {
-      return NextResponse.json({
-        available: false,
-        error: 'Inference service URL not configured',
-      });
-    }
-
-    // Prefer the YOLO status endpoint
-    try {
-      const statusResponse = await fetchWithTimeout(`${baseUrl.replace(/\/$/, '')}/api/v1/yolo/status`);
-      if (statusResponse.ok) {
-        return NextResponse.json({
-          available: true,
-          status: statusResponse.data,
-        });
-      }
-    } catch (error) {
-      // fall through to health fallback
-      void error;
-    }
-
-    // Fallback to generic health endpoints
-    const healthCandidates = [
-      `${baseUrl.replace(/\/$/, '')}/api/v1/health`,
-      `${baseUrl.replace(/\/$/, '')}/health`,
-    ];
-
-    for (const url of healthCandidates) {
-      try {
-        const response = await fetchWithTimeout(url);
-        if (response.ok) {
-          return NextResponse.json({
-            available: true,
-            health: response.data,
-          });
-        }
-      } catch {
-        // try next candidate
-      }
-    }
+    const runtime = await yoloRuntimeService.getStatus({ refresh: true, checkHealth: true });
 
     return NextResponse.json({
-      available: false,
-      error: 'Inference service unavailable',
+      available: runtime.healthy,
+      runtime,
+      error: runtime.healthy ? null : runtime.lastError || 'Inference service unavailable',
     });
   } catch (error) {
     console.error('Error checking inference health:', error);

--- a/app/api/training/health/route.ts
+++ b/app/api/training/health/route.ts
@@ -5,7 +5,7 @@
  */
 import { NextResponse } from 'next/server';
 import { getAuthenticatedUser } from '@/lib/auth/api-auth';
-import { yoloService } from '@/lib/services/yolo';
+import { yoloRuntimeService } from '@/lib/services/yolo-runtime';
 
 export async function GET() {
   try {
@@ -14,20 +14,12 @@ export async function GET() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    try {
-      const health = await yoloService.checkHealth();
-      const available = health.status === 'healthy';
-      return NextResponse.json({
-        available,
-        health,
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Service unavailable';
-      return NextResponse.json({
-        available: false,
-        error: message,
-      });
-    }
+    const runtime = await yoloRuntimeService.getStatus({ refresh: true, checkHealth: true });
+    return NextResponse.json({
+      available: runtime.healthy,
+      runtime,
+      error: runtime.healthy ? null : runtime.lastError || 'Service unavailable',
+    });
   } catch (error) {
     console.error('Error checking YOLO health:', error);
     return NextResponse.json(

--- a/lib/services/inference.ts
+++ b/lib/services/inference.ts
@@ -14,6 +14,7 @@ import { normalizeDetectionType } from '@/lib/utils/detection-types';
 import { fetchImageSafely } from '@/lib/utils/security';
 import { resolveGeoCoordinates, validateGeoCoordinates } from '@/lib/utils/georeferencing';
 import { sam3Orchestrator } from '@/lib/services/sam3-orchestrator';
+import { yoloRuntimeService, type YOLORuntimeStatus } from '@/lib/services/yolo-runtime';
 import { acquireGpuLock, refreshGpuLock, releaseGpuLock } from '@/lib/services/gpu-lock';
 
 interface InferenceAsset {
@@ -64,6 +65,7 @@ export interface InferenceJobConfig {
   errors?: string[];
   backend?: InferenceBackend;
   tiling?: InferenceTilingSummary;
+  yoloRuntime?: Partial<YOLORuntimeStatus>;
 }
 
 export interface InferenceResult {
@@ -278,6 +280,62 @@ export async function processInferenceJob(options: {
           duplicateImages,
           draftDetectionsReplaced,
           errors: [`GPU not available: ${gpuResult.message}`],
+        };
+      }
+    }
+
+    const runtimeStartingConfig: InferenceJobConfig = {
+      modelId,
+      modelName,
+      confidence,
+      inferenceMode,
+      inferenceModeLabel,
+      saveDetections,
+      replaceDraftDetections,
+      totalImages,
+      processedImages,
+      detectionsFound,
+      skippedImages,
+      duplicateImages,
+      replaceableDuplicateImages,
+      reviewedDuplicateImages,
+      draftDetectionsReplaced,
+      skippedReason,
+      backend: effectiveBackend,
+      yoloRuntime: {
+        state: 'starting',
+        managedInstance: yoloRuntimeService.hasManagedInstance(),
+      },
+    };
+    await updateJobProgress(jobId, runtimeStartingConfig, 0);
+
+    const runtimeResult = await yoloRuntimeService.ensureReady();
+    if (!runtimeResult.ready) {
+      const runtimeError = `YOLO runtime unavailable: ${runtimeResult.lastError || runtimeResult.state}`;
+      if (backend === 'auto') {
+        effectiveBackend = 'roboflow';
+      } else {
+        await prisma.processingJob.update({
+          where: { id: jobId },
+          data: {
+            status: 'FAILED',
+            errorMessage: runtimeError,
+            config: {
+              ...runtimeStartingConfig,
+              yoloRuntime: runtimeResult,
+            } as unknown as Prisma.InputJsonObject,
+          },
+        });
+        if (gpuLock.token) {
+          await releaseGpuLock(gpuLock.token);
+        }
+        return {
+          processedImages: 0,
+          detectionsFound: 0,
+          skippedImages,
+          duplicateImages,
+          draftDetectionsReplaced,
+          errors: [runtimeError],
         };
       }
     }

--- a/lib/services/yolo-inference.ts
+++ b/lib/services/yolo-inference.ts
@@ -1,4 +1,5 @@
 import YOLOService, { yoloService } from '@/lib/services/yolo';
+import { yoloRuntimeService } from '@/lib/services/yolo-runtime';
 import { roboflowService, ROBOFLOW_MODELS, ModelType } from '@/lib/services/roboflow';
 import { fetchImageSafely } from '@/lib/utils/security';
 import {
@@ -45,10 +46,12 @@ export interface DetectionResult {
 }
 
 const inferenceBaseUrl =
-  process.env.YOLO_INFERENCE_URL ||
-  process.env.SAM3_SERVICE_URL ||
-  process.env.SAM3_API_URL ||
-  null;
+  yoloRuntimeService.hasManagedInstance()
+    ? null
+    : process.env.YOLO_INFERENCE_URL ||
+      process.env.SAM3_SERVICE_URL ||
+      process.env.SAM3_API_URL ||
+      null;
 
 const yoloInferenceClient = inferenceBaseUrl
   ? new YOLOService({

--- a/lib/services/yolo-runtime.ts
+++ b/lib/services/yolo-runtime.ts
@@ -1,0 +1,372 @@
+import {
+  EC2Client,
+  DescribeInstancesCommand,
+  StartInstancesCommand,
+} from '@aws-sdk/client-ec2';
+
+type EC2Sender = Pick<EC2Client, 'send'>;
+
+export type YOLORuntimeState =
+  | 'not_configured'
+  | 'stopped'
+  | 'starting'
+  | 'running'
+  | 'ready'
+  | 'stopping'
+  | 'error';
+
+export interface YOLORuntimeStatus {
+  configured: boolean;
+  managedInstance: boolean;
+  instanceId: string | null;
+  state: YOLORuntimeState;
+  ipAddress: string | null;
+  baseUrl: string | null;
+  healthy: boolean;
+  lastError: string | null;
+}
+
+export interface YOLORuntimeReadyResult extends YOLORuntimeStatus {
+  ready: boolean;
+}
+
+interface YOLORuntimeOptions {
+  env?: NodeJS.ProcessEnv;
+  ec2Client?: EC2Sender;
+  fetchFn?: typeof fetch;
+  sleepFn?: (ms: number) => Promise<void>;
+}
+
+const DEFAULT_REGION = 'ap-southeast-2';
+const DEFAULT_PORT = '8001';
+const DEFAULT_DISCOVERY_TTL_MS = 60_000;
+const DEFAULT_STARTUP_TIMEOUT_MS = 300_000;
+const DEFAULT_HEALTH_INTERVAL_MS = 5_000;
+const DEFAULT_HEALTH_TIMEOUT_MS = 5_000;
+
+function normalizeUrl(url: string | undefined | null): string | null {
+  const trimmed = url?.trim();
+  return trimmed ? trimmed.replace(/\/$/, '') : null;
+}
+
+function readPositiveInteger(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(value || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function mapEc2State(state?: string): YOLORuntimeState {
+  switch (state) {
+    case 'pending':
+      return 'starting';
+    case 'running':
+      return 'running';
+    case 'stopping':
+      return 'stopping';
+    case 'shutting-down':
+    case 'terminated':
+    case 'stopped':
+      return 'stopped';
+    default:
+      return 'error';
+  }
+}
+
+function isHealthyPayload(data: unknown): boolean {
+  if (!data || typeof data !== 'object') return false;
+  const payload = data as Record<string, unknown>;
+  return (
+    payload.status === 'healthy' ||
+    payload.status === 'ready' ||
+    payload.ready === true ||
+    payload.available === true
+  );
+}
+
+function responseBodyPreview(data: unknown): string {
+  if (typeof data === 'string') return data.slice(0, 200);
+  try {
+    return JSON.stringify(data).slice(0, 200);
+  } catch {
+    return String(data).slice(0, 200);
+  }
+}
+
+export class YOLORuntimeService {
+  private env: NodeJS.ProcessEnv;
+  private ec2Client: EC2Sender | null = null;
+  private fetchFn: typeof fetch;
+  private sleepFn: (ms: number) => Promise<void>;
+  private instanceId: string | null;
+  private region: string;
+  private port: string;
+  private explicitBaseUrl: string | null;
+  private discoveryTtlMs: number;
+  private startupTimeoutMs: number;
+  private healthIntervalMs: number;
+  private healthTimeoutMs: number;
+  private ipAddress: string | null = null;
+  private state: YOLORuntimeState;
+  private healthy = false;
+  private lastError: string | null = null;
+  private lastDiscoveredAt = 0;
+  private startupPromise: Promise<YOLORuntimeReadyResult> | null = null;
+
+  constructor(options: YOLORuntimeOptions = {}) {
+    this.env = options.env || process.env;
+    this.fetchFn = options.fetchFn || fetch;
+    this.sleepFn = options.sleepFn || ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+    this.instanceId =
+      this.env.YOLO_EC2_INSTANCE_ID ||
+      this.env.YOLO_INSTANCE_ID ||
+      null;
+    this.region =
+      this.env.YOLO_EC2_REGION ||
+      this.env.YOLO_AWS_REGION ||
+      this.env.AWS_REGION ||
+      DEFAULT_REGION;
+    this.port = this.env.YOLO_PORT || DEFAULT_PORT;
+    this.explicitBaseUrl = normalizeUrl(this.env.YOLO_INFERENCE_URL || this.env.YOLO_SERVICE_URL);
+    this.discoveryTtlMs = readPositiveInteger(this.env.YOLO_DISCOVERY_TTL_MS, DEFAULT_DISCOVERY_TTL_MS);
+    this.startupTimeoutMs = readPositiveInteger(this.env.YOLO_STARTUP_TIMEOUT_MS, DEFAULT_STARTUP_TIMEOUT_MS);
+    this.healthIntervalMs = readPositiveInteger(this.env.YOLO_HEALTH_CHECK_INTERVAL_MS, DEFAULT_HEALTH_INTERVAL_MS);
+    this.healthTimeoutMs = readPositiveInteger(this.env.YOLO_HEALTH_TIMEOUT_MS, DEFAULT_HEALTH_TIMEOUT_MS);
+    this.ec2Client = options.ec2Client || null;
+    this.state = this.isConfigured() ? 'stopped' : 'not_configured';
+  }
+
+  isConfigured(): boolean {
+    return Boolean(this.instanceId || this.explicitBaseUrl);
+  }
+
+  hasManagedInstance(): boolean {
+    return Boolean(this.instanceId);
+  }
+
+  getStatusSnapshot(): YOLORuntimeStatus {
+    return {
+      configured: this.isConfigured(),
+      managedInstance: this.hasManagedInstance(),
+      instanceId: this.instanceId,
+      state: this.state,
+      ipAddress: this.ipAddress,
+      baseUrl: this.getCurrentBaseUrl(),
+      healthy: this.healthy,
+      lastError: this.lastError,
+    };
+  }
+
+  async getStatus(options: { refresh?: boolean; checkHealth?: boolean } = {}): Promise<YOLORuntimeStatus> {
+    if (!this.isConfigured()) {
+      this.state = 'not_configured';
+      this.lastError = 'YOLO runtime is not configured';
+      return this.getStatusSnapshot();
+    }
+
+    if (options.refresh || this.shouldRefreshDiscovery()) {
+      await this.refreshEc2Status();
+    }
+
+    if (options.checkHealth) {
+      await this.checkHealth();
+    }
+
+    return this.getStatusSnapshot();
+  }
+
+  async resolveBaseUrl(forceRefresh: boolean = false): Promise<string | null> {
+    if (this.hasManagedInstance()) {
+      if (forceRefresh || this.shouldRefreshDiscovery()) {
+        await this.refreshEc2Status();
+      }
+      if (this.ipAddress) {
+        return `http://${this.ipAddress}:${this.port}`;
+      }
+      return null;
+    }
+
+    return this.explicitBaseUrl;
+  }
+
+  async ensureReady(): Promise<YOLORuntimeReadyResult> {
+    if (!this.isConfigured()) {
+      this.state = 'not_configured';
+      this.lastError = 'YOLO runtime is not configured';
+      return { ...this.getStatusSnapshot(), ready: false };
+    }
+
+    if (this.startupPromise) {
+      return this.startupPromise;
+    }
+
+    this.startupPromise = this.ensureReadyInternal().finally(() => {
+      this.startupPromise = null;
+    });
+    return this.startupPromise;
+  }
+
+  private async ensureReadyInternal(): Promise<YOLORuntimeReadyResult> {
+    await this.getStatus({ refresh: true, checkHealth: true });
+    if (this.healthy) {
+      this.state = 'ready';
+      return { ...this.getStatusSnapshot(), ready: true };
+    }
+
+    if (!this.hasManagedInstance()) {
+      this.lastError = this.lastError || 'YOLO service is unavailable';
+      return { ...this.getStatusSnapshot(), ready: false };
+    }
+
+    if (this.state === 'stopped') {
+      const started = await this.startInstance();
+      if (!started) {
+        return { ...this.getStatusSnapshot(), ready: false };
+      }
+    }
+
+    return this.waitForReady();
+  }
+
+  private async startInstance(): Promise<boolean> {
+    if (!this.instanceId) return false;
+    const client = this.getEc2Client();
+    if (!client) {
+      this.lastError = 'AWS EC2 client is not available for YOLO runtime';
+      this.state = 'error';
+      return false;
+    }
+
+    try {
+      console.log(`[YOLO-Runtime] Requesting EC2 start for ${this.instanceId}`);
+      this.state = 'starting';
+      await client.send(new StartInstancesCommand({ InstanceIds: [this.instanceId] }));
+      this.lastError = null;
+      return true;
+    } catch (error) {
+      this.state = 'error';
+      this.lastError = error instanceof Error ? error.message : 'Failed to start YOLO EC2 instance';
+      console.error('[YOLO-Runtime] Failed to start EC2 instance:', error);
+      return false;
+    }
+  }
+
+  private async waitForReady(): Promise<YOLORuntimeReadyResult> {
+    const startedAt = Date.now();
+
+    while (Date.now() - startedAt < this.startupTimeoutMs) {
+      await this.sleepFn(this.healthIntervalMs);
+      await this.getStatus({ refresh: true, checkHealth: true });
+      if (this.healthy) {
+        this.state = 'ready';
+        this.lastError = null;
+        return { ...this.getStatusSnapshot(), ready: true };
+      }
+    }
+
+    this.state = 'error';
+    this.lastError = `Timed out waiting for YOLO runtime after ${this.startupTimeoutMs}ms`;
+    return { ...this.getStatusSnapshot(), ready: false };
+  }
+
+  private shouldRefreshDiscovery(): boolean {
+    if (!this.hasManagedInstance()) return false;
+    if (!this.ipAddress) return true;
+    return Date.now() - this.lastDiscoveredAt > this.discoveryTtlMs;
+  }
+
+  private getCurrentBaseUrl(): string | null {
+    if (this.hasManagedInstance() && this.ipAddress) {
+      return `http://${this.ipAddress}:${this.port}`;
+    }
+    if (this.hasManagedInstance()) {
+      return null;
+    }
+    return this.explicitBaseUrl;
+  }
+
+  private getEc2Client(): EC2Sender | null {
+    if (!this.instanceId) return null;
+    if (!this.ec2Client) {
+      this.ec2Client = new EC2Client({ region: this.region });
+    }
+    return this.ec2Client;
+  }
+
+  private async refreshEc2Status(): Promise<void> {
+    if (!this.instanceId) return;
+    const client = this.getEc2Client();
+    if (!client) return;
+
+    try {
+      const response = await client.send(
+        new DescribeInstancesCommand({ InstanceIds: [this.instanceId] })
+      );
+      const instance = response.Reservations?.[0]?.Instances?.[0];
+      if (!instance) {
+        this.state = 'error';
+        this.ipAddress = null;
+        this.healthy = false;
+        this.lastError = `YOLO EC2 instance ${this.instanceId} was not found`;
+        return;
+      }
+
+      this.ipAddress = instance.PublicIpAddress || null;
+      this.state = mapEc2State(instance.State?.Name);
+      this.lastDiscoveredAt = Date.now();
+      if (this.state !== 'running' && this.state !== 'ready') {
+        this.healthy = false;
+      }
+      this.lastError = null;
+    } catch (error) {
+      this.state = 'error';
+      this.healthy = false;
+      this.lastError = error instanceof Error ? error.message : 'Failed to describe YOLO EC2 instance';
+      console.error('[YOLO-Runtime] Failed to refresh EC2 status:', error);
+    }
+  }
+
+  private async checkHealth(): Promise<boolean> {
+    const baseUrl = this.getCurrentBaseUrl();
+    if (!baseUrl) {
+      this.healthy = false;
+      if (!this.lastError) {
+        this.lastError = 'YOLO runtime base URL is unavailable';
+      }
+      return false;
+    }
+
+    const endpoints = ['/health', '/api/v1/health', '/api/v1/yolo/status'];
+    for (const endpoint of endpoints) {
+      try {
+        const response = await this.fetchFn(`${baseUrl}${endpoint}`, {
+          signal: AbortSignal.timeout(this.healthTimeoutMs),
+        });
+        const text = await response.text();
+        let data: unknown = text;
+        try {
+          data = text ? JSON.parse(text) : {};
+        } catch {
+          // Keep text for diagnostics.
+        }
+
+        if (response.ok && isHealthyPayload(data)) {
+          this.healthy = true;
+          this.state = 'ready';
+          this.lastError = null;
+          return true;
+        }
+
+        this.lastError = `YOLO health ${endpoint} returned ${response.status}: ${responseBodyPreview(data)}`;
+      } catch (error) {
+        this.lastError = error instanceof Error ? error.message : 'YOLO health check failed';
+      }
+    }
+
+    this.healthy = false;
+    if (this.state === 'ready') {
+      this.state = 'running';
+    }
+    return false;
+  }
+}
+
+export const yoloRuntimeService = new YOLORuntimeService();

--- a/lib/services/yolo.ts
+++ b/lib/services/yolo.ts
@@ -4,6 +4,7 @@
  * TypeScript client for the EC2-hosted YOLO training and inference service.
  */
 import { awsSam3Service } from '@/lib/services/aws-sam3';
+import { yoloRuntimeService } from '@/lib/services/yolo-runtime';
 
 const YOLO_PORT = process.env.YOLO_PORT || '8001';
 const YOLO_DISCOVERY_TTL_MS = Number.parseInt(
@@ -132,7 +133,10 @@ export class YOLOService {
   private detectEndpoint: '/api/v1/yolo/detect' | '/api/v1/detect' | null = null;
 
   constructor(options?: { baseUrl?: string; timeout?: number; apiKey?: string }) {
-    const configuredUrl = options?.baseUrl || process.env.YOLO_SERVICE_URL || null;
+    const configuredUrl =
+      options?.baseUrl ||
+      (yoloRuntimeService.hasManagedInstance() ? null : process.env.YOLO_SERVICE_URL) ||
+      null;
     this.explicitBaseUrl = configuredUrl ? configuredUrl.replace(/\/$/, '') : null;
     this.timeout = options?.timeout || 30000;
     this.apiKey = options?.apiKey || process.env.YOLO_SERVICE_API_KEY;
@@ -163,6 +167,14 @@ export class YOLOService {
   }
 
   private async resolveBaseUrlInternal(): Promise<string | null> {
+    const yoloRuntimeBaseUrl = await yoloRuntimeService.resolveBaseUrl(true);
+    if (yoloRuntimeBaseUrl) {
+      this.cachedBaseUrl = yoloRuntimeBaseUrl;
+      this.lastResolvedAt = Date.now();
+      this.lastResolveError = null;
+      return yoloRuntimeBaseUrl;
+    }
+
     if (!awsSam3Service.isConfigured()) {
       const configError = awsSam3Service.getConfigError();
       this.lastResolveError = configError
@@ -321,6 +333,8 @@ export class YOLOService {
   }
 
   async startTraining(config: TrainingConfig): Promise<TrainingJobResponse> {
+    await this.ensureManagedRuntimeReady('YOLO training');
+
     const basePayload: Record<string, unknown> = {
       dataset_s3_path: config.dataset_s3_path,
       model_name: config.model_name,
@@ -388,6 +402,8 @@ export class YOLOService {
   }
 
   async detect(request: DetectionRequest): Promise<DetectionResponse> {
+    await this.ensureManagedRuntimeReady('YOLO inference');
+
     if (!request.image && !request.s3_path) {
       throw new YOLOServiceError('Either image (base64) or s3_path must be provided');
     }
@@ -471,6 +487,19 @@ export class YOLOService {
 
   async listModels(): Promise<ModelListResponse> {
     return this.request<ModelListResponse>('/api/v1/models');
+  }
+
+  private async ensureManagedRuntimeReady(operation: string): Promise<void> {
+    if (this.explicitBaseUrl || !yoloRuntimeService.hasManagedInstance()) return;
+
+    const runtime = await yoloRuntimeService.ensureReady();
+    if (!runtime.ready) {
+      throw new YOLOServiceError(
+        `${operation} runtime unavailable: ${runtime.lastError || runtime.state}`,
+        503,
+        runtime
+      );
+    }
   }
 
   async listCachedModels(): Promise<{ models?: string[]; cached_models?: string[] }> {

--- a/tests/unit/yolo-runtime.test.ts
+++ b/tests/unit/yolo-runtime.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from 'vitest';
+import { StartInstancesCommand } from '@aws-sdk/client-ec2';
+import { YOLORuntimeService } from '@/lib/services/yolo-runtime';
+
+function describeResponse(state: string, ip?: string) {
+  return {
+    Reservations: [
+      {
+        Instances: [
+          {
+            State: { Name: state },
+            PublicIpAddress: ip,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe('YOLO runtime lifecycle', () => {
+  it('does not start EC2 during passive status checks', async () => {
+    const sent: unknown[] = [];
+    const ec2Client = {
+      send: vi.fn(async (command: unknown) => {
+        sent.push(command);
+        return describeResponse('stopped');
+      }),
+    };
+
+    const service = new YOLORuntimeService({
+      env: {
+        YOLO_EC2_INSTANCE_ID: 'i-yolo',
+        YOLO_EC2_REGION: 'ap-southeast-2',
+      } as unknown as NodeJS.ProcessEnv,
+      ec2Client,
+      fetchFn: vi.fn() as unknown as typeof fetch,
+      sleepFn: async () => {},
+    });
+
+    const status = await service.getStatus({ refresh: true, checkHealth: true });
+
+    expect(status.state).toBe('stopped');
+    expect(status.healthy).toBe(false);
+    expect(sent.some((command) => command instanceof StartInstancesCommand)).toBe(false);
+  });
+
+  it('starts a stopped managed EC2 instance and waits for YOLO health', async () => {
+    const sent: unknown[] = [];
+    const describeStates = [
+      describeResponse('stopped'),
+      describeResponse('pending'),
+      describeResponse('running', '13.54.121.111'),
+    ];
+    const ec2Client = {
+      send: vi.fn(async (command: unknown) => {
+        sent.push(command);
+        if (command instanceof StartInstancesCommand) {
+          return {};
+        }
+        return describeStates.shift() || describeResponse('running', '13.54.121.111');
+      }),
+    };
+    const fetchFn = vi.fn(async () => (
+      new Response(
+        JSON.stringify({
+          status: 'healthy',
+          gpu_available: true,
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    )) as unknown as typeof fetch;
+
+    const service = new YOLORuntimeService({
+      env: {
+        YOLO_EC2_INSTANCE_ID: 'i-yolo',
+        YOLO_EC2_REGION: 'ap-southeast-2',
+        YOLO_PORT: '8001',
+        YOLO_STARTUP_TIMEOUT_MS: '30000',
+      } as unknown as NodeJS.ProcessEnv,
+      ec2Client,
+      fetchFn,
+      sleepFn: async () => {},
+    });
+
+    const result = await service.ensureReady();
+
+    expect(result.ready).toBe(true);
+    expect(result.state).toBe('ready');
+    expect(result.baseUrl).toBe('http://13.54.121.111:8001');
+    expect(sent.some((command) => command instanceof StartInstancesCommand)).toBe(true);
+    expect(fetchFn).toHaveBeenCalledWith(
+      'http://13.54.121.111:8001/health',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+
+  it('checks an explicit URL without attempting EC2 lifecycle actions', async () => {
+    const fetchFn = vi.fn(async () => (
+      new Response(JSON.stringify({ status: 'healthy' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    )) as unknown as typeof fetch;
+
+    const service = new YOLORuntimeService({
+      env: {
+        YOLO_SERVICE_URL: 'http://localhost:8001/',
+      } as unknown as NodeJS.ProcessEnv,
+      fetchFn,
+      sleepFn: async () => {},
+    });
+
+    const result = await service.ensureReady();
+
+    expect(result.ready).toBe(true);
+    expect(result.managedInstance).toBe(false);
+    expect(result.baseUrl).toBe('http://localhost:8001');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a dedicated YOLO runtime lifecycle service for EC2 discovery, start, and health waiting.
- Route YOLO inference/training clients through dynamic EC2 discovery when YOLO_EC2_INSTANCE_ID is configured, avoiding stale hardcoded public IPs after stop/start.
- Update inference/training health endpoints to report runtime state without starting EC2 on passive checks.
- Make queued local YOLO inference wait for the runtime before processing, with clear job failure metadata if startup fails.

## Production env required
- Set YOLO_EC2_INSTANCE_ID=i-04a662566087d9c4f
- Set YOLO_EC2_REGION=ap-southeast-2
- Keep YOLO_PORT=8001

## Verification
- npm run test:unit -- tests/unit/yolo-runtime.test.ts tests/unit/yolo-training-service.test.ts tests/unit/inference-run-route.test.ts
- npm run lint
- npm run build

## Notes
- Passive health checks do not start EC2; active inference/training calls do.
- npx tsc --noEmit still fails on existing repo baseline issues unrelated to this change.