### PR TITLE
Make dense review overlay selection-safe

### DIFF
--- a/app/api/review/[sessionId]/action/route.ts
+++ b/app/api/review/[sessionId]/action/route.ts
@@ -3,7 +3,7 @@ import prisma from '@/lib/db';
 import { getAuthenticatedUser } from '@/lib/auth/api-auth';
 import { normalizeDetectionType } from '@/lib/utils/detection-types';
 
-type ReviewAction = 'accept' | 'reject' | 'correct' | 'edit';
+type ReviewAction = 'accept' | 'reject' | 'correct' | 'edit' | 'restore';
 type ReviewSource = 'manual' | 'pending' | 'detection';
 
 function confidenceToEnum(confidence: number): 'CERTAIN' | 'LIKELY' | 'UNCERTAIN' {
@@ -197,7 +197,17 @@ export async function POST(
             ? 'rejected'
             : 'pending';
 
-        if (action === 'reject') {
+        if (action === 'restore') {
+          nextStatus = 'pending';
+          await tx.manualAnnotation.update({
+            where: { id: itemId },
+            data: {
+              verified: false,
+              verifiedAt: null,
+              verifiedBy: null,
+            },
+          });
+        } else if (action === 'reject') {
           nextStatus = 'rejected';
           await tx.manualAnnotation.update({
             where: { id: itemId },
@@ -233,7 +243,18 @@ export async function POST(
               ? 'rejected'
               : 'pending';
 
-        if (action === 'reject') {
+        if (action === 'restore') {
+          nextStatus = 'pending';
+          await tx.pendingAnnotation.update({
+            where: { id: itemId },
+            data: {
+              status: 'PENDING',
+              reviewedAt: null,
+              reviewedBy: null,
+              rejectionReason: null,
+            },
+          });
+        } else if (action === 'reject') {
           nextStatus = 'rejected';
           await tx.pendingAnnotation.update({
             where: { id: itemId },
@@ -318,7 +339,19 @@ export async function POST(
             ? 'accepted'
             : 'pending';
 
-        if (action === 'reject') {
+        if (action === 'restore') {
+          nextStatus = 'pending';
+          await tx.detection.update({
+            where: { id: itemId },
+            data: {
+              rejected: false,
+              verified: false,
+              userCorrected: false,
+              reviewedAt: null,
+              reviewedBy: null,
+            },
+          });
+        } else if (action === 'reject') {
           nextStatus = 'rejected';
           await tx.detection.update({
             where: { id: itemId },
@@ -361,14 +394,34 @@ export async function POST(
         }
       }
 
-      if (prevStatus === 'pending' && nextStatus !== 'pending') {
+      if (prevStatus !== nextStatus) {
+        const data: {
+          itemsReviewed?: { increment: number };
+          itemsAccepted?: { increment: number };
+          itemsRejected?: { increment: number };
+        } = {};
+
+        if (prevStatus === 'pending' && nextStatus !== 'pending') {
+          data.itemsReviewed = { increment: 1 };
+        } else if (prevStatus !== 'pending' && nextStatus === 'pending') {
+          data.itemsReviewed = { increment: -1 };
+        }
+
+        if (prevStatus !== 'accepted' && nextStatus === 'accepted') {
+          data.itemsAccepted = { increment: 1 };
+        } else if (prevStatus === 'accepted' && nextStatus !== 'accepted') {
+          data.itemsAccepted = { increment: -1 };
+        }
+
+        if (prevStatus !== 'rejected' && nextStatus === 'rejected') {
+          data.itemsRejected = { increment: 1 };
+        } else if (prevStatus === 'rejected' && nextStatus !== 'rejected') {
+          data.itemsRejected = { increment: -1 };
+        }
+
         await tx.reviewSession.update({
           where: { id: params.sessionId },
-          data: {
-            itemsReviewed: { increment: 1 },
-            ...(nextStatus === 'accepted' ? { itemsAccepted: { increment: 1 } } : {}),
-            ...(nextStatus === 'rejected' ? { itemsRejected: { increment: 1 } } : {}),
-          },
+          data,
         });
       }
 

--- a/app/review/page.tsx
+++ b/app/review/page.tsx
@@ -235,7 +235,11 @@ function ReviewPageContent() {
   );
 
   const handleAction = useCallback(
-    async (item: ReviewItem, action: 'accept' | 'reject' | 'correct', correctedClass?: string) => {
+    async (
+      item: ReviewItem,
+      action: 'accept' | 'reject' | 'correct' | 'restore',
+      correctedClass?: string
+    ) => {
       if (!sessionId) return;
       setActionLoading(true);
       setActionError(null);

--- a/components/review/ReviewViewer.tsx
+++ b/components/review/ReviewViewer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 import {
   AlertTriangle,
@@ -73,7 +73,7 @@ export interface ReviewItem {
 interface ReviewViewerProps {
   items: ReviewItem[];
   assets?: ReviewItemAsset[];
-  onAction: (item: ReviewItem, action: 'accept' | 'reject' | 'correct', correctedClass?: string) => Promise<void>;
+  onAction: (item: ReviewItem, action: 'accept' | 'reject' | 'correct' | 'restore', correctedClass?: string) => Promise<void>;
   onEdit: (item: ReviewItem) => void;
 }
 
@@ -97,6 +97,8 @@ export function ReviewViewer({ items, assets = [], onAction, onEdit }: ReviewVie
   const [zoomLevel, setZoomLevel] = useState(1);
   const [panOffset, setPanOffset] = useState({ x: 0, y: 0 });
   const [viewMode, setViewMode] = useState<'image' | 'map'>('image');
+  const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
+  const reviewItemRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
   useEffect(() => {
     if (currentIndex >= groupedAssets.length) {
@@ -110,7 +112,16 @@ export function ReviewViewer({ items, assets = [], onAction, onEdit }: ReviewVie
   useEffect(() => {
     setZoomLevel(1);
     setPanOffset({ x: 0, y: 0 });
+    setSelectedItemId(null);
   }, [currentGroup?.asset.id]);
+
+  useEffect(() => {
+    if (!selectedItemId) return;
+    reviewItemRefs.current[selectedItemId]?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'center',
+    });
+  }, [selectedItemId]);
 
   const handleZoomIn = () => setZoomLevel((prev) => Math.min(prev * 1.2, 5));
   const handleZoomOut = () => setZoomLevel((prev) => Math.max(prev / 1.2, 0.1));
@@ -193,14 +204,8 @@ export function ReviewViewer({ items, assets = [], onAction, onEdit }: ReviewVie
             <InteractiveDetectionOverlay
               imageUrl={currentGroup.asset.storageUrl}
               detections={overlayItems}
-              onAccept={(id) => {
-                const item = currentItems.find((entry) => entry.id === id);
-                if (item) onAction(item, 'accept');
-              }}
-              onReject={(id) => {
-                const item = currentItems.find((entry) => entry.id === id);
-                if (item) onAction(item, 'reject');
-              }}
+              selectedDetectionId={selectedItemId}
+              onSelectDetection={setSelectedItemId}
               imageWidth={currentGroup.asset.imageWidth || undefined}
               imageHeight={currentGroup.asset.imageHeight || undefined}
               zoomLevel={zoomLevel}
@@ -278,12 +283,29 @@ export function ReviewViewer({ items, assets = [], onAction, onEdit }: ReviewVie
           <div className="space-y-2">
             {currentItems.map((item) => {
               const warningText = item.warnings.join('; ');
+              const isSelected = selectedItemId === item.id;
               return (
-                <div key={item.id} className="rounded-lg border border-gray-200 bg-white p-3">
+                <div
+                  key={item.id}
+                  ref={(element) => {
+                    reviewItemRefs.current[item.id] = element;
+                  }}
+                  onClick={() => setSelectedItemId(item.id)}
+                  className={`rounded-lg border bg-white p-3 transition ${
+                    isSelected ? 'border-blue-500 shadow-sm ring-2 ring-blue-100' : 'border-gray-200'
+                  }`}
+                >
                   <div className="flex items-start justify-between gap-2">
                     <div className="min-w-0">
-                      <div className="truncate text-sm font-semibold text-gray-900" title={item.className}>
-                        {item.className}
+                      <div className="flex items-center gap-2">
+                        <div className="truncate text-sm font-semibold text-gray-900" title={item.className}>
+                          {item.className}
+                        </div>
+                        {isSelected && (
+                          <span className="rounded-full bg-blue-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-blue-700">
+                            Selected
+                          </span>
+                        )}
                       </div>
                       <div className="truncate text-xs text-gray-500" title={`${Math.round(item.confidence * 100)}% confidence · ${item.source}`}>
                         {Math.round(item.confidence * 100)}% confidence · {item.source}
@@ -328,14 +350,25 @@ export function ReviewViewer({ items, assets = [], onAction, onEdit }: ReviewVie
                       >
                         Accept
                       </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => onAction(item, 'reject')}
-                        className="h-8 px-2 text-xs"
-                      >
-                        Reject
-                      </Button>
+                      {item.status === 'rejected' ? (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => onAction(item, 'restore')}
+                          className="h-8 px-2 text-xs"
+                        >
+                          Restore
+                        </Button>
+                      ) : (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => onAction(item, 'reject')}
+                          className="h-8 px-2 text-xs"
+                        >
+                          Reject
+                        </Button>
+                      )}
                       <Button
                         variant="outline"
                         size="sm"

--- a/components/training/InteractiveDetectionOverlay.tsx
+++ b/components/training/InteractiveDetectionOverlay.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
-import { Check, X } from 'lucide-react';
 
 interface Detection {
   id: string;
@@ -15,8 +14,8 @@ interface Detection {
 interface InteractiveDetectionOverlayProps {
   imageUrl: string;
   detections: Detection[];
-  onAccept: (id: string) => void;
-  onReject: (id: string) => void;
+  selectedDetectionId?: string | null;
+  onSelectDetection?: (id: string) => void;
   imageWidth?: number;
   imageHeight?: number;
   zoomLevel?: number;
@@ -27,8 +26,8 @@ interface InteractiveDetectionOverlayProps {
 export function InteractiveDetectionOverlay({
   imageUrl,
   detections,
-  onAccept,
-  onReject,
+  selectedDetectionId,
+  onSelectDetection,
   imageWidth = 4000, // Default DJI image width
   imageHeight = 3000, // Default DJI image height
   zoomLevel = 1,
@@ -67,24 +66,6 @@ export function InteractiveDetectionOverlay({
     return () => observer.disconnect();
   }, [imageLoaded, actualImageSize.width, actualImageSize.height]);
 
-  // Handle keyboard shortcuts
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (!hoveredId) return;
-
-      if (e.key === 'a' || e.key === 'A') {
-        e.preventDefault();
-        onAccept(hoveredId);
-      } else if (e.key === 'd' || e.key === 'D' || e.key === 'Delete' || e.key === 'Backspace') {
-        e.preventDefault();
-        onReject(hoveredId);
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [hoveredId, onAccept, onReject]);
-
   const scale = containerSize.width > 0 ? containerSize.width / actualImageSize.width : 1;
   const scaledWidth = actualImageSize.width * scale;
   const scaledHeight = actualImageSize.height * scale;
@@ -106,7 +87,10 @@ export function InteractiveDetectionOverlay({
     };
   };
 
-  const getStatusColor = (status: string, isHovered: boolean) => {
+  const getStatusColor = (status: string, isHovered: boolean, isSelected: boolean) => {
+    if (isSelected) {
+      return { stroke: '#2563eb', fill: 'rgba(37, 99, 235, 0.18)' };
+    }
     switch (status) {
       case 'ACCEPTED':
         return { stroke: '#22c55e', fill: 'rgba(34, 197, 94, 0.2)' };
@@ -200,14 +184,15 @@ export function InteractiveDetectionOverlay({
             {detections.map((detection) => {
               const box = scaleBox(detection.bbox);
               const isHovered = hoveredId === detection.id;
-              const colors = getStatusColor(detection.status, isHovered);
-              const isPending = detection.status === 'PENDING';
+              const isSelected = selectedDetectionId === detection.id;
+              const colors = getStatusColor(detection.status, isHovered, isSelected);
 
               return (
                 <g
                   key={detection.id}
                   onMouseEnter={() => setHoveredId(detection.id)}
                   onMouseLeave={() => setHoveredId(null)}
+                  onClick={() => onSelectDetection?.(detection.id)}
                   className="pointer-events-auto cursor-pointer"
                 >
                   {/* Detection Box */}
@@ -218,12 +203,25 @@ export function InteractiveDetectionOverlay({
                     height={box.height}
                     fill={colors.fill}
                     stroke={colors.stroke}
-                    strokeWidth={isHovered ? 3 : 2}
+                    strokeWidth={isSelected ? 4 : isHovered ? 3 : 2}
                     className="transition-all"
                     style={{
                       opacity: detection.status === 'REJECTED' ? 0.5 : 1,
                     }}
                   />
+                  {isSelected && (
+                    <rect
+                      x={Math.max(0, box.x - 3)}
+                      y={Math.max(0, box.y - 3)}
+                      width={box.width + 6}
+                      height={box.height + 6}
+                      fill="none"
+                      stroke="#2563eb"
+                      strokeWidth="2"
+                      strokeDasharray="6 4"
+                      className="pointer-events-none"
+                    />
+                  )}
 
                   {/* Status Icon for accepted/rejected */}
                   {detection.status === 'ACCEPTED' && (
@@ -260,42 +258,8 @@ export function InteractiveDetectionOverlay({
                     </text>
                   </g>
 
-                  {/* Hover Action Buttons - Only for pending */}
-                  {isHovered && isPending && (
-                    <foreignObject
-                      x={box.x + box.width / 2 - 50}
-                      y={box.y + box.height / 2 - 18}
-                      width="100"
-                      height="36"
-                      className="pointer-events-auto"
-                    >
-                      <div className="flex items-center justify-center gap-2">
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onAccept(detection.id);
-                          }}
-                          className="w-10 h-10 rounded-full bg-green-500 hover:bg-green-600 text-white flex items-center justify-center shadow-lg transition-transform hover:scale-110"
-                          title="Accept (A)"
-                        >
-                          <Check className="w-5 h-5" />
-                        </button>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onReject(detection.id);
-                          }}
-                          className="w-10 h-10 rounded-full bg-red-500 hover:bg-red-600 text-white flex items-center justify-center shadow-lg transition-transform hover:scale-110"
-                          title="Reject (D)"
-                        >
-                          <X className="w-5 h-5" />
-                        </button>
-                      </div>
-                    </foreignObject>
-                  )}
-
                   {/* Weed Type Label on Hover */}
-                  {isHovered && (
+                  {(isHovered || isSelected) && (
                     <g transform={`translate(${box.x}, ${box.y - 24})`}>
                       <rect
                         width={Math.max(detection.weedType.length * 8 + 16, 80)}
@@ -321,11 +285,15 @@ export function InteractiveDetectionOverlay({
       </div>
 
       {/* Keyboard Shortcut Hint */}
-      {hoveredId && (
+      {selectedDetectionId ? (
         <div className="absolute bottom-2 left-2 bg-black/70 text-white text-xs px-2 py-1 rounded">
-          Press <kbd className="bg-gray-600 px-1 rounded">A</kbd> to accept, <kbd className="bg-gray-600 px-1 rounded">D</kbd> to reject
+          Selected detection. Use the Review Items panel to accept, reject, correct, or restore it.
         </div>
-      )}
+      ) : hoveredId ? (
+        <div className="absolute bottom-2 left-2 bg-black/70 text-white text-xs px-2 py-1 rounded">
+          Click a box to select it. Review actions are in the side panel.
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- removes inline Accept/Reject hover controls from the image overlay so dense sapling boxes cannot be actioned accidentally
- adds explicit selected-detection state between the image and Review Items panel
- adds a restore review action so mistaken rejects can be returned to pending without rerunning inference

## Verification
- npm run lint
- npm run build

## Notes
- This is a review UX safety patch only. It does not change inference, thresholds, exports, training, or detection persistence except for the new explicit restore action.