### PR TITLE
Fix AG-3 dense review edit blockers

### DIFF
--- a/app/annotate/[assetId]/AnnotateClient.tsx
+++ b/app/annotate/[assetId]/AnnotateClient.tsx
@@ -191,6 +191,7 @@ export function AnnotateClient({ assetId }: AnnotateClientProps) {
   const highlightId = searchParams.get("highlightId");
   const highlightSource = searchParams.get("source");
   const returnToParam = searchParams.get("returnTo");
+  const focusReviewItem = searchParams.get("focusReviewItem") !== "0";
   const returnTo = useMemo(() => {
     if (!returnToParam) return null;
     let decoded = returnToParam;
@@ -220,6 +221,7 @@ export function AnnotateClient({ assetId }: AnnotateClientProps) {
       returnTo,
     };
   }, [highlightId, highlightSource, reviewSessionId, returnTo]);
+  const reviewEditFocusMode = Boolean(editContext && focusReviewItem);
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const canvasContainerRef = useRef<HTMLDivElement>(null);
@@ -1698,7 +1700,7 @@ export function AnnotateClient({ assetId }: AnnotateClientProps) {
     ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
 
     // AI suggestions
-    if (showAiSuggestions) {
+    if (showAiSuggestions && !reviewEditFocusMode) {
       aiSuggestions.filter(s => s.boundingBox && !s.rejected).forEach((suggestion) => {
         const color = suggestion.color || '#0ea5e9';
         const bbox = suggestion.boundingBox!;
@@ -1745,8 +1747,17 @@ export function AnnotateClient({ assetId }: AnnotateClientProps) {
       ctx.setLineDash([]);
     }
 
-    // Existing annotations
-    annotations.forEach((annotation) => {
+    // Existing annotations. Review edit mode intentionally isolates the selected
+    // item so dense detections cannot hide the geometry being corrected.
+    const visibleAnnotations = reviewEditFocusMode
+      ? annotations.filter((annotation) =>
+          annotation.id === editContext?.originalItemId ||
+          annotation.id === selectedAnnotation ||
+          annotation.id === editingAnnotationId
+        )
+      : annotations;
+
+    visibleAnnotations.forEach((annotation) => {
       const isSelected = selectedAnnotation === annotation.id;
       const isHovered = hoveredAnnotation === annotation.id;
       const color = getClassColor(annotation.weedType);
@@ -1924,7 +1935,7 @@ export function AnnotateClient({ assetId }: AnnotateClientProps) {
     }
 
     ctx.restore();
-  }, [annotations, currentPolygon, selectedAnnotation, hoveredAnnotation, scale, imageLoaded, zoomLevel, panOffset, aiSuggestions, showAiSuggestions, highlightOverlay, annotationMode, sam3Points, sam3PreviewPolygon, boxExemplars, currentBox, editingAnnotationId, editedCoordinates, draggingVertexIndex]);
+  }, [annotations, currentPolygon, selectedAnnotation, hoveredAnnotation, scale, imageLoaded, zoomLevel, panOffset, aiSuggestions, showAiSuggestions, reviewEditFocusMode, editContext?.originalItemId, highlightOverlay, annotationMode, sam3Points, sam3PreviewPolygon, boxExemplars, currentBox, editingAnnotationId, editedCoordinates, draggingVertexIndex]);
 
   useEffect(() => { redrawCanvas(); }, [redrawCanvas]);
 

--- a/app/api/review/[sessionId]/items/route.ts
+++ b/app/api/review/[sessionId]/items/route.ts
@@ -179,6 +179,10 @@ function toClientAsset<T extends {
   };
 }
 
+function sourceKey(source: string, sourceId: string): string {
+  return `${source}:${sourceId}`;
+}
+
 async function resolveCenterGeo(
   asset: {
     gpsLatitude: number | null;
@@ -395,15 +399,41 @@ export async function GET(
           },
         })
       : Promise.resolve([]);
+    const reviewEditsPromise = prisma.reviewSessionEdit.findMany({
+      where: { reviewSessionId: sessionId },
+    });
 
-    const [manualAnnotations, aiDetections, yoloDetections, pendingAnnotations] = await Promise.all([
+    const [manualAnnotations, aiDetections, yoloDetections, pendingAnnotations, reviewEdits] = await Promise.all([
       manualAnnotationsPromise,
       aiDetectionsPromise,
       yoloDetectionsPromise,
       pendingAnnotationsPromise,
+      reviewEditsPromise,
     ]);
+    const editedAnnotationIds = reviewEdits.map((edit) => edit.newAnnotationId);
+    const editedAnnotationIdSet = new Set(editedAnnotationIds);
+    const editedSourceKeys = new Set(
+      reviewEdits.map((edit) => sourceKey(edit.sourceType, edit.sourceId))
+    );
+    const editedManualAnnotations = editedAnnotationIds.length > 0
+      ? await prisma.manualAnnotation.findMany({
+          where: {
+            id: { in: editedAnnotationIds },
+            session: {
+              assetId: { in: filteredAssetIds },
+            },
+          },
+          include: {
+            session: {
+              select: {
+                asset: { select: assetSelect },
+              },
+            },
+          },
+        })
+      : [];
 
-    const manualItems = await Promise.all(manualAnnotations.map(async (annotation) => {
+    const toManualReviewItem = async (annotation: (typeof manualAnnotations)[number]) => {
         const assetRecord = annotation.session.asset;
         const asset = toClientAsset(assetRecord);
         const validation = validateGeoParams(asset);
@@ -447,7 +477,15 @@ export async function GET(
           canExport: validation.valid,
           warnings: validation.warnings,
         };
-      }));
+      };
+    const manualItems = await Promise.all(
+      manualAnnotations
+        .filter((annotation) => !editedAnnotationIdSet.has(annotation.id))
+        .map(toManualReviewItem)
+    );
+    const editedItems = await Promise.all(
+      editedManualAnnotations.map(toManualReviewItem)
+    );
     const aiItems = await Promise.all(aiDetections.map(async (detection) => {
         const assetRecord = detection.asset;
         const asset = toClientAsset(assetRecord);
@@ -601,7 +639,15 @@ export async function GET(
           },
         };
       }));
-    const items = [...manualItems, ...aiItems, ...yoloItems, ...pendingItems];
+    const sourceItemIsActive = (item: { source: string; sourceId: string }) =>
+      !editedSourceKeys.has(sourceKey(item.source, item.sourceId));
+    const items = [
+      ...manualItems.filter(sourceItemIsActive),
+      ...editedItems,
+      ...aiItems.filter(sourceItemIsActive),
+      ...yoloItems.filter(sourceItemIsActive),
+      ...pendingItems.filter(sourceItemIsActive),
+    ];
 
     if (sessionBiasEnabled && items.length >= 8) {
       const biasCorrections = solveSessionAssetBias(

--- a/app/review/page.tsx
+++ b/app/review/page.tsx
@@ -275,7 +275,7 @@ function ReviewPageContent() {
       if (!sessionId) return;
       const returnTo = encodeURIComponent(`/review?sessionId=${sessionId}`);
       router.push(
-        `/annotate/${item.assetId}?highlightId=${item.sourceId}&source=${item.source}&reviewSessionId=${sessionId}&returnTo=${returnTo}`
+        `/annotate/${item.assetId}?highlightId=${item.sourceId}&source=${item.source}&reviewSessionId=${sessionId}&returnTo=${returnTo}&focusReviewItem=1`
       );
     },
     [router, sessionId]

--- a/components/review/ReviewViewer.tsx
+++ b/components/review/ReviewViewer.tsx
@@ -129,6 +129,10 @@ export function ReviewViewer({ items, assets = [], onAction, onEdit }: ReviewVie
     setZoomLevel(1);
     setPanOffset({ x: 0, y: 0 });
   };
+  const handleEditItem = (item: ReviewItem) => {
+    setSelectedItemId(item.id);
+    onEdit(item);
+  };
 
   const classOptions = useMemo(() => {
     const unique = new Set(items.map((item) => item.className));
@@ -381,7 +385,7 @@ export function ReviewViewer({ items, assets = [], onAction, onEdit }: ReviewVie
                       <Button
                         variant="outline"
                         size="sm"
-                        onClick={() => onEdit(item)}
+                        onClick={() => handleEditItem(item)}
                         className="h-8 px-2 text-xs"
                       >
                         <Pencil className="mr-1 h-3 w-3" />

--- a/components/training/InteractiveDetectionOverlay.tsx
+++ b/components/training/InteractiveDetectionOverlay.tsx
@@ -75,6 +75,8 @@ export function InteractiveDetectionOverlay({
   const badgeWidth = denseDetectionMode ? 34 : 40;
   const badgeHeight = denseDetectionMode ? 16 : 18;
   const badgeFontSize = denseDetectionMode ? 10 : 11;
+  const clamp = (value: number, min: number, max: number) =>
+    Math.min(Math.max(value, min), max);
 
   // Convert pixel coordinates to scaled coordinates
   const scaleBox = (bbox: number[]) => {
@@ -186,6 +188,16 @@ export function InteractiveDetectionOverlay({
               const isHovered = hoveredId === detection.id;
               const isSelected = selectedDetectionId === detection.id;
               const colors = getStatusColor(detection.status, isHovered, isSelected);
+              const showBadge = !denseDetectionMode || isHovered || isSelected;
+              const badgeX = clamp(box.x + 4, 0, Math.max(0, renderWidth - badgeWidth - 2));
+              const badgeY = clamp(box.y + 4, 0, Math.max(0, renderHeight - badgeHeight - 2));
+              const weedLabel =
+                detection.weedType.length > 36
+                  ? `${detection.weedType.slice(0, 33)}...`
+                  : detection.weedType;
+              const labelWidth = Math.max(weedLabel.length * 8 + 16, 80);
+              const labelX = clamp(box.x, 0, Math.max(0, renderWidth - labelWidth - 2));
+              const labelY = clamp(box.y - 24, 0, Math.max(0, renderHeight - 20));
 
               return (
                 <g
@@ -238,31 +250,32 @@ export function InteractiveDetectionOverlay({
                   )}
 
                   {/* Confidence Badge */}
-                  <g transform={`translate(${box.x + 4}, ${box.y + 4})`}>
-                    <rect
-                      width={badgeWidth}
-                      height={badgeHeight}
-                      rx="4"
-                      fill={detection.confidence >= 0.8 ? '#22c55e' : detection.confidence >= 0.5 ? '#f59e0b' : '#ef4444'}
-                      opacity={denseDetectionMode && !isHovered ? 0.9 : 1}
-                    />
-                    <text
-                      x={badgeWidth / 2}
-                      y={denseDetectionMode ? 12 : 13}
-                      textAnchor="middle"
-                      fill="white"
-                      fontSize={badgeFontSize}
-                      fontWeight="bold"
-                    >
-                      {Math.round(detection.confidence * 100)}%
-                    </text>
-                  </g>
+                  {showBadge && (
+                    <g transform={`translate(${badgeX}, ${badgeY})`}>
+                      <rect
+                        width={badgeWidth}
+                        height={badgeHeight}
+                        rx="4"
+                        fill={detection.confidence >= 0.8 ? '#22c55e' : detection.confidence >= 0.5 ? '#f59e0b' : '#ef4444'}
+                      />
+                      <text
+                        x={badgeWidth / 2}
+                        y={denseDetectionMode ? 12 : 13}
+                        textAnchor="middle"
+                        fill="white"
+                        fontSize={badgeFontSize}
+                        fontWeight="bold"
+                      >
+                        {Math.round(detection.confidence * 100)}%
+                      </text>
+                    </g>
+                  )}
 
                   {/* Weed Type Label on Hover */}
                   {(isHovered || isSelected) && (
-                    <g transform={`translate(${box.x}, ${box.y - 24})`}>
+                    <g transform={`translate(${labelX}, ${labelY})`}>
                       <rect
-                        width={Math.max(detection.weedType.length * 8 + 16, 80)}
+                        width={labelWidth}
                         height="20"
                         rx="4"
                         fill="rgba(0,0,0,0.8)"
@@ -273,7 +286,7 @@ export function InteractiveDetectionOverlay({
                         fill="white"
                         fontSize="12"
                       >
-                        {detection.weedType}
+                        {weedLabel}
                       </text>
                     </g>
                   )}

--- a/lib/services/review-summary.ts
+++ b/lib/services/review-summary.ts
@@ -3,7 +3,12 @@ import { resolveReviewSessionAssetIds } from "@/lib/services/review-session-asse
 
 type ReviewPrisma = Pick<
   PrismaClient,
-  "manualAnnotation" | "detection" | "pendingAnnotation" | "yOLOInferenceJob" | "processingJob"
+  | "manualAnnotation"
+  | "detection"
+  | "pendingAnnotation"
+  | "reviewSessionEdit"
+  | "yOLOInferenceJob"
+  | "processingJob"
 >;
 
 export interface ReviewSessionSummaryInput {
@@ -57,6 +62,30 @@ async function resolveInferenceJobIds(
     yoloInferenceJobIds: yoloJobs.map((job) => job.id),
     aiProcessingJobIds: processingJobs.map((job) => job.id),
   };
+}
+
+type ReviewStatus = "pending" | "accepted" | "rejected";
+
+function manualStatus(annotation: { verified: boolean; verifiedAt: Date | null }): ReviewStatus {
+  if (annotation.verified) return "accepted";
+  if (annotation.verifiedAt) return "rejected";
+  return "pending";
+}
+
+function pendingStatus(annotation: { status: string }): ReviewStatus {
+  if (annotation.status === "ACCEPTED") return "accepted";
+  if (annotation.status === "REJECTED") return "rejected";
+  return "pending";
+}
+
+function detectionStatus(detection: {
+  verified: boolean;
+  rejected: boolean;
+  userCorrected: boolean;
+}): ReviewStatus {
+  if (detection.rejected) return "rejected";
+  if (detection.verified || detection.userCorrected) return "accepted";
+  return "pending";
 }
 
 export async function getReviewItemSummary(
@@ -190,9 +219,105 @@ export async function getReviewItemSummary(
       : Promise.resolve(0),
   ]);
 
-  const pendingCount = manualPending + aiPending + yoloPending + samPending;
-  const acceptedCount = manualAccepted + aiAccepted + yoloAccepted + samAccepted;
-  const rejectedCount = manualRejected + aiRejected + yoloRejected + samRejected;
+  let pendingCount = manualPending + aiPending + yoloPending + samPending;
+  let acceptedCount = manualAccepted + aiAccepted + yoloAccepted + samAccepted;
+  let rejectedCount = manualRejected + aiRejected + yoloRejected + samRejected;
+
+  const reviewEdits = await prisma.reviewSessionEdit.findMany({
+    where: { reviewSessionId: session.id },
+  });
+
+  if (reviewEdits.length > 0) {
+    const decrement = (status: ReviewStatus) => {
+      if (status === "accepted") acceptedCount = Math.max(0, acceptedCount - 1);
+      else if (status === "rejected") rejectedCount = Math.max(0, rejectedCount - 1);
+      else pendingCount = Math.max(0, pendingCount - 1);
+    };
+    const increment = (status: ReviewStatus) => {
+      if (status === "accepted") acceptedCount += 1;
+      else if (status === "rejected") rejectedCount += 1;
+      else pendingCount += 1;
+    };
+
+    const manualSourceIds = reviewEdits
+      .filter((edit) => edit.sourceType === "manual")
+      .map((edit) => edit.sourceId);
+    const pendingSourceIds = reviewEdits
+      .filter((edit) => edit.sourceType === "pending")
+      .map((edit) => edit.sourceId);
+    const detectionSourceIds = reviewEdits
+      .filter((edit) => edit.sourceType === "detection")
+      .map((edit) => edit.sourceId);
+    const editedAnnotationIds = Array.from(
+      new Set(reviewEdits.map((edit) => edit.newAnnotationId))
+    );
+
+    const [manualOriginals, pendingOriginals, detectionOriginals, editedReplacements] =
+      await Promise.all([
+        manualSourceIds.length > 0
+          ? prisma.manualAnnotation.findMany({
+              where: {
+                id: { in: manualSourceIds },
+                session: { assetId: { in: assetIds } },
+              },
+              select: { id: true, verified: true, verifiedAt: true },
+            })
+          : Promise.resolve([]),
+        pendingSourceIds.length > 0
+          ? prisma.pendingAnnotation.findMany({
+              where: {
+                id: { in: pendingSourceIds },
+                assetId: { in: assetIds },
+              },
+              select: { id: true, status: true },
+            })
+          : Promise.resolve([]),
+        detectionSourceIds.length > 0
+          ? prisma.detection.findMany({
+              where: {
+                id: { in: detectionSourceIds },
+                assetId: { in: assetIds },
+              },
+              select: { id: true, verified: true, rejected: true, userCorrected: true },
+            })
+          : Promise.resolve([]),
+        isBatchReview && editedAnnotationIds.length > 0
+          ? prisma.manualAnnotation.findMany({
+              where: {
+                id: { in: editedAnnotationIds },
+                session: { assetId: { in: assetIds } },
+              },
+              select: { id: true, verified: true, verifiedAt: true },
+            })
+          : Promise.resolve([]),
+      ]);
+
+    const manualOriginalStatusById = new Map(
+      manualOriginals.map((annotation) => [annotation.id, manualStatus(annotation)])
+    );
+    const pendingOriginalStatusById = new Map(
+      pendingOriginals.map((annotation) => [annotation.id, pendingStatus(annotation)])
+    );
+    const detectionOriginalStatusById = new Map(
+      detectionOriginals.map((detection) => [detection.id, detectionStatus(detection)])
+    );
+
+    for (const edit of reviewEdits) {
+      const status =
+        edit.sourceType === "manual"
+          ? manualOriginalStatusById.get(edit.sourceId)
+          : edit.sourceType === "pending"
+            ? pendingOriginalStatusById.get(edit.sourceId)
+            : edit.sourceType === "detection"
+              ? detectionOriginalStatusById.get(edit.sourceId)
+              : null;
+      if (status) decrement(status);
+    }
+
+    for (const replacement of editedReplacements) {
+      increment(manualStatus(replacement));
+    }
+  }
 
   return {
     pendingCount,


### PR DESCRIPTION
## Summary
- Quiet dense review overlays by hiding confidence badges until hover/selection and clamping labels inside the image bounds.
- Preserve explicit selection when editing a review item and open annotation edit mode in a focused view.
- Make review item and summary APIs honor ReviewSessionEdit replacements so corrected geometry is shown and superseded originals are hidden from review counts.

## Verification
- npm run lint
- npm run build
- npx tsc --noEmit --pretty false | rg 'app/api/review/\[sessionId\]/items|lib/services/review-summary|app/annotate/\[assetId\]/AnnotateClient|components/training/InteractiveDetectionOverlay|components/review/ReviewViewer|app/review/page' || true

Note: full tsc remains blocked by existing repo-wide Next route/type issues unrelated to this PR.