### PR TITLE
Fix AG-3 DINO export for unlinked YOLO detections

### DIFF
--- a/scripts/ag3-dino-export.ts
+++ b/scripts/ag3-dino-export.ts
@@ -537,40 +537,58 @@ async function exportActualBundle(options: CliOptions): Promise<ExportBundle> {
 
   const inferenceJobIds = toStringArray(session.inferenceJobIds);
   const batchJobIds = toStringArray(session.batchJobIds);
+  const exportAssetIds = assets.map((asset) => asset.id);
 
-  const detectionRows = await prisma.detection.findMany({
-    where: {
-      assetId: { in: assets.map((asset) => asset.id) },
-      OR: [
-        ...(inferenceJobIds.length > 0
-          ? [{ inferenceJobId: { in: inferenceJobIds } }]
-          : [
-              { customModelId: PINE_MODEL_ID },
-              { createdAt: { gte: session.createdAt }, type: 'YOLO_LOCAL' as const },
-            ]),
-      ],
-    },
-    select: {
-      id: true,
-      assetId: true,
-      type: true,
-      className: true,
-      confidence: true,
-      boundingBox: true,
-      preprocessingMeta: true,
-      verified: true,
-      rejected: true,
-      userCorrected: true,
-      customModelId: true,
-      inferenceJobId: true,
-      metadata: true,
-    },
-  });
+  const detectionSelect = {
+    id: true,
+    assetId: true,
+    type: true,
+    className: true,
+    confidence: true,
+    boundingBox: true,
+    preprocessingMeta: true,
+    verified: true,
+    rejected: true,
+    userCorrected: true,
+    customModelId: true,
+    inferenceJobId: true,
+    metadata: true,
+  } as const;
+
+  const linkedDetectionRows = inferenceJobIds.length > 0
+    ? await prisma.detection.findMany({
+        where: {
+          assetId: { in: exportAssetIds },
+          inferenceJobId: { in: inferenceJobIds },
+        },
+        select: detectionSelect,
+      })
+    : [];
+
+  const detectionRows = linkedDetectionRows.length > 0
+    ? linkedDetectionRows
+    : await prisma.detection.findMany({
+        where: {
+          assetId: { in: exportAssetIds },
+          OR: [
+            { customModelId: PINE_MODEL_ID },
+            { createdAt: { gte: session.createdAt }, type: 'YOLO_LOCAL' as const },
+          ],
+        },
+        select: detectionSelect,
+      });
+
+  if (inferenceJobIds.length > 0 && linkedDetectionRows.length === 0 && detectionRows.length > 0) {
+    console.warn(
+      `No detections were linked to inference job(s) ${inferenceJobIds.join(', ')}; ` +
+      `exporting ${detectionRows.length} model detections from the same asset set instead.`
+    );
+  }
 
   const pendingRows = batchJobIds.length > 0
     ? await prisma.pendingAnnotation.findMany({
         where: {
-          assetId: { in: assets.map((asset) => asset.id) },
+          assetId: { in: exportAssetIds },
           batchJobId: { in: batchJobIds },
         },
         select: {


### PR DESCRIPTION
## Summary
- Fall back to pine YOLO model detections on the review-session assets when detections are not linked by inferenceJobId
- Reuse the detection select shape for linked and fallback exports
- Keep pending-annotation export behavior unchanged

## Verification
- git diff --check
- npm run ag3:dino-export -- --sample --out /tmp/ag3-dino-sample-fallback-check
- npm run ag3:dino-export -- --sessionId cmq1z6x920003kx3r8mw6j2kz --limit 10 --no-images --out /tmp/ag3-dino-hqp-10-cmq1z-dry
- npm run lint

## Notes
The latest HQP 10-image review session had 1,095 pine YOLO detections stored with customModelId=cmpp43ahk0001n5wgzn77vjrf and inferenceJobId=null, so the first exporter pass produced an empty bundle until this fallback was added.