### PR TITLE
AG-3: pine review ingest — YOLO-seg import, task=segment export, bulk registration

### DIFF
--- a/app/api/projects/[id]/versions/preview/route.ts
+++ b/app/api/projects/[id]/versions/preview/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/db';
 import { getAuthenticatedUser } from '@/lib/auth/api-auth';
-import { datasetPreparation } from '@/lib/services/dataset-preparation';
+import { datasetPreparation, type DatasetTask } from '@/lib/services/dataset-preparation';
 
 function isDatasetVersionsEnabled(features: unknown): boolean {
   if (process.env.ENABLE_DATASET_VERSIONS === 'true') return true;
@@ -42,12 +42,16 @@ export async function POST(
     }
 
     const body = await request.json();
-    const { splits, filters, classes, reviewSessionId } = body || {};
+    const { splits, filters, classes, reviewSessionId, task = 'detect' } = body || {};
     const selectedClasses = Array.isArray(classes) && classes.length > 0
       ? classes
       : Array.isArray(filters?.weedTypes) && filters.weedTypes.length > 0
         ? filters.weedTypes
         : undefined;
+
+    if (task !== 'detect' && task !== 'segment') {
+      return NextResponse.json({ error: 'task must be detect or segment' }, { status: 400 });
+    }
 
     let scopedAssetIds: string[] | undefined;
     if (typeof reviewSessionId === 'string' && reviewSessionId) {
@@ -82,6 +86,7 @@ export async function POST(
       minConfidence: filters?.minConfidence ?? 0.5,
       verifiedOnly: filters?.verifiedOnly ?? false,
       createdBefore: new Date(),
+      task: task as DatasetTask,
     });
 
     return NextResponse.json({ preview });

--- a/app/api/projects/[id]/versions/route.ts
+++ b/app/api/projects/[id]/versions/route.ts
@@ -75,7 +75,12 @@ export async function POST(
       filters,
       classes,
       reviewSessionId,
+      task = 'detect',
     } = body || {};
+
+    if (task !== 'detect' && task !== 'segment') {
+      return NextResponse.json({ error: 'task must be detect or segment' }, { status: 400 });
+    }
 
     let scopedAssetIds: string[] | undefined;
     if (typeof reviewSessionId === 'string' && reviewSessionId) {
@@ -118,6 +123,7 @@ export async function POST(
       preprocessing,
       augmentation,
       splits,
+      task,
       filters: {
         ...(filters || {}),
         ...(typeof reviewSessionId === 'string' && reviewSessionId ? { reviewSessionId } : {}),

--- a/app/api/review/[sessionId]/push/route.ts
+++ b/app/api/review/[sessionId]/push/route.ts
@@ -105,6 +105,7 @@ export async function POST(
       learningRate?: number;
       augmentationPreset?: string;
       augmentationConfig?: Record<string, unknown>;
+      task?: 'detect' | 'segment';
     } | undefined;
 
     if (!target || !['roboflow', 'yolo', 'both'].includes(target)) {
@@ -291,6 +292,7 @@ export async function POST(
         createdById: auth.userId,
         augmentationPreset: yoloConfig.augmentationPreset,
         augmentationConfig: yoloConfig.augmentationConfig,
+        task: yoloConfig.task || 'detect',
       });
       const augmentation = buildTrainingAugmentationFromInput(
         yoloConfig.augmentationPreset,
@@ -329,9 +331,10 @@ export async function POST(
           createdById: auth.userId,
           trainingConfig: JSON.stringify({
             modelName,
-            trainingIntent: yoloConfig.trainingIntent || 'update_existing',
-            ...(augmentation ? { augmentation } : {}),
-          }),
+              trainingIntent: yoloConfig.trainingIntent || 'update_existing',
+              task: yoloConfig.task || 'detect',
+              ...(augmentation ? { augmentation } : {}),
+            }),
         },
       });
 
@@ -377,6 +380,7 @@ export async function POST(
           batch_size: yoloConfig.batchSize || 16,
           image_size: yoloConfig.imageSize || 640,
           learning_rate: yoloConfig.learningRate || 0.01,
+          task: yoloConfig.task || 'detect',
           ...(augmentation ? { augmentation } : {}),
         });
 
@@ -388,6 +392,7 @@ export async function POST(
             trainingConfig: JSON.stringify({
               modelName,
               trainingIntent: yoloConfig.trainingIntent || 'update_existing',
+              task: yoloConfig.task || 'detect',
               ...(augmentation ? { augmentation } : {}),
               gpuLockToken: gpuLock.token,
             }),

--- a/app/api/training/datasets/preview/route.ts
+++ b/app/api/training/datasets/preview/route.ts
@@ -5,7 +5,7 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/db';
-import { datasetPreparation } from '@/lib/services/dataset-preparation';
+import { datasetPreparation, type DatasetTask } from '@/lib/services/dataset-preparation';
 import { getAuthenticatedUser } from '@/lib/auth/api-auth';
 import { checkRateLimit } from '@/lib/utils/security';
 import { normalizeTrainingDatasetSourceFlags } from '@/lib/utils/training-dataset-sources';
@@ -42,6 +42,7 @@ export async function POST(request: NextRequest) {
       includeManualAnnotations,
       includeSAM3,
       minConfidence = 0.5,
+      task = 'detect',
     } = body;
     const sourceFlags = normalizeTrainingDatasetSourceFlags({
       includeAIDetections,
@@ -55,6 +56,10 @@ export async function POST(request: NextRequest) {
 
     if (classes && !Array.isArray(classes)) {
       return NextResponse.json({ error: 'classes must be an array if provided' }, { status: 400 });
+    }
+
+    if (task !== 'detect' && task !== 'segment') {
+      return NextResponse.json({ error: 'task must be detect or segment' }, { status: 400 });
     }
 
     if (splitRatio) {
@@ -110,6 +115,7 @@ export async function POST(request: NextRequest) {
       includeManualAnnotations: sourceFlags.includeManualAnnotations,
       includeSAM3: sourceFlags.includeSAM3,
       minConfidence,
+      task: task as DatasetTask,
     });
 
     return NextResponse.json({ preview, sources: sourceFlags });

--- a/app/api/training/datasets/route.ts
+++ b/app/api/training/datasets/route.ts
@@ -6,7 +6,7 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/db';
-import { datasetPreparation } from '@/lib/services/dataset-preparation';
+import { datasetPreparation, type DatasetTask } from '@/lib/services/dataset-preparation';
 import { getAuthenticatedUser, getUserTeamIds } from '@/lib/auth/api-auth';
 import { checkRateLimit } from '@/lib/utils/security';
 import { normalizeTrainingDatasetSourceFlags } from '@/lib/utils/training-dataset-sources';
@@ -55,6 +55,7 @@ export async function POST(request: NextRequest) {
       minConfidence = 0.5,
       augmentationPreset = 'none',
       augmentationConfig,
+      task = 'detect',
     } = body;
     const sourceFlags = normalizeTrainingDatasetSourceFlags({
       includeAIDetections,
@@ -75,6 +76,10 @@ export async function POST(request: NextRequest) {
         { error: 'classes array is required and must not be empty' },
         { status: 400 }
       );
+    }
+
+    if (task !== 'detect' && task !== 'segment') {
+      return NextResponse.json({ error: 'task must be detect or segment' }, { status: 400 });
     }
 
     if (splitRatio) {
@@ -154,6 +159,7 @@ export async function POST(request: NextRequest) {
       createdById: auth.userId,
       augmentationPreset,
       augmentationConfig,
+      task: task as DatasetTask,
     });
 
     const datasetPatch: {

--- a/lib/services/dataset-preparation.ts
+++ b/lib/services/dataset-preparation.ts
@@ -22,7 +22,10 @@ interface BoundingBox {
 interface YOLOAnnotation {
   classId: number;
   bbox: BoundingBox;
+  polygon?: AnnotationPoint[];
 }
+
+export type DatasetTask = 'detect' | 'segment';
 
 export interface DatasetConfig {
   projectId?: string;
@@ -48,6 +51,7 @@ export interface DatasetConfig {
   skipCreateRecord?: boolean;
   augmentationPreset?: string;
   augmentationConfig?: Record<string, unknown> | null;
+  task?: DatasetTask;
 }
 
 interface PreparedDataset {
@@ -128,6 +132,7 @@ export function sanitizeClassName(name: string): string {
 interface NormalizedAssetAnnotation {
   className: string;
   bbox: BoundingBox;
+  polygon?: AnnotationPoint[];
 }
 
 class DatasetPreparationService {
@@ -168,6 +173,7 @@ class DatasetPreparationService {
     const splitRatio = this.normalizeSplitRatio(config.splitRatio);
     const shuffled = this.shuffleArray([...assets]);
     const splits = this.splitDataset(shuffled, splitRatio);
+    const task = config.task || 'detect';
 
     let totalLabels = 0;
     let processedImages = 0;
@@ -183,7 +189,8 @@ class DatasetPreparationService {
           config.includeAIDetections ?? true,
           config.includeManualAnnotations ?? true,
           config.minConfidence ?? 0.5,
-          config.includeSAM3 ?? true
+          config.includeSAM3 ?? true,
+          task
         );
 
         if (yoloAnnotations.length === 0) {
@@ -191,10 +198,7 @@ class DatasetPreparationService {
         }
 
         const labelContent = yoloAnnotations
-          .map(
-            (ann) =>
-              `${ann.classId} ${ann.bbox.x.toFixed(6)} ${ann.bbox.y.toFixed(6)} ${ann.bbox.width.toFixed(6)} ${ann.bbox.height.toFixed(6)}`
-          )
+          .map((ann) => this.formatYOLOAnnotation(ann, task))
           .join('\n');
 
         const labelKey = `${s3BasePath}/${splitName}/labels/${asset.id}.txt`;
@@ -208,7 +212,7 @@ class DatasetPreparationService {
       }
     }
 
-    const dataYaml = this.generateDataYaml(s3BasePath, dedupedClasses, splitCounts);
+    const dataYaml = this.generateDataYaml(s3BasePath, dedupedClasses, splitCounts, task);
     await S3Service.uploadBuffer(
       Buffer.from(dataYaml),
       `${s3BasePath}/data.yaml`,
@@ -284,11 +288,12 @@ class DatasetPreparationService {
     for (const asset of assets) {
       const annotations = this.collectAssetAnnotations(
         asset,
-        includeAI,
-        includeManual,
-        minConfidence,
-        includeSAM3
-      );
+          includeAI,
+          includeManual,
+          minConfidence,
+          includeSAM3,
+          config.task || 'detect'
+        );
       for (const annotation of annotations) {
         incrementAvailable(annotation.className);
       }
@@ -319,7 +324,8 @@ class DatasetPreparationService {
         includeAI,
         includeManual,
         minConfidence,
-        includeSAM3
+        includeSAM3,
+        config.task || 'detect'
       );
 
       if (yoloAnnotations.length === 0) continue;
@@ -497,7 +503,8 @@ class DatasetPreparationService {
     includeAI: boolean,
     includeManual: boolean,
     minConfidence: number,
-    includeSAM3: boolean
+    includeSAM3: boolean,
+    task: DatasetTask = 'detect'
   ): YOLOAnnotation[] {
     return this.collectAssetAnnotations(
       asset,
@@ -509,7 +516,13 @@ class DatasetPreparationService {
       .map((annotation) => {
         const classId = classMap.get(annotation.className);
         if (classId === undefined) return null;
-        return { classId, bbox: annotation.bbox };
+        return {
+          classId,
+          bbox: annotation.bbox,
+          ...(task === 'segment' && annotation.polygon && annotation.polygon.length >= 3
+            ? { polygon: annotation.polygon }
+            : {}),
+        };
       })
       .filter((annotation): annotation is YOLOAnnotation => annotation !== null);
   }
@@ -526,7 +539,11 @@ class DatasetPreparationService {
     const imageWidth = asset.imageWidth || 4000;
     const imageHeight = asset.imageHeight || 3000;
 
-    const addAnnotation = (rawClassName: string, bbox: BoundingBox | null) => {
+    const addAnnotation = (
+      rawClassName: string,
+      bbox: BoundingBox | null,
+      polygon?: AnnotationPoint[] | null
+    ) => {
       if (!bbox) return;
       const className = sanitizeClassName(rawClassName);
       if (!className) return;
@@ -535,7 +552,11 @@ class DatasetPreparationService {
       if (seen.has(key)) return;
       seen.add(key);
 
-      annotations.push({ className, bbox });
+      annotations.push({
+        className,
+        bbox,
+        ...(polygon && polygon.length >= 3 ? { polygon } : {}),
+      });
     };
 
     if (includeAI && asset.detections) {
@@ -561,7 +582,8 @@ class DatasetPreparationService {
 
           addAnnotation(
             annotation.roboflowClassName || annotation.weedType,
-            this.polygonToBBox(points, imageWidth, imageHeight)
+            this.polygonToBBox(points, imageWidth, imageHeight),
+            this.normalizePolygon(points, imageWidth, imageHeight)
           );
         }
       }
@@ -577,12 +599,23 @@ class DatasetPreparationService {
 
         addAnnotation(
           pending.weedType,
-          this.parsePendingBBox(pending, imageWidth, imageHeight)
+          this.parsePendingBBox(pending, imageWidth, imageHeight),
+          this.parsePendingPolygon(pending, imageWidth, imageHeight)
         );
       }
     }
 
     return annotations;
+  }
+
+  private parsePendingPolygon(
+    pending: { polygon?: unknown },
+    imgWidth: number,
+    imgHeight: number
+  ): AnnotationPoint[] | null {
+    const points = this.parsePolygonPoints(pending.polygon);
+    if (!points || points.length < 3) return null;
+    return this.normalizePolygon(points, imgWidth, imgHeight);
   }
 
   private parsePendingBBox(
@@ -708,6 +741,29 @@ class DatasetPreparationService {
     return this.pixelToYOLO(x1, y1, x2, y2, imgWidth, imgHeight);
   }
 
+  private normalizePolygon(
+    points: AnnotationPoint[],
+    imgWidth: number,
+    imgHeight: number
+  ): AnnotationPoint[] {
+    return points.map(([x, y]) => [
+      Math.max(0, Math.min(1, x / imgWidth)),
+      Math.max(0, Math.min(1, y / imgHeight)),
+    ]);
+  }
+
+  private formatYOLOAnnotation(annotation: YOLOAnnotation, task: DatasetTask = 'detect'): string {
+    if (task === 'segment' && annotation.polygon && annotation.polygon.length >= 3) {
+      const coordinates = annotation.polygon
+        .flatMap(([x, y]) => [x, y])
+        .map((value) => value.toFixed(6))
+        .join(' ');
+      return `${annotation.classId} ${coordinates}`;
+    }
+
+    return `${annotation.classId} ${annotation.bbox.x.toFixed(6)} ${annotation.bbox.y.toFixed(6)} ${annotation.bbox.width.toFixed(6)} ${annotation.bbox.height.toFixed(6)}`;
+  }
+
   private clampBBox(bbox: BoundingBox): BoundingBox {
     return {
       x: Math.max(0, Math.min(1, bbox.x)),
@@ -736,7 +792,8 @@ class DatasetPreparationService {
   private generateDataYaml(
     s3BasePath: string,
     classes: string[],
-    counts: { train: number; val: number; test: number }
+    counts: { train: number; val: number; test: number },
+    task: DatasetTask = 'detect'
   ): string {
     const s3Uri = `s3://${this.bucket}/${s3BasePath}`;
 
@@ -744,6 +801,7 @@ class DatasetPreparationService {
 # Generated: ${new Date().toISOString()}
 
 path: ${s3Uri}
+task: ${task}
 train: train/images
 val: val/images
 test: ${counts.test > 0 ? 'test/images' : ''}

--- a/lib/services/training-dataset-version.ts
+++ b/lib/services/training-dataset-version.ts
@@ -1,5 +1,9 @@
 import prisma from '@/lib/db';
-import { datasetPreparation, sanitizeClassName } from '@/lib/services/dataset-preparation';
+import {
+  datasetPreparation,
+  sanitizeClassName,
+  type DatasetTask,
+} from '@/lib/services/dataset-preparation';
 import { S3Service } from '@/lib/services/s3';
 import { createHash, randomUUID } from 'crypto';
 import type { TrainingDataset } from '@prisma/client';
@@ -37,6 +41,7 @@ export interface CreateVersionConfig {
   augmentation?: AugmentationConfig;
   splits?: { train: number; val: number; test: number };
   filters?: SnapshotFilters;
+  task?: DatasetTask;
 }
 
 interface AnnotationManifestEntry {
@@ -123,6 +128,7 @@ class TrainingDatasetVersionService {
           minConfidence: storedFilterConfig.minConfidence,
           verifiedOnly: storedFilterConfig.verifiedOnly,
           createdBefore: existing.snapshotAt || new Date(),
+          task: config.task || 'detect',
         });
         return { dataset: existing, preview };
       }
@@ -139,6 +145,7 @@ class TrainingDatasetVersionService {
       minConfidence: filterConfig.minConfidence,
       verifiedOnly: filterConfig.verifiedOnly,
       createdBefore: snapshotAt,
+      task: config.task || 'detect',
     });
 
     if (preview.imageCount === 0) {
@@ -156,6 +163,7 @@ class TrainingDatasetVersionService {
       minConfidence: filterConfig.minConfidence,
       verifiedOnly: filterConfig.verifiedOnly,
       createdBefore: snapshotAt,
+      task: config.task || 'detect',
     });
 
     if (preparedAssets.length === 0) {
@@ -287,6 +295,7 @@ class TrainingDatasetVersionService {
           s3BasePath,
           skipCreateRecord: true,
           createdById: config.createdById ?? undefined,
+          task: config.task || 'detect',
         }
       );
     } catch (error) {

--- a/lib/services/yolo.ts
+++ b/lib/services/yolo.ts
@@ -29,6 +29,7 @@ export interface TrainingConfig {
   learning_rate?: number;
   checkpoint_s3_path?: string;
   augmentation?: Record<string, unknown>;
+  task?: 'detect' | 'segment';
 }
 
 export interface TrainingJobResponse {
@@ -329,6 +330,7 @@ export class YOLOService {
       batch_size: config.batch_size || 16,
       image_size: config.image_size || 640,
       learning_rate: config.learning_rate || 0.01,
+      task: config.task || 'detect',
       ...(config.checkpoint_s3_path ? { checkpoint_s3_path: config.checkpoint_s3_path } : {}),
     };
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "sam3:contract": "tsx -r tsconfig-paths/register scripts/sam3-replay.ts --include-source-target --technique both --crop-source source-detections",
     "ag3:dino-export": "tsx -r tsconfig-paths/register scripts/ag3-dino-export.ts",
     "ag3:dino-import": "tsx -r tsconfig-paths/register scripts/ag3-dino-import.ts",
+    "ag3:pine-yolo-seg-import": "tsx -r tsconfig-paths/register scripts/pine-yolo-seg-import.ts",
+    "ag3:pine-bulk-register": "tsx -r tsconfig-paths/register scripts/pine-bulk-register.ts",
     "seed:verified": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed-verified.ts",
     "docker:build": "docker build -t agridrone-ops .",
     "docker:dev": "docker-compose -f docker-compose.yml -f docker-compose.dev.yml up",

--- a/scripts/ag3-dino-import.ts
+++ b/scripts/ag3-dino-import.ts
@@ -10,7 +10,7 @@ interface CliOptions {
   schemaOnly: boolean;
 }
 
-interface CandidateFile {
+export interface CandidateFile {
   schemaVersion?: string;
   sourceSessionId?: string;
   projectId?: string;
@@ -19,7 +19,7 @@ interface CandidateFile {
   candidates?: CandidateInput[];
 }
 
-interface CandidateInput {
+export interface CandidateInput {
   assetId: string;
   className?: string;
   confidence?: number;
@@ -39,6 +39,35 @@ interface NormalizedCandidate {
   bbox: [number, number, number, number];
   polygon: number[][];
   notes?: string;
+}
+
+export interface ImportReviewSessionOwner {
+  teamId: string;
+  createdById: string;
+  yoloModelName?: string | null;
+}
+
+export interface ImportDinoCandidatesOptions {
+  candidateFile: CandidateFile;
+  candidatesPath?: string;
+  createReviewSession?: boolean;
+  dryRun?: boolean;
+  schemaOnly?: boolean;
+  reviewSessionOwner?: ImportReviewSessionOwner;
+}
+
+export interface ImportDinoCandidatesResult {
+  ok: true;
+  schemaOnly?: boolean;
+  dryRun?: boolean;
+  projectId: string | null;
+  sourceSessionId: string | null;
+  batchJobId?: string;
+  reviewSessionId?: string | null;
+  reviewUrl?: string | null;
+  assets: number;
+  candidates: number;
+  createReviewSession?: boolean;
 }
 
 function parseArgs(argv: string[]): CliOptions {
@@ -226,21 +255,21 @@ async function resolveContext(file: CandidateFile) {
   return { sourceSession, projectId };
 }
 
-async function main() {
-  const options = parseArgs(process.argv.slice(2));
-  const candidateFile = await loadCandidateFile(options.candidatesPath);
+export async function importDinoCandidates(
+  options: ImportDinoCandidatesOptions
+): Promise<ImportDinoCandidatesResult> {
+  const candidateFile = options.candidateFile;
   const candidates = normalizeCandidates(candidateFile);
 
   if (options.schemaOnly) {
-    console.log(JSON.stringify({
+    return {
       ok: true,
       schemaOnly: true,
       sourceSessionId: candidateFile.sourceSessionId || null,
       projectId: candidateFile.projectId || null,
       candidates: candidates.length,
       assets: Array.from(new Set(candidates.map((candidate) => candidate.assetId))).length,
-    }, null, 2));
-    return;
+    };
   }
 
   const context = await resolveContext(candidateFile);
@@ -259,12 +288,12 @@ async function main() {
     throw new Error(`Candidates reference assets outside project ${context.projectId}: ${missingAssetIds.join(', ')}`);
   }
 
-  if (options.createReviewSession && !context.sourceSession) {
-    throw new Error('--create-review-session requires sourceSessionId so team/user ownership can be copied safely.');
+  if (options.createReviewSession && !context.sourceSession && !options.reviewSessionOwner) {
+    throw new Error('--create-review-session requires sourceSessionId or explicit review session owner.');
   }
 
   if (options.dryRun) {
-    console.log(JSON.stringify({
+    return {
       ok: true,
       dryRun: true,
       projectId: context.projectId,
@@ -272,8 +301,7 @@ async function main() {
       assets: assetIds.length,
       candidates: candidates.length,
       createReviewSession: options.createReviewSession,
-    }, null, 2));
-    return;
+    };
   }
 
   const result = await prisma.$transaction(async (tx) => {
@@ -291,7 +319,7 @@ async function main() {
           source: 'DINO_CANDIDATE_MINING',
           sourceSessionId: candidateFile.sourceSessionId || null,
           generator: candidateFile.generator || null,
-          importedFrom: path.resolve(options.candidatesPath),
+          importedFrom: options.candidatesPath ? path.resolve(options.candidatesPath) : null,
           importedAt: new Date().toISOString(),
         } as Prisma.InputJsonValue,
         status: 'COMPLETED',
@@ -316,15 +344,25 @@ async function main() {
     });
 
     let reviewSession: { id: string } | null = null;
-    if (options.createReviewSession && context.sourceSession) {
+    if (options.createReviewSession) {
+      const owner = context.sourceSession
+        ? {
+            teamId: context.sourceSession.teamId,
+            createdById: context.sourceSession.createdById,
+            yoloModelName: 'DINO candidate mining',
+          }
+        : options.reviewSessionOwner;
+      if (!owner) {
+        throw new Error('Review session owner could not be resolved.');
+      }
       reviewSession = await tx.reviewSession.create({
         data: {
-          teamId: context.sourceSession.teamId,
-          createdById: context.sourceSession.createdById,
+          teamId: owner.teamId,
+          createdById: owner.createdById,
           projectId: context.projectId,
           workflowType: 'batch_review',
           targetType: 'training',
-          yoloModelName: 'DINO candidate mining',
+          yoloModelName: owner.yoloModelName || 'DINO candidate mining',
           weedTypeFilter: candidateFile.className || candidates[0]?.weedType || 'Pine Sapling',
           assetIds,
           assetCount: assetIds.length,
@@ -342,7 +380,7 @@ async function main() {
     };
   });
 
-  console.log(JSON.stringify({
+  return {
     ok: true,
     projectId: context.projectId,
     batchJobId: result.batchJobId,
@@ -350,14 +388,29 @@ async function main() {
     assets: assetIds.length,
     candidates: candidates.length,
     reviewUrl: result.reviewSessionId ? `/review?sessionId=${result.reviewSessionId}` : null,
-  }, null, 2));
+  };
 }
 
-main()
-  .catch((error) => {
-    console.error(error instanceof Error ? error.message : error);
-    process.exitCode = 1;
-  })
-  .finally(async () => {
-    await prisma.$disconnect().catch(() => undefined);
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const candidateFile = await loadCandidateFile(options.candidatesPath);
+  const result = await importDinoCandidates({
+    candidateFile,
+    candidatesPath: options.candidatesPath,
+    createReviewSession: options.createReviewSession,
+    dryRun: options.dryRun,
+    schemaOnly: options.schemaOnly,
   });
+  console.log(JSON.stringify(result, null, 2));
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename)) {
+  main()
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : error);
+      process.exitCode = 1;
+    })
+    .finally(async () => {
+      await prisma.$disconnect().catch(() => undefined);
+    });
+}

--- a/scripts/ag3-dino-import.ts
+++ b/scripts/ag3-dino-import.ts
@@ -378,6 +378,10 @@ export async function importDinoCandidates(
       batchJobId: batchJob.id,
       reviewSessionId: reviewSession?.id || null,
     };
+  }, {
+    // Bulk imports (25k+ rows) over a remote DB blow the 5s default.
+    maxWait: 30_000,
+    timeout: 600_000,
   });
 
   return {

--- a/scripts/pine-bulk-register.ts
+++ b/scripts/pine-bulk-register.ts
@@ -11,6 +11,7 @@ interface CliOptions {
   imagesDir: string;
   projectRef: string;
   flightSession?: string;
+  skipUpload?: boolean;
 }
 
 interface ProjectContext {
@@ -51,6 +52,8 @@ function parseArgs(argv: string[]): CliOptions {
     } else if (arg === '--flight-session') {
       options.flightSession = requireValue(arg, next);
       index += 1;
+    } else if (arg === '--skip-upload') {
+      options.skipUpload = true;
     } else if (arg === '--help' || arg === '-h') {
       printHelpAndExit();
     } else {
@@ -218,6 +221,7 @@ async function storeImage(args: {
   contentType: string;
   flightSession?: string;
   storageMode: StorageMode;
+  skipUpload?: boolean;
 }): Promise<{
   storageUrl: string;
   storageType: string;
@@ -251,7 +255,13 @@ async function storeImage(args: {
     contentType: args.contentType,
     flightSession: args.flightSession,
   });
-  await S3Service.uploadBuffer(args.buffer, key, args.contentType);
+  if (args.skipUpload) {
+    // Objects were uploaded out-of-band (e.g. aws s3 sync from a box with
+    // bucket access); record the computed key without a PutObject call.
+    console.log(`skip-upload: recording ${key}`);
+  } else {
+    await S3Service.uploadBuffer(args.buffer, key, args.contentType);
+  }
   const cloudFrontBase =
     process.env.CLOUDFRONT_BASE_URL ??
     process.env.NEXT_PUBLIC_CLOUDFRONT_BASE_URL ??
@@ -335,6 +345,7 @@ async function main() {
       contentType,
       flightSession: options.flightSession,
       storageMode,
+      skipUpload: options.skipUpload,
     });
 
     const asset = await prisma.asset.create({

--- a/scripts/pine-bulk-register.ts
+++ b/scripts/pine-bulk-register.ts
@@ -45,7 +45,7 @@ function parseArgs(argv: string[]): CliOptions {
     if (arg === '--images-dir') {
       options.imagesDir = requireValue(arg, next);
       index += 1;
-    } else if (arg === '--project') {
+    } else if (arg === '--project' || arg === '--project-id') {
       options.projectRef = requireValue(arg, next);
       index += 1;
     } else if (arg === '--flight-session') {

--- a/scripts/pine-bulk-register.ts
+++ b/scripts/pine-bulk-register.ts
@@ -1,0 +1,394 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import exifr from 'exifr';
+import sharp from 'sharp';
+import prisma from '@/lib/db';
+import { S3Service } from '@/lib/services/s3';
+
+type StorageMode = 's3' | 'local';
+
+interface CliOptions {
+  imagesDir: string;
+  projectRef: string;
+  flightSession?: string;
+}
+
+interface ProjectContext {
+  id: string;
+  name: string;
+  teamId: string;
+  createdById: string;
+}
+
+interface ExistingAsset {
+  id: string;
+  fileName: string;
+}
+
+interface ImageCandidate {
+  fileName: string;
+  filePath: string;
+}
+
+export interface BulkRegistrationPlan {
+  toRegister: ImageCandidate[];
+  skipped: Array<{ fileName: string; assetId: string; reason: string }>;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: Partial<CliOptions> = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === '--images-dir') {
+      options.imagesDir = requireValue(arg, next);
+      index += 1;
+    } else if (arg === '--project') {
+      options.projectRef = requireValue(arg, next);
+      index += 1;
+    } else if (arg === '--flight-session') {
+      options.flightSession = requireValue(arg, next);
+      index += 1;
+    } else if (arg === '--help' || arg === '-h') {
+      printHelpAndExit();
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!options.imagesDir) {
+    throw new Error('Provide --images-dir <dir>.');
+  }
+  if (!options.projectRef) {
+    throw new Error('Provide --project <name-or-id>.');
+  }
+
+  return options as CliOptions;
+}
+
+function requireValue(flag: string, value: string | undefined): string {
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${flag} requires a value.`);
+  }
+  return value;
+}
+
+function printHelpAndExit(): never {
+  console.log(`
+Usage:
+  npm run ag3:pine-bulk-register -- --images-dir /path/to/images --project <name-or-id> --flight-session "Pine SAM3 batch"
+
+Environment:
+  PINE_BULK_REGISTER_STORAGE=s3|local  Defaults to s3.
+  PINE_BULK_REGISTER_LOCAL_DIR=public/uploads/ag3-pine  Required only when storage=local if you want a custom root.
+  AWS_REGION, AWS_S3_BUCKET, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY are used for storage=s3.
+`);
+  process.exit(0);
+}
+
+function fileStem(fileName: string): string {
+  return path.parse(fileName).name;
+}
+
+export function planBulkRegistration(
+  images: ImageCandidate[],
+  existingAssets: ExistingAsset[]
+): BulkRegistrationPlan {
+  const existingByStem = new Map<string, ExistingAsset>();
+  for (const asset of existingAssets) {
+    existingByStem.set(fileStem(asset.fileName), asset);
+  }
+
+  const seenInputStems = new Set<string>();
+  const toRegister: ImageCandidate[] = [];
+  const skipped: BulkRegistrationPlan['skipped'] = [];
+
+  for (const image of images) {
+    const stem = fileStem(image.fileName);
+    const existing = existingByStem.get(stem);
+    if (existing) {
+      skipped.push({
+        fileName: image.fileName,
+        assetId: existing.id,
+        reason: 'filename_stem_already_registered',
+      });
+      continue;
+    }
+    if (seenInputStems.has(stem)) {
+      skipped.push({
+        fileName: image.fileName,
+        assetId: '',
+        reason: 'duplicate_input_filename_stem',
+      });
+      continue;
+    }
+    seenInputStems.add(stem);
+    toRegister.push(image);
+  }
+
+  return { toRegister, skipped };
+}
+
+async function listJpegImages(imagesDir: string): Promise<ImageCandidate[]> {
+  const root = path.resolve(imagesDir);
+  const entries = await fs.readdir(root, { withFileTypes: true });
+  const images = entries
+    .filter((entry) => entry.isFile() && /\.(jpe?g)$/i.test(entry.name))
+    .map((entry) => ({
+      fileName: entry.name,
+      filePath: path.join(root, entry.name),
+    }))
+    .sort((left, right) => left.fileName.localeCompare(right.fileName));
+
+  if (images.length === 0) {
+    throw new Error(`No JPG images found in ${root}.`);
+  }
+
+  return images;
+}
+
+async function resolveProject(projectRef: string): Promise<ProjectContext> {
+  const projects = await prisma.project.findMany({
+    where: {
+      OR: [{ id: projectRef }, { name: projectRef }],
+    },
+    select: {
+      id: true,
+      name: true,
+      teamId: true,
+      team: {
+        select: {
+          members: {
+            orderBy: { createdAt: 'asc' },
+            take: 1,
+            select: { userId: true },
+          },
+        },
+      },
+    },
+  });
+
+  if (projects.length === 0) {
+    throw new Error(`Project not found by id or name: ${projectRef}`);
+  }
+  if (projects.length > 1) {
+    throw new Error(`Project reference "${projectRef}" matched multiple projects; use the project id.`);
+  }
+
+  const project = projects[0];
+  const createdById = project.team.members[0]?.userId;
+  if (!createdById) {
+    throw new Error(`Project ${project.id} has no team members to own imported assets.`);
+  }
+
+  return {
+    id: project.id,
+    name: project.name,
+    teamId: project.teamId,
+    createdById,
+  };
+}
+
+function resolveStorageMode(): StorageMode {
+  const value = (process.env.PINE_BULK_REGISTER_STORAGE || 's3').toLowerCase();
+  if (value === 's3' || value === 'local') return value;
+  throw new Error('PINE_BULK_REGISTER_STORAGE must be "s3" or "local".');
+}
+
+function mimeTypeFor(fileName: string): string {
+  const ext = path.extname(fileName).toLowerCase();
+  if (ext === '.jpg' || ext === '.jpeg') return 'image/jpeg';
+  return 'application/octet-stream';
+}
+
+function sanitizePathSegment(value: string): string {
+  return value
+    .trim()
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'default';
+}
+
+async function storeImage(args: {
+  projectId: string;
+  createdById: string;
+  image: ImageCandidate;
+  buffer: Buffer;
+  contentType: string;
+  flightSession?: string;
+  storageMode: StorageMode;
+}): Promise<{
+  storageUrl: string;
+  storageType: string;
+  s3Key: string | null;
+  s3Bucket: string | null;
+}> {
+  if (args.storageMode === 'local') {
+    const localRoot = path.resolve(process.env.PINE_BULK_REGISTER_LOCAL_DIR || 'public/uploads/ag3-pine');
+    const relativeParts = [
+      args.projectId,
+      args.flightSession ? sanitizePathSegment(args.flightSession) : 'default',
+      args.image.fileName,
+    ];
+    const targetPath = path.join(localRoot, ...relativeParts);
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    await fs.copyFile(args.image.filePath, targetPath);
+    const publicRoot = path.resolve('public');
+    const storageUrl = path.relative(publicRoot, targetPath).split(path.sep).join('/');
+    return {
+      storageUrl: `/${storageUrl}`,
+      storageType: 'local',
+      s3Key: null,
+      s3Bucket: null,
+    };
+  }
+
+  const key = S3Service.generateKey({
+    userId: args.createdById,
+    projectId: args.projectId,
+    fileName: args.image.fileName,
+    contentType: args.contentType,
+    flightSession: args.flightSession,
+  });
+  await S3Service.uploadBuffer(args.buffer, key, args.contentType);
+  const cloudFrontBase =
+    process.env.CLOUDFRONT_BASE_URL ??
+    process.env.NEXT_PUBLIC_CLOUDFRONT_BASE_URL ??
+    null;
+  const storageUrl = cloudFrontBase
+    ? `${cloudFrontBase.replace(/\/$/, '')}/${key}`
+    : S3Service.buildPublicUrl(key);
+
+  return {
+    storageUrl,
+    storageType: 's3',
+    s3Key: key,
+    s3Bucket: S3Service.bucketName,
+  };
+}
+
+async function extractMetadata(buffer: Buffer, fileName: string): Promise<{
+  gpsLatitude: number | null;
+  gpsLongitude: number | null;
+  altitude: number | null;
+  warnings: string[];
+}> {
+  const warnings: string[] = [];
+  try {
+    const gps = await exifr.gps(buffer);
+    if (!gps) {
+      warnings.push(`${fileName}: no GPS EXIF found`);
+      return { gpsLatitude: null, gpsLongitude: null, altitude: null, warnings };
+    }
+
+    const gpsLatitude = Number.isFinite(gps.latitude) ? gps.latitude ?? null : null;
+    const gpsLongitude = Number.isFinite(gps.longitude) ? gps.longitude ?? null : null;
+    const altitude = Number.isFinite(gps.altitude) ? gps.altitude ?? null : null;
+    if (gpsLatitude == null || gpsLongitude == null) {
+      warnings.push(`${fileName}: GPS EXIF was present but incomplete or invalid`);
+    }
+    return { gpsLatitude, gpsLongitude, altitude, warnings };
+  } catch (error) {
+    warnings.push(
+      `${fileName}: EXIF/GPS read failed: ${error instanceof Error ? error.message : 'unknown error'}`
+    );
+    return { gpsLatitude: null, gpsLongitude: null, altitude: null, warnings };
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const project = await resolveProject(options.projectRef);
+  const images = await listJpegImages(options.imagesDir);
+  const existingAssets = await prisma.asset.findMany({
+    where: { projectId: project.id },
+    select: { id: true, fileName: true },
+  });
+  const plan = planBulkRegistration(images, existingAssets);
+  const storageMode = resolveStorageMode();
+  const stemToAssetId: Record<string, string> = {};
+  const warnings: string[] = [];
+
+  for (const skipped of plan.skipped) {
+    if (skipped.assetId) {
+      stemToAssetId[fileStem(skipped.fileName)] = skipped.assetId;
+    }
+  }
+
+  for (const image of plan.toRegister) {
+    const buffer = await fs.readFile(image.filePath);
+    const sharpMetadata = await sharp(buffer).metadata();
+    if (!sharpMetadata.width || !sharpMetadata.height) {
+      throw new Error(`${image.fileName}: sharp could not determine image width/height.`);
+    }
+
+    const stat = await fs.stat(image.filePath);
+    const contentType = mimeTypeFor(image.fileName);
+    const gps = await extractMetadata(buffer, image.fileName);
+    warnings.push(...gps.warnings);
+    const stored = await storeImage({
+      projectId: project.id,
+      createdById: project.createdById,
+      image,
+      buffer,
+      contentType,
+      flightSession: options.flightSession,
+      storageMode,
+    });
+
+    const asset = await prisma.asset.create({
+      data: {
+        fileName: image.fileName,
+        storageUrl: stored.storageUrl,
+        mimeType: contentType,
+        fileSize: stat.size,
+        s3Key: stored.s3Key,
+        s3Bucket: stored.s3Bucket,
+        storageType: stored.storageType,
+        gpsLatitude: gps.gpsLatitude,
+        gpsLongitude: gps.gpsLongitude,
+        altitude: gps.altitude,
+        imageWidth: sharpMetadata.width,
+        imageHeight: sharpMetadata.height,
+        metadata: {
+          source: 'pine-bulk-register',
+          originalPath: path.resolve(image.filePath),
+          importedAt: new Date().toISOString(),
+          warnings: gps.warnings,
+        },
+        projectId: project.id,
+        createdById: project.createdById,
+        flightSession: options.flightSession || null,
+      },
+      select: { id: true },
+    });
+
+    stemToAssetId[fileStem(image.fileName)] = asset.id;
+  }
+
+  console.log(JSON.stringify({
+    ok: true,
+    projectId: project.id,
+    projectName: project.name,
+    storageMode,
+    flightSession: options.flightSession || null,
+    discoveredImages: images.length,
+    registered: plan.toRegister.length,
+    skipped: plan.skipped.length,
+    warnings,
+    stemToAssetId,
+    skippedFiles: plan.skipped,
+  }, null, 2));
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename)) {
+  main()
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : error);
+      process.exitCode = 1;
+    })
+    .finally(async () => {
+      await prisma.$disconnect().catch(() => undefined);
+    });
+}

--- a/scripts/pine-bulk-register.ts
+++ b/scripts/pine-bulk-register.ts
@@ -135,7 +135,7 @@ async function listJpegImages(imagesDir: string): Promise<ImageCandidate[]> {
   const root = path.resolve(imagesDir);
   const entries = await fs.readdir(root, { withFileTypes: true });
   const images = entries
-    .filter((entry) => entry.isFile() && /\.(jpe?g)$/i.test(entry.name))
+    .filter((entry) => (entry.isFile() || entry.isSymbolicLink()) && /\.(jpe?g)$/i.test(entry.name))
     .map((entry) => ({
       fileName: entry.name,
       filePath: path.join(root, entry.name),

--- a/scripts/pine-yolo-seg-import.ts
+++ b/scripts/pine-yolo-seg-import.ts
@@ -331,5 +331,8 @@ if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename
     })
     .finally(async () => {
       await prisma.$disconnect().catch(() => undefined);
+      // Module graph (lib/db + dataset-preparation) holds keep-alive handles
+      // that prevent natural exit; this is a CLI, so exit explicitly.
+      process.exit(process.exitCode ?? 0);
     });
 }

--- a/scripts/pine-yolo-seg-import.ts
+++ b/scripts/pine-yolo-seg-import.ts
@@ -1,0 +1,335 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import prisma from '@/lib/db';
+import { sanitizeClassName } from '@/lib/services/dataset-preparation';
+import {
+  importDinoCandidates,
+  type CandidateFile,
+  type CandidateInput,
+} from './ag3-dino-import';
+
+interface CliOptions {
+  labelsDir: string;
+  projectId: string;
+  sessionName?: string;
+  className: string;
+  dryRun: boolean;
+}
+
+interface AssetLookup {
+  id: string;
+  fileName: string;
+  imageWidth: number | null;
+  imageHeight: number | null;
+}
+
+export interface ParsedYoloSegRow {
+  sourceClassId: string;
+  points: Array<[number, number]>;
+}
+
+interface BuildCandidatesResult {
+  candidateFile: CandidateFile;
+  summary: {
+    labelFiles: number;
+    matchedAssets: number;
+    candidates: number;
+    className: string;
+    stemToAssetId: Record<string, string>;
+  };
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: Partial<CliOptions> = {
+    className: 'pine_sapling',
+    dryRun: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === '--labels-dir') {
+      options.labelsDir = requireValue(arg, next);
+      index += 1;
+    } else if (arg === '--project') {
+      options.projectId = requireValue(arg, next);
+      index += 1;
+    } else if (arg === '--session-name') {
+      options.sessionName = requireValue(arg, next);
+      index += 1;
+    } else if (arg === '--class') {
+      options.className = requireValue(arg, next);
+      index += 1;
+    } else if (arg === '--dry-run') {
+      options.dryRun = true;
+    } else if (arg === '--help' || arg === '-h') {
+      printHelpAndExit();
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!options.labelsDir) {
+    throw new Error('Provide --labels-dir <dir>.');
+  }
+  if (!options.projectId) {
+    throw new Error('Provide --project <projectId>.');
+  }
+
+  return options as CliOptions;
+}
+
+function requireValue(flag: string, value: string | undefined): string {
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${flag} requires a value.`);
+  }
+  return value;
+}
+
+function printHelpAndExit(): never {
+  console.log(`
+Usage:
+  npm run ag3:pine-yolo-seg-import -- --labels-dir /path/to/labels --project <projectId> --session-name "Pine SAM3 batch"
+  npm run ag3:pine-yolo-seg-import -- --labels-dir /path/to/labels --project <projectId> --dry-run
+
+YOLO-seg label rows must be: class x1 y1 x2 y2 ... with normalized polygon coordinates.
+The label filename stem must match an image filename stem in the project.
+`);
+  process.exit(0);
+}
+
+export function parseYoloSegLabelLine(line: string, source: string): ParsedYoloSegRow {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    throw new Error(`${source}: empty YOLO-seg row`);
+  }
+
+  const parts = trimmed.split(/\s+/);
+  if (parts.length < 7) {
+    throw new Error(`${source}: YOLO-seg row must contain class plus at least three points`);
+  }
+  if ((parts.length - 1) % 2 !== 0) {
+    throw new Error(`${source}: YOLO-seg row has an odd number of polygon coordinates`);
+  }
+
+  const sourceClassId = parts[0];
+  const coordinates = parts.slice(1).map((value) => Number(value));
+  if (!coordinates.every(Number.isFinite)) {
+    throw new Error(`${source}: YOLO-seg row contains a non-numeric coordinate`);
+  }
+
+  const points: Array<[number, number]> = [];
+  for (let index = 0; index < coordinates.length; index += 2) {
+    const x = coordinates[index];
+    const y = coordinates[index + 1];
+    if (x < 0 || x > 1 || y < 0 || y > 1) {
+      throw new Error(`${source}: normalized polygon coordinate is outside 0..1`);
+    }
+    points.push([x, y]);
+  }
+
+  return { sourceClassId, points };
+}
+
+export function denormalizeYoloSegRow(
+  row: ParsedYoloSegRow,
+  imageWidth: number,
+  imageHeight: number
+): { polygon: number[][]; bbox: [number, number, number, number] } {
+  const polygon = row.points.map(([x, y]) => [x * imageWidth, y * imageHeight]);
+  const xs = polygon.map((point) => point[0]);
+  const ys = polygon.map((point) => point[1]);
+  return {
+    polygon,
+    bbox: [
+      Math.min(...xs),
+      Math.min(...ys),
+      Math.max(...xs),
+      Math.max(...ys),
+    ],
+  };
+}
+
+export function buildStemAssetMap(assets: AssetLookup[]): Map<string, AssetLookup[]> {
+  const byStem = new Map<string, AssetLookup[]>();
+  for (const asset of assets) {
+    const stem = path.parse(asset.fileName).name;
+    const group = byStem.get(stem) || [];
+    group.push(asset);
+    byStem.set(stem, group);
+  }
+  return byStem;
+}
+
+export async function buildPineYoloSegCandidates(args: {
+  labelsDir: string;
+  projectId: string;
+  className: string;
+  assets: AssetLookup[];
+}): Promise<BuildCandidatesResult> {
+  const labelsDir = path.resolve(args.labelsDir);
+  const entries = await fs.readdir(labelsDir, { withFileTypes: true });
+  const labelFiles = entries
+    .filter((entry) => entry.isFile() && path.extname(entry.name).toLowerCase() === '.txt')
+    .map((entry) => entry.name)
+    .sort((left, right) => left.localeCompare(right));
+
+  if (labelFiles.length === 0) {
+    throw new Error(`No .txt label files found in ${labelsDir}.`);
+  }
+
+  const className = sanitizeClassName(args.className);
+  if (!className) {
+    throw new Error(`Class name "${args.className}" is empty after sanitization.`);
+  }
+
+  const assetsByStem = buildStemAssetMap(args.assets);
+  const candidates: CandidateInput[] = [];
+  const stemToAssetId: Record<string, string> = {};
+
+  for (const labelFile of labelFiles) {
+    const stem = path.parse(labelFile).name;
+    const matches = assetsByStem.get(stem) || [];
+    if (matches.length === 0) {
+      throw new Error(`${labelFile}: no asset in project ${args.projectId} has filename stem "${stem}".`);
+    }
+    if (matches.length > 1) {
+      throw new Error(
+        `${labelFile}: filename stem "${stem}" is ambiguous across assets ${matches
+          .map((asset) => `${asset.id} (${asset.fileName})`)
+          .join(', ')}.`
+      );
+    }
+
+    const asset = matches[0];
+    if (!asset.imageWidth || !asset.imageHeight) {
+      throw new Error(
+        `${labelFile}: asset ${asset.id} (${asset.fileName}) is missing imageWidth/imageHeight; bulk-register or backfill dimensions before import.`
+      );
+    }
+
+    stemToAssetId[stem] = asset.id;
+    const raw = await fs.readFile(path.join(labelsDir, labelFile), 'utf8');
+    const lines = raw.split(/\r?\n/);
+    for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+      const line = lines[lineIndex].trim();
+      if (!line) continue;
+      const parsed = parseYoloSegLabelLine(line, `${labelFile}:${lineIndex + 1}`);
+      const { polygon, bbox } = denormalizeYoloSegRow(
+        parsed,
+        asset.imageWidth,
+        asset.imageHeight
+      );
+      candidates.push({
+        assetId: asset.id,
+        className,
+        confidence: 1,
+        bbox,
+        polygon,
+        notes: `YOLO-seg import ${labelFile}:${lineIndex + 1}`,
+      });
+    }
+  }
+
+  if (candidates.length === 0) {
+    throw new Error(`No YOLO-seg rows found in ${labelsDir}.`);
+  }
+
+  return {
+    candidateFile: {
+      schemaVersion: 'ag3-dino-candidates/v1',
+      projectId: args.projectId,
+      className,
+      generator: {
+        source: 'pine-yolo-seg-import',
+        labelsDir,
+      },
+      candidates,
+    },
+    summary: {
+      labelFiles: labelFiles.length,
+      matchedAssets: Object.keys(stemToAssetId).length,
+      candidates: candidates.length,
+      className,
+      stemToAssetId,
+    },
+  };
+}
+
+async function resolveProjectOwner(projectId: string): Promise<{ teamId: string; createdById: string }> {
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    select: {
+      id: true,
+      teamId: true,
+      team: {
+        select: {
+          members: {
+            orderBy: { createdAt: 'asc' },
+            take: 1,
+            select: { userId: true },
+          },
+        },
+      },
+    },
+  });
+
+  if (!project) {
+    throw new Error(`Project not found: ${projectId}`);
+  }
+  const createdById = project.team.members[0]?.userId;
+  if (!createdById) {
+    throw new Error(`Project ${projectId} has no team members to own the review session.`);
+  }
+
+  return { teamId: project.teamId, createdById };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const assets = await prisma.asset.findMany({
+    where: { projectId: options.projectId },
+    select: {
+      id: true,
+      fileName: true,
+      imageWidth: true,
+      imageHeight: true,
+    },
+  });
+
+  const built = await buildPineYoloSegCandidates({
+    labelsDir: options.labelsDir,
+    projectId: options.projectId,
+    className: options.className,
+    assets,
+  });
+
+  const owner = await resolveProjectOwner(options.projectId);
+  const result = await importDinoCandidates({
+    candidateFile: built.candidateFile,
+    createReviewSession: true,
+    dryRun: options.dryRun,
+    reviewSessionOwner: {
+      ...owner,
+      yoloModelName: options.sessionName || 'Pine YOLO-seg import',
+    },
+  });
+
+  console.log(JSON.stringify({
+    ...result,
+    dryRun: options.dryRun || result.dryRun || undefined,
+    importSummary: built.summary,
+  }, null, 2));
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename)) {
+  main()
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : error);
+      process.exitCode = 1;
+    })
+    .finally(async () => {
+      await prisma.$disconnect().catch(() => undefined);
+    });
+}

--- a/scripts/pine-yolo-seg-import.ts
+++ b/scripts/pine-yolo-seg-import.ts
@@ -52,7 +52,7 @@ function parseArgs(argv: string[]): CliOptions {
     if (arg === '--labels-dir') {
       options.labelsDir = requireValue(arg, next);
       index += 1;
-    } else if (arg === '--project') {
+    } else if (arg === '--project' || arg === '--project-id') {
       options.projectId = requireValue(arg, next);
       index += 1;
     } else if (arg === '--session-name') {

--- a/tests/unit/pine-bulk-register.test.ts
+++ b/tests/unit/pine-bulk-register.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  default: {
+    $disconnect: vi.fn(),
+  },
+}));
+
+import { planBulkRegistration } from '@/scripts/pine-bulk-register';
+
+describe('pine bulk register planning', () => {
+  it('skips already-registered filename stems and duplicate input stems', () => {
+    const plan = planBulkRegistration(
+      [
+        { fileName: 'PINE_001.JPG', filePath: '/images/PINE_001.JPG' },
+        { fileName: 'PINE_002.jpg', filePath: '/images/PINE_002.jpg' },
+        { fileName: 'PINE_002.jpeg', filePath: '/images/PINE_002.jpeg' },
+        { fileName: 'PINE_003.JPG', filePath: '/images/PINE_003.JPG' },
+      ],
+      [
+        { id: 'asset-1', fileName: 'PINE_001.jpg' },
+        { id: 'asset-9', fileName: 'other.jpg' },
+      ]
+    );
+
+    expect(plan.toRegister).toEqual([
+      { fileName: 'PINE_002.jpg', filePath: '/images/PINE_002.jpg' },
+      { fileName: 'PINE_003.JPG', filePath: '/images/PINE_003.JPG' },
+    ]);
+    expect(plan.skipped).toEqual([
+      {
+        fileName: 'PINE_001.JPG',
+        assetId: 'asset-1',
+        reason: 'filename_stem_already_registered',
+      },
+      {
+        fileName: 'PINE_002.jpeg',
+        assetId: '',
+        reason: 'duplicate_input_filename_stem',
+      },
+    ]);
+  });
+});

--- a/tests/unit/pine-yolo-seg-import.test.ts
+++ b/tests/unit/pine-yolo-seg-import.test.ts
@@ -1,0 +1,145 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  default: {
+    $disconnect: vi.fn(),
+  },
+}));
+
+import {
+  buildPineYoloSegCandidates,
+  denormalizeYoloSegRow,
+  parseYoloSegLabelLine,
+} from '@/scripts/pine-yolo-seg-import';
+
+describe('pine YOLO-seg import helpers', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pine-yolo-seg-import-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('parses YOLO-seg rows and denormalizes polygons/bboxes against image dimensions', () => {
+    const row = parseYoloSegLabelLine(
+      '0 0.100000 0.200000 0.300000 0.200000 0.300000 0.500000 0.100000 0.500000',
+      'PINE_001.txt:1'
+    );
+
+    expect(row).toEqual({
+      sourceClassId: '0',
+      points: [
+        [0.1, 0.2],
+        [0.3, 0.2],
+        [0.3, 0.5],
+        [0.1, 0.5],
+      ],
+    });
+    expect(denormalizeYoloSegRow(row, 1000, 500)).toEqual({
+      polygon: [
+        [100, 100],
+        [300, 100],
+        [300, 250],
+        [100, 250],
+      ],
+      bbox: [100, 100, 300, 250],
+    });
+  });
+
+  it('rejects malformed YOLO-seg rows with clear source context', () => {
+    expect(() => parseYoloSegLabelLine('0 0.1 0.2 0.3', 'bad.txt:4')).toThrow(
+      'bad.txt:4: YOLO-seg row must contain class plus at least three points'
+    );
+    expect(() => parseYoloSegLabelLine('0 0.1 0.2 0.3 0.4 0.5 1.2', 'bad.txt:5')).toThrow(
+      'bad.txt:5: normalized polygon coordinate is outside 0..1'
+    );
+  });
+
+  it('builds DINO-compatible candidates by filename stem and collapses to one sanitized class', async () => {
+    await fs.writeFile(
+      path.join(tempDir, 'PINE_001.txt'),
+      [
+        '0 0.1 0.2 0.3 0.2 0.3 0.5 0.1 0.5',
+        '7 0.4 0.4 0.6 0.4 0.6 0.7 0.4 0.7',
+      ].join('\n')
+    );
+
+    const built = await buildPineYoloSegCandidates({
+      labelsDir: tempDir,
+      projectId: 'project-1',
+      className: 'Pine Sapling',
+      assets: [
+        {
+          id: 'asset-1',
+          fileName: 'PINE_001.JPG',
+          imageWidth: 1000,
+          imageHeight: 500,
+        },
+      ],
+    });
+
+    expect(built.summary).toMatchObject({
+      labelFiles: 1,
+      matchedAssets: 1,
+      candidates: 2,
+      className: 'pine_sapling',
+      stemToAssetId: { PINE_001: 'asset-1' },
+    });
+    expect(built.candidateFile).toMatchObject({
+      schemaVersion: 'ag3-dino-candidates/v1',
+      projectId: 'project-1',
+      className: 'pine_sapling',
+    });
+    expect(built.candidateFile.candidates).toEqual([
+      expect.objectContaining({
+        assetId: 'asset-1',
+        className: 'pine_sapling',
+        confidence: 1,
+        bbox: [100, 100, 300, 250],
+        polygon: [
+          [100, 100],
+          [300, 100],
+          [300, 250],
+          [100, 250],
+        ],
+      }),
+      expect.objectContaining({
+        assetId: 'asset-1',
+        className: 'pine_sapling',
+        confidence: 1,
+        bbox: [400, 200, 600, 350],
+      }),
+    ]);
+  });
+
+  it('aborts when the matched asset is missing image dimensions', async () => {
+    await fs.writeFile(
+      path.join(tempDir, 'PINE_001.txt'),
+      '0 0.1 0.2 0.3 0.2 0.3 0.5 0.1 0.5\n'
+    );
+
+    await expect(
+      buildPineYoloSegCandidates({
+        labelsDir: tempDir,
+        projectId: 'project-1',
+        className: 'pine_sapling',
+        assets: [
+          {
+            id: 'asset-1',
+            fileName: 'PINE_001.JPG',
+            imageWidth: null,
+            imageHeight: 500,
+          },
+        ],
+      })
+    ).rejects.toThrow(
+      'PINE_001.txt: asset asset-1 (PINE_001.JPG) is missing imageWidth/imageHeight'
+    );
+  });
+});

--- a/tests/unit/training-dataset-sources.test.ts
+++ b/tests/unit/training-dataset-sources.test.ts
@@ -12,14 +12,24 @@ describe('training dataset sources', () => {
       includeAI: boolean,
       includeManual: boolean,
       minConfidence: number,
-      includeSAM3: boolean
+      includeSAM3: boolean,
+      task?: 'detect' | 'segment'
     ) => Array<{
       classId: number;
       bbox: { x: number; y: number; width: number; height: number };
+      polygon?: Array<[number, number]>;
     }>;
+    formatYOLOAnnotation: (
+      annotation: {
+        classId: number;
+        bbox: { x: number; y: number; width: number; height: number };
+        polygon?: Array<[number, number]>;
+      },
+      task?: 'detect' | 'segment'
+    ) => string;
   };
 
-  function convertToYOLO(asset: Record<string, unknown>) {
+  function convertToYOLO(asset: Record<string, unknown>, task: 'detect' | 'segment' = 'detect') {
     return datasetPreparationInternals.convertToYOLO(
       {
         id: 'asset-1',
@@ -32,7 +42,8 @@ describe('training dataset sources', () => {
       true,
       true,
       0.5,
-      true
+      true,
+      task
     );
   }
 
@@ -74,6 +85,76 @@ describe('training dataset sources', () => {
         },
       },
     ]);
+  });
+
+  it('keeps default detect label output byte-identical for bbox callers', () => {
+    const labels = convertToYOLO({
+      pendingAnnotations: [
+        {
+          weedType: 'Lantana',
+          confidence: 0.92,
+          status: 'ACCEPTED',
+          bbox: [10, 20, 50, 80],
+          polygon: [
+            [10, 20],
+            [50, 20],
+            [50, 80],
+            [10, 80],
+          ],
+        },
+      ],
+    });
+
+    expect(labels).toEqual([
+      {
+        classId: 0,
+        bbox: {
+          x: 0.3,
+          y: 0.5,
+          width: 0.4,
+          height: 0.6,
+        },
+      },
+    ]);
+    expect(datasetPreparationInternals.formatYOLOAnnotation(labels[0])).toBe(
+      '0 0.300000 0.500000 0.400000 0.600000'
+    );
+  });
+
+  it('emits YOLO-seg polygon rows for segment task and falls back to bbox without polygons', () => {
+    const segmentLabels = convertToYOLO(
+      {
+        pendingAnnotations: [
+          {
+            weedType: 'Lantana',
+            confidence: 0.92,
+            status: 'ACCEPTED',
+            bbox: [10, 20, 50, 80],
+            polygon: [
+              [10, 20],
+              [50, 20],
+              [50, 80],
+              [10, 80],
+            ],
+          },
+          {
+            weedType: 'Lantana',
+            confidence: 0.92,
+            status: 'ACCEPTED',
+            bbox: [60, 10, 90, 40],
+            polygon: [],
+          },
+        ],
+      },
+      'segment'
+    );
+
+    expect(datasetPreparationInternals.formatYOLOAnnotation(segmentLabels[0], 'segment')).toBe(
+      '0 0.100000 0.200000 0.500000 0.200000 0.500000 0.800000 0.100000 0.800000'
+    );
+    expect(datasetPreparationInternals.formatYOLOAnnotation(segmentLabels[1], 'segment')).toBe(
+      '0 0.750000 0.250000 0.300000 0.300000'
+    );
   });
 
   it('excludes pending and rejected SAM3 labels from YOLO datasets', () => {

--- a/tests/unit/yolo-training-service.test.ts
+++ b/tests/unit/yolo-training-service.test.ts
@@ -32,6 +32,7 @@ describe('yolo training service', () => {
       batch_size: 8,
       image_size: 960,
       learning_rate: 0.005,
+      task: 'detect',
       augmentation: {
         preset: 'agricultural',
         fliplr: 0.5,


### PR DESCRIPTION
## Summary

Closes the three gaps between the SAM3 batch auto-labeller and a fully self-hosted review→train loop (Roboflow replacement for this workflow):

1. **`scripts/pine-yolo-seg-import.ts`** — imports externally-generated YOLO-seg labels (normalized polygons, one txt per image) as reviewable `PendingAnnotation`s via the existing `importDinoCandidates` path (now exported rather than duplicated). Resolves filename stems to assets, enforces populated image dimensions (45MP denormalization guard), `--dry-run` supported.
2. **`task=segment` dataset export** — `dataset-preparation` emits YOLO-seg polygon rows when `task: "segment"` and a polygon exists. **Default remains `detect` with byte-identical output, regression-tested**, so existing training flows are unchanged. Task threaded through review push, training dataset, and version routes.
3. **`scripts/pine-bulk-register.ts`** — headless, idempotent bulk registration of large JPGs (sharp dimensions, EXIF warn-only, no AI-on-upload), printing the stem→assetId map the importer joins on.

## Tests

84/84 unit tests passing (vitest), including byte-identical default-detect regression. Lint warnings are pre-existing (unused var + hook deps in unrelated files).

## Context

First consumer: 267 Glasshouse pine images with 25,818 SAM3 text-prompt generated polygons (recall 0.72 / precision 0.63 vs the 11 human-labeled GT images; plantation terrain much stronger than grassy verges). Review flow: delete wrong boxes per image + existing bulk-accept, then `task: segment` export to the EC2 YOLO11 training service.

Stacked on `codex/promote-ag3-dino-bundle-fix` (needs the `PendingAnnotation` importer from #197/#198 lineage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)