### PR TITLE
Persist Teach batch progress and expose the SAM3 route

### DIFF
--- a/app/api/sam3/v2/batch/[batchId]/route.ts
+++ b/app/api/sam3/v2/batch/[batchId]/route.ts
@@ -6,6 +6,7 @@ import {
   SAM3_BATCH_JOB_KINDS,
   summarizeChildBatchJobs,
 } from '@/lib/utils/sam3-batch-jobs';
+import { summarizeSam3BatchExecution } from '@/lib/utils/sam3-batch-execution';
 
 interface RouteParams {
   params: Promise<{ batchId: string }>;
@@ -151,6 +152,10 @@ export async function GET(
     });
 
     const aggregateStageInfo = summarizeChildBatchJobs(childStageSummaries);
+    const execution = summarizeSam3BatchExecution(
+      childJobs.map((childJob) => parseStageLog(childJob.stageLog)),
+      batchJob.mode
+    );
     const assetSummary = childStageSummaries.reduce(
       (summary, child) => {
         summary.success += child.assetSummary.success;
@@ -212,6 +217,7 @@ export async function GET(
         accepted: statusCounts.ACCEPTED || 0,
         rejected: statusCounts.REJECTED || 0,
       },
+      execution,
       annotations,
     });
   }
@@ -251,6 +257,7 @@ export async function GET(
   const totalAnnotations = groupedStatusCounts.reduce((sum, row) => sum + row._count._all, 0);
   const stageLog = parseStageLog(batchJob.stageLog);
   const stageSummary = summarizeStageLog(stageLog);
+  const execution = summarizeSam3BatchExecution([stageLog], batchJob.mode);
 
   return NextResponse.json({
     success: true,
@@ -288,6 +295,7 @@ export async function GET(
       accepted: statusCounts.ACCEPTED || 0,
       rejected: statusCounts.REJECTED || 0,
     },
+    execution,
     annotations,
   });
 }

--- a/components/teach/TeachBatchStatus.tsx
+++ b/components/teach/TeachBatchStatus.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import {
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle2,
+  Clock3,
+  Cpu,
+  Loader2,
+  RotateCcw,
+  ShieldCheck,
+} from "lucide-react";
+import {
+  describeTeachBatchStage,
+  getTeachBatchProgress,
+  type TeachBatchJobStatus,
+  type TeachBatchStatusResponse,
+} from "@/lib/utils/teach-batch-run";
+
+interface TeachBatchStatusProps {
+  status: TeachBatchJobStatus;
+  summary?: TeachBatchStatusResponse["summary"];
+  execution?: TeachBatchStatusResponse["execution"];
+  pollError?: string | null;
+  reviewing?: boolean;
+  onRetryStatus: () => void;
+  onReview: () => void;
+  onStartAgain: () => void;
+}
+
+export function TeachBatchStatus({
+  status,
+  summary,
+  execution,
+  pollError,
+  reviewing = false,
+  onRetryStatus,
+  onReview,
+  onStartAgain,
+}: TeachBatchStatusProps) {
+  const progress = getTeachBatchProgress(status.processedImages, status.totalImages);
+  const complete = status.status === "COMPLETED";
+  const failed = status.status === "FAILED" || status.status === "CANCELLED";
+  const active = !complete && !failed;
+  const title = describeTeachBatchStage(status);
+
+  return (
+    <section
+      aria-live="polite"
+      className={`mx-5 mt-3 rounded-xl border px-4 py-4 shadow-sm lg:mx-7 ${
+        failed
+          ? "border-red-200 bg-red-50"
+          : complete
+            ? "border-emerald-200 bg-emerald-50"
+            : "border-blue-200 bg-blue-50"
+      }`}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex min-w-0 gap-3">
+          <span className={`mt-0.5 flex h-9 w-9 flex-none items-center justify-center rounded-lg ${failed ? "bg-red-100 text-red-700" : complete ? "bg-emerald-100 text-emerald-700" : "bg-blue-100 text-blue-700"}`}>
+            {failed ? <AlertTriangle className="h-5 w-5" /> : complete ? <CheckCircle2 className="h-5 w-5" /> : status.status === "QUEUED" ? <Clock3 className="h-5 w-5" /> : <Loader2 className="h-5 w-5 animate-spin" />}
+          </span>
+          <div className="min-w-0">
+            <h2 className="font-semibold text-gray-950">{title}</h2>
+            <p className="mt-1 text-sm text-gray-600">
+              {status.processedImages} of {status.totalImages} images processed
+              {status.detectionsFound > 0 ? ` · ${status.detectionsFound} suggestions found` : ""}
+            </p>
+          </div>
+        </div>
+        <span className="rounded-full border border-current/15 bg-white/70 px-2.5 py-1 text-xs font-semibold text-gray-700">
+          {status.status.toLowerCase().replaceAll("_", " ")}
+        </span>
+      </div>
+
+      <div className="mt-3 h-2 overflow-hidden rounded-full bg-white/80" aria-label={`${progress}% complete`}>
+        <div className={`h-full rounded-full transition-all ${failed ? "bg-red-500" : complete ? "bg-emerald-500" : "bg-blue-500"}`} style={{ width: `${progress}%` }} />
+      </div>
+
+      {summary && complete ? (
+        <p className="mt-3 text-sm text-gray-700">
+          {summary.pending} pending review · {summary.accepted} accepted · {summary.rejected} rejected
+        </p>
+      ) : null}
+
+      {status.errorMessage ? (
+        <div className={`mt-3 rounded-lg border px-3 py-2 text-sm ${failed ? "border-red-200 bg-white text-red-800" : "border-amber-200 bg-amber-50 text-amber-900"}`}>
+          {status.errorMessage}
+        </div>
+      ) : null}
+
+      {pollError ? (
+        <div className="mt-3 flex flex-wrap items-center justify-between gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+          <span>{pollError}</span>
+          <button type="button" onClick={onRetryStatus} className="inline-flex items-center gap-1.5 font-semibold text-amber-950">
+            <RotateCcw className="h-3.5 w-3.5" /> Check again
+          </button>
+        </div>
+      ) : null}
+
+      <details className="mt-3 rounded-lg border border-gray-200/80 bg-white/70 px-3 py-2.5 text-sm text-gray-700">
+        <summary className="cursor-pointer font-medium text-gray-900">Technical details</summary>
+        <div className="mt-3 grid gap-2 sm:grid-cols-2">
+          <p className="flex items-start gap-2"><Cpu className="mt-0.5 h-4 w-4 flex-none text-gray-500" /><span><strong>Model route:</strong> {execution?.pipelineLabel || "Direct SAM3 batch service"}</span></p>
+          <p className="flex items-start gap-2"><ShieldCheck className="mt-0.5 h-4 w-4 flex-none text-gray-500" /><span><strong>External fallback:</strong> {execution?.externalProviderFallback === false ? "None — no YOLO or Roboflow provider fallback" : "Awaiting runtime evidence"}</span></p>
+          <p><strong>Runtime evidence:</strong> {execution?.runtimeConfirmed ? "Recorded by the worker" : "Waiting for the worker"}</p>
+          <p><strong>Review profile:</strong> {execution?.reviewProfile?.replaceAll("_", " ") || "Waiting for the worker"}</p>
+        </div>
+        {execution && (execution.candidateExpansionAssets > 0 || execution.refinementFallbackAssets > 0) ? (
+          <p className="mt-3 rounded-md bg-amber-50 px-2.5 py-2 text-amber-900">
+            Same-model recovery used on {execution.degradedAssets} image{execution.degradedAssets === 1 ? "" : "s"}: {execution.candidateExpansionAssets} lower-threshold candidate expansion · {execution.refinementFallbackAssets} unrefined candidate fallback. Review these suggestions carefully.
+          </p>
+        ) : null}
+      </details>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {complete ? (
+          <button type="button" onClick={onReview} disabled={reviewing} className="inline-flex h-10 items-center gap-2 rounded-lg bg-emerald-600 px-4 text-sm font-semibold text-white hover:bg-emerald-700 disabled:opacity-60">
+            {reviewing ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
+            {reviewing ? "Opening review…" : "Review these suggestions"}
+            {!reviewing && <ArrowRight className="h-4 w-4" />}
+          </button>
+        ) : null}
+        {complete ? (
+          <button type="button" onClick={onStartAgain} disabled={reviewing} className="inline-flex h-10 items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 text-sm font-semibold text-gray-800 hover:bg-gray-50 disabled:opacity-60">
+            <RotateCcw className="h-4 w-4" /> Start a new search
+          </button>
+        ) : null}
+        {failed ? (
+          <button type="button" onClick={onStartAgain} className="inline-flex h-10 items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 text-sm font-semibold text-gray-800 hover:bg-gray-50">
+            <RotateCcw className="h-4 w-4" /> Start this search again
+          </button>
+        ) : null}
+        {active && pollError ? (
+          <button type="button" onClick={onStartAgain} className="inline-flex h-10 items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 text-sm font-semibold text-gray-800 hover:bg-gray-50">
+            Discard saved search
+          </button>
+        ) : null}
+        {active ? <p className="self-center text-xs text-gray-600">You can leave this page. Progress will be restored when you return.</p> : null}
+      </div>
+    </section>
+  );
+}

--- a/components/teach/TeachWorkspace.tsx
+++ b/components/teach/TeachWorkspace.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   ArrowRight,
   Box,
@@ -24,6 +24,14 @@ import {
   X,
 } from "lucide-react";
 import { useSignedUrl } from "@/lib/hooks/useSignedUrl";
+import { TeachBatchStatus } from "@/components/teach/TeachBatchStatus";
+import {
+  isTeachBatchTerminal,
+  parseTeachBatchRun,
+  TEACH_BATCH_RUN_STORAGE_KEY,
+  type TeachBatchRun,
+  type TeachBatchStatusResponse,
+} from "@/lib/utils/teach-batch-run";
 
 interface Project {
   id: string;
@@ -74,16 +82,17 @@ const GUIDE_ITEMS = [
   { icon: Leaf, title: "Different growth stages", body: "Include young, mature, and flowering plants." },
 ];
 
-function Thumbnail({ asset, active, demo, onSelect }: { asset: Asset; active: boolean; demo: boolean; onSelect: () => void }) {
+function Thumbnail({ asset, active, demo, disabled, onSelect }: { asset: Asset; active: boolean; demo: boolean; disabled: boolean; onSelect: () => void }) {
   const signed = useSignedUrl(demo ? null : asset.id, "asset", asset.storageUrl);
   const src = demo ? asset.storageUrl : signed.url || asset.storageUrl;
   return (
     <button
       type="button"
       onClick={onSelect}
+      disabled={disabled}
       aria-label={`Use ${asset.fileName} as the source image`}
       aria-current={active ? "true" : undefined}
-      className={`relative h-[74px] w-[100px] flex-none overflow-hidden rounded-lg border-2 bg-gray-100 transition focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${active ? "border-blue-500 shadow-sm" : "border-transparent hover:border-gray-300"}`}
+      className={`relative h-[74px] w-[100px] flex-none overflow-hidden rounded-lg border-2 bg-gray-100 transition focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 ${active ? "border-blue-500 shadow-sm" : "border-transparent hover:border-gray-300"}`}
     >
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
@@ -98,6 +107,7 @@ function Thumbnail({ asset, active, demo, onSelect }: { asset: Asset; active: bo
 }
 
 export default function TeachWorkspace() {
+  const router = useRouter();
   const searchParams = useSearchParams();
   const demo = process.env.NODE_ENV !== "production" && searchParams.get("demo") === "1";
   const [projects, setProjects] = useState<Project[]>(demo ? [DEMO_PROJECT] : []);
@@ -120,6 +130,12 @@ export default function TeachWorkspace() {
   const [imageSize, setImageSize] = useState({ width: 1536, height: 1024 });
   const [frameSize, setFrameSize] = useState({ width: 1, height: 1 });
   const [filter, setFilter] = useState("");
+  const [activeRun, setActiveRun] = useState<TeachBatchRun | null>(null);
+  const [batchData, setBatchData] = useState<TeachBatchStatusResponse | null>(null);
+  const [pollError, setPollError] = useState<string | null>(null);
+  const [pollNonce, setPollNonce] = useState(0);
+  const [openingReview, setOpeningReview] = useState(false);
+  const [storageReady, setStorageReady] = useState(false);
   const imageRef = useRef<HTMLDivElement>(null);
   const filmstripRef = useRef<HTMLDivElement>(null);
 
@@ -128,6 +144,8 @@ export default function TeachWorkspace() {
   const signedMain = useSignedUrl(demo ? null : asset?.id || null, "asset", asset?.storageUrl);
   const mainImage = demo ? asset?.storageUrl : signedMain.url || asset?.storageUrl;
   const batchCount = demo ? 146 : assets.length;
+  const batchLocked = Boolean(activeRun);
+  const batchBusy = Boolean(activeRun && (!batchData || !isTeachBatchTerminal(batchData.batchJob.status)));
   const visibleAssets = useMemo(() => {
     const query = filter.trim().toLowerCase();
     return query ? assets.filter((item, index) => item.fileName.toLowerCase().includes(query) || String(index + 1).includes(query)) : assets;
@@ -166,6 +184,48 @@ export default function TeachWorkspace() {
   }, [demo, searchParams]);
 
   useEffect(() => {
+    if (demo) {
+      setStorageReady(true);
+      return;
+    }
+    const restored = parseTeachBatchRun(window.localStorage.getItem(TEACH_BATCH_RUN_STORAGE_KEY));
+    setActiveRun(restored);
+    if (restored) {
+      setBatchData({
+        batchJob: {
+          id: restored.batchJobId,
+          projectId: restored.projectId,
+          weedType: restored.target,
+          status: "QUEUED",
+          mode: "concept_propagation",
+          processedImages: 0,
+          totalImages: 0,
+          detectionsFound: 0,
+        },
+      });
+    }
+    setStorageReady(true);
+  }, [demo]);
+
+  useEffect(() => {
+    if (!storageReady || demo) return;
+    if (activeRun) {
+      window.localStorage.setItem(TEACH_BATCH_RUN_STORAGE_KEY, JSON.stringify(activeRun));
+    } else {
+      window.localStorage.removeItem(TEACH_BATCH_RUN_STORAGE_KEY);
+    }
+  }, [activeRun, demo, storageReady]);
+
+  useEffect(() => {
+    if (!activeRun || projects.length === 0) return;
+    if (projects.some((item) => item.id === activeRun.projectId)) {
+      setProjectId(activeRun.projectId);
+      setTarget(activeRun.target);
+      setTargetDraft(activeRun.target);
+    }
+  }, [activeRun, projects]);
+
+  useEffect(() => {
     if (demo || !projectId) return;
     let cancelled = false;
     async function loadAssets() {
@@ -190,6 +250,65 @@ export default function TeachWorkspace() {
   }, [demo, projectId]);
 
   useEffect(() => {
+    if (demo || !activeRun) return;
+
+    const controller = new AbortController();
+    let cancelled = false;
+    let timer: number | null = null;
+    let consecutiveFailures = 0;
+
+    const schedule = (delay: number) => {
+      if (!cancelled) timer = window.setTimeout(fetchStatus, delay);
+    };
+
+    const fetchStatus = async () => {
+      try {
+        const response = await fetch(`${activeRun.pollUrl}?includeAnnotations=false`, {
+          signal: controller.signal,
+        });
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok) {
+          const error = new Error(data.error || "The batch status could not be loaded.");
+          error.name = response.status === 401 || response.status === 403 || response.status === 404
+            ? "TerminalStatusError"
+            : "StatusError";
+          throw error;
+        }
+        if (cancelled || !data?.batchJob) return;
+        if (data.batchJob.id !== activeRun.batchJobId || data.batchJob.projectId !== activeRun.projectId) {
+          throw new Error("The restored batch does not match this project.");
+        }
+
+        consecutiveFailures = 0;
+        setPollError(null);
+        setBatchData(data as TeachBatchStatusResponse);
+        if (!isTeachBatchTerminal(data.batchJob.status)) schedule(3000);
+      } catch (statusError) {
+        if (cancelled || controller.signal.aborted) return;
+        consecutiveFailures += 1;
+        const message = statusError instanceof Error ? statusError.message : "The batch status could not be loaded.";
+        setPollError(
+          statusError instanceof Error && statusError.name === "TerminalStatusError"
+            ? message
+            : consecutiveFailures >= 5
+              ? "Status updates paused after repeated connection failures. Your batch has not been cancelled."
+              : "Connection interrupted. Retrying the batch status…"
+        );
+        if (!(statusError instanceof Error && statusError.name === "TerminalStatusError") && consecutiveFailures < 5) {
+          schedule(5000);
+        }
+      }
+    };
+
+    void fetchStatus();
+    return () => {
+      cancelled = true;
+      controller.abort();
+      if (timer) window.clearTimeout(timer);
+    };
+  }, [activeRun, demo, pollNonce]);
+
+  useEffect(() => {
     const frame = imageRef.current;
     if (!frame) return;
     const update = () => setFrameSize({ width: frame.clientWidth || 1, height: frame.clientHeight || 1 });
@@ -212,7 +331,7 @@ export default function TeachWorkspace() {
   }
 
   function beginBox(event: React.PointerEvent<HTMLDivElement>) {
-    if (boxes.length >= 8) return;
+    if (batchLocked || boxes.length >= 8) return;
     const point = eventPoint(event);
     if (!point) return;
     event.currentTarget.setPointerCapture(event.pointerId);
@@ -243,6 +362,7 @@ export default function TeachWorkspace() {
   }
 
   function handleCanvasKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (batchLocked) return;
     if (!["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Enter", "Escape"].includes(event.key)) return;
     event.preventDefault();
     if (event.key === "Escape") {
@@ -269,6 +389,7 @@ export default function TeachWorkspace() {
   }
 
   function selectAsset(nextAsset: Asset) {
+    if (batchLocked) return;
     if (nextAsset.id === assetId) return;
     if (boxes.length && !window.confirm("Choose a different source image? Your current example boxes will be cleared.")) return;
     setAssetId(nextAsset.id);
@@ -304,7 +425,7 @@ export default function TeachWorkspace() {
   }
 
   async function searchBatch() {
-    if (!project || !asset || boxes.length < 3) return;
+    if (!project || !asset || boxes.length < 3 || batchBusy) return;
     setSubmitting(true);
     setError(null);
     setNotice(null);
@@ -332,11 +453,77 @@ export default function TeachWorkspace() {
       });
       const data = await response.json().catch(() => ({}));
       if (!response.ok) throw new Error(data.error || "The search could not be started.");
-      setNotice(`Search started across ${assets.length} images. Every suggestion will wait in Review.`);
+      if (!data.batchJobId) throw new Error("The search started without a traceable batch ID.");
+      const run: TeachBatchRun = {
+        batchJobId: data.batchJobId,
+        pollUrl: data.pollUrl || `/api/sam3/v2/batch/${data.batchJobId}`,
+        projectId: project.id,
+        target,
+        submittedAt: new Date().toISOString(),
+      };
+      setActiveRun(run);
+      setBatchData({
+        batchJob: {
+          id: data.batchJobId,
+          projectId: project.id,
+          weedType: target,
+          status: data.status || "QUEUED",
+          mode: data.mode || "concept_propagation",
+          processedImages: data.processedImages || 0,
+          totalImages: data.totalImages || assets.length,
+          detectionsFound: 0,
+        },
+      });
+      setNotice(null);
     } catch (submitError) {
       setError(submitError instanceof Error ? submitError.message : "The search could not be started.");
     } finally {
       setSubmitting(false);
+    }
+  }
+
+  function clearActiveRun(message?: string) {
+    setActiveRun(null);
+    setBatchData(null);
+    setPollError(null);
+    setOpeningReview(false);
+    if (message) setNotice(message);
+  }
+
+  async function openBatchReview() {
+    if (!activeRun || !batchData || batchData.batchJob.status !== "COMPLETED") return;
+    if (activeRun.reviewSessionId) {
+      router.push(`/review?sessionId=${activeRun.reviewSessionId}`);
+      return;
+    }
+
+    setOpeningReview(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          projectId: activeRun.projectId,
+          workflowType: "batch_review",
+          targetType: "both",
+          weedTypeFilter: activeRun.target,
+          batchJobIds: [activeRun.batchJobId],
+        }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data?.session?.id) {
+        const details = data?.details ? `: ${data.details}` : "";
+        throw new Error(`${data?.error || "The review session could not be created"}${details}`);
+      }
+      const nextRun = { ...activeRun, reviewSessionId: data.session.id };
+      setActiveRun(nextRun);
+      window.localStorage.setItem(TEACH_BATCH_RUN_STORAGE_KEY, JSON.stringify(nextRun));
+      router.push(`/review?sessionId=${data.session.id}`);
+    } catch (reviewError) {
+      setError(reviewError instanceof Error ? reviewError.message : "The review session could not be created.");
+    } finally {
+      setOpeningReview(false);
     }
   }
 
@@ -351,7 +538,7 @@ export default function TeachWorkspace() {
           <span className="flex h-9 w-9 flex-none items-center justify-center rounded-lg bg-emerald-50 text-emerald-600"><Box className="h-5 w-5" /></span>
           <div className="min-w-0">
             <div className="flex items-center gap-2">
-              <select aria-label="Project" value={projectId} onChange={(event) => setProjectId(event.target.value)} disabled={demo || loadingProjects} className="max-w-[190px] truncate bg-transparent text-base font-semibold outline-none disabled:opacity-100 sm:max-w-[420px] sm:text-lg">
+              <select aria-label="Project" value={projectId} onChange={(event) => setProjectId(event.target.value)} disabled={demo || loadingProjects || batchLocked} className="max-w-[190px] truncate bg-transparent text-base font-semibold outline-none disabled:opacity-100 sm:max-w-[420px] sm:text-lg">
                 {projects.map((item) => <option key={item.id} value={item.id}>{item.name}</option>)}
               </select>
             </div>
@@ -378,13 +565,28 @@ export default function TeachWorkspace() {
           <section className="flex flex-wrap items-center justify-between gap-4 border-b border-gray-200 bg-white px-5 py-3.5 lg:px-7">
             <div>
               <h1 className="text-xl font-semibold tracking-tight">What should we find?</h1>
-              {editingTarget ? <div className="mt-2 flex gap-2"><input autoFocus aria-label="Target name" value={targetDraft} onChange={(event) => setTargetDraft(event.target.value)} onKeyDown={(event) => { if (event.key === "Enter" && targetDraft.trim()) { setTarget(targetDraft.trim()); setEditingTarget(false); } }} className="h-10 w-64 rounded-lg border border-gray-300 px-3 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100" /><button type="button" onClick={() => { if (targetDraft.trim()) { setTarget(targetDraft.trim()); setEditingTarget(false); } }} className="rounded-lg bg-gray-950 px-3 text-sm font-medium text-white">Save</button></div> : <div className="mt-2 inline-flex items-center gap-3 rounded-lg border border-gray-200 bg-white px-2.5 py-2"><span className="h-8 w-8 overflow-hidden rounded-md bg-emerald-50">{mainImage ? <img src={mainImage} alt="" className="h-full w-full scale-150 object-cover" /> : <Leaf className="m-2 h-4 w-4 text-emerald-600" />}</span><span className="font-semibold">{target}</span><button type="button" onClick={() => setEditingTarget(true)} className="ml-4 text-sm font-medium text-blue-600">Change target</button></div>}
+              {editingTarget ? <div className="mt-2 flex gap-2"><input autoFocus aria-label="Target name" value={targetDraft} onChange={(event) => setTargetDraft(event.target.value)} onKeyDown={(event) => { if (event.key === "Enter" && targetDraft.trim()) { setTarget(targetDraft.trim()); setEditingTarget(false); } }} className="h-10 w-64 rounded-lg border border-gray-300 px-3 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100" /><button type="button" onClick={() => { if (targetDraft.trim()) { setTarget(targetDraft.trim()); setEditingTarget(false); } }} className="rounded-lg bg-gray-950 px-3 text-sm font-medium text-white">Save</button></div> : <div className="mt-2 inline-flex items-center gap-3 rounded-lg border border-gray-200 bg-white px-2.5 py-2"><span className="h-8 w-8 overflow-hidden rounded-md bg-emerald-50">{mainImage ? <img src={mainImage} alt="" className="h-full w-full scale-150 object-cover" /> : <Leaf className="m-2 h-4 w-4 text-emerald-600" />}</span><span className="font-semibold">{target}</span><button type="button" disabled={batchLocked} onClick={() => setEditingTarget(true)} className="ml-4 text-sm font-medium text-blue-600 disabled:cursor-not-allowed disabled:text-gray-400">Change target</button></div>}
             </div>
             <button type="button" onClick={() => setGuideOpen((open) => !open)} aria-expanded={guideOpen} className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3.5 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"><CircleHelp className="h-4 w-4" /> How to mark examples <ChevronDown className={`h-4 w-4 transition ${guideOpen ? "rotate-180" : ""}`} /></button>
           </section>
 
           {error && <div className="mx-5 mt-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 lg:mx-7">{error}</div>}
           {notice && <div className="mx-5 mt-3 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800 lg:mx-7">{notice}</div>}
+          {activeRun && batchData ? (
+            <TeachBatchStatus
+              status={batchData.batchJob}
+              summary={batchData.summary}
+              execution={batchData.execution}
+              pollError={pollError}
+              reviewing={openingReview}
+              onRetryStatus={() => {
+                setPollError(null);
+                setPollNonce((value) => value + 1);
+              }}
+              onReview={() => void openBatchReview()}
+              onStartAgain={() => clearActiveRun("Previous search cleared. Your examples are ready to use again.")}
+            />
+          ) : null}
 
           <section className="relative mx-5 mt-3 flex min-h-[410px] flex-1 items-center justify-center overflow-hidden rounded-xl border border-gray-200 bg-gray-900 lg:mx-7">
             {loadingAssets || signedMain.loading ? <div className="flex items-center text-white"><Loader2 className="mr-2 h-5 w-5 animate-spin" />Loading image…</div> : !asset || !mainImage ? <div className="text-center text-white"><ImageIcon className="mx-auto mb-3 h-9 w-9 text-gray-400" /><p className="font-medium">This project has no images yet.</p><Link href="/upload" className="mt-3 inline-block text-sm text-emerald-300 underline">Upload images</Link></div> : <div
@@ -394,7 +596,7 @@ export default function TeachWorkspace() {
               tabIndex={0}
               aria-label="Example marking canvas"
               aria-describedby="teach-canvas-instructions"
-              className="relative h-full min-h-[410px] w-full touch-none select-none cursor-crosshair overflow-hidden"
+              className={`relative h-full min-h-[410px] w-full touch-none select-none overflow-hidden ${batchLocked ? "cursor-not-allowed" : "cursor-crosshair"}`}
               onPointerDown={beginBox}
               onPointerMove={moveBox}
               onPointerUp={finishBox}
@@ -407,7 +609,7 @@ export default function TeachWorkspace() {
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img src={mainImage} alt={`${project?.name || "Project"} source imagery`} className="absolute inset-0 h-full w-full object-cover" onLoad={(event) => { const size = { width: event.currentTarget.naturalWidth, height: event.currentTarget.naturalHeight }; setImageSize(size); setKeyboardCursor({ x: size.width / 2, y: size.height / 2 }); }} draggable={false} />
               <div className="absolute left-3 top-3 max-w-[340px] rounded-lg bg-gray-950/90 px-4 py-3 text-white shadow-lg backdrop-blur-sm"><p className="font-semibold">Mark 3–8 examples that look different</p><p className="mt-1 text-sm leading-5 text-gray-300">Choose plants that vary in size, colour, lighting, and background.</p><p className="mt-2 text-sm"><span className="font-semibold text-emerald-300">{boxes.length}</span> of 3–8 examples marked</p><div className="mt-2 flex gap-1.5">{Array.from({ length: 8 }, (_, index) => <span key={index} className={`h-1.5 flex-1 rounded-full ${index < boxes.length ? "bg-emerald-400" : "bg-gray-600"}`} />)}</div></div>
-              {boxes.map((box, index) => <div key={box.id} className="pointer-events-none absolute border-2 border-emerald-400 bg-emerald-400/10" style={styleBox(box)}><span className="absolute -left-0.5 -top-7 flex h-7 min-w-7 items-center justify-center rounded-t-md bg-emerald-500 px-1 text-xs font-bold text-white">{index + 1}</span><button type="button" aria-label={`Remove example ${index + 1}`} onPointerDown={(event) => event.stopPropagation()} onClick={(event) => { event.stopPropagation(); setBoxes((current) => current.filter((item) => item.id !== box.id)); }} className="pointer-events-auto absolute -right-3 -top-3 flex h-7 w-7 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-700 shadow"><X className="h-3.5 w-3.5" /></button></div>)}
+              {boxes.map((box, index) => <div key={box.id} className="pointer-events-none absolute border-2 border-emerald-400 bg-emerald-400/10" style={styleBox(box)}><span className="absolute -left-0.5 -top-7 flex h-7 min-w-7 items-center justify-center rounded-t-md bg-emerald-500 px-1 text-xs font-bold text-white">{index + 1}</span><button type="button" aria-label={`Remove example ${index + 1}`} disabled={batchLocked} onPointerDown={(event) => event.stopPropagation()} onClick={(event) => { event.stopPropagation(); setBoxes((current) => current.filter((item) => item.id !== box.id)); }} className="pointer-events-auto absolute -right-3 -top-3 flex h-7 w-7 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-700 shadow disabled:cursor-not-allowed disabled:opacity-60"><X className="h-3.5 w-3.5" /></button></div>)}
               {draft && <div className="pointer-events-none absolute border-2 border-dashed border-emerald-300 bg-emerald-300/10" style={styleBox(draft)} />}
               {keyboardActive && <Crosshair className="pointer-events-none absolute h-6 w-6 -translate-x-1/2 -translate-y-1/2 text-white drop-shadow" style={stylePoint(keyboardCursor)} aria-hidden="true" />}
               {guideOpen && <aside className="absolute bottom-3 right-3 top-3 w-[270px] overflow-y-auto rounded-lg border border-gray-200 bg-white p-4 shadow-xl"><div className="flex items-center justify-between"><h2 className="font-semibold">How to mark good examples</h2><button type="button" aria-label="Close example guide" onClick={() => setGuideOpen(false)} className="rounded p-1 text-gray-500 hover:bg-gray-100"><X className="h-4 w-4" /></button></div><div className="mt-4 space-y-4">{GUIDE_ITEMS.map(({ icon: Icon, title, body }) => <div key={title} className="flex gap-3"><Icon className="mt-0.5 h-4 w-4 flex-none text-gray-600" /><div><p className="text-sm font-semibold">{title}</p><p className="mt-1 text-xs leading-5 text-gray-600">{body}</p></div></div>)}</div></aside>}
@@ -415,13 +617,13 @@ export default function TeachWorkspace() {
           </section>
 
           <section className="border-b border-gray-200 bg-white px-5 pb-3 pt-3 lg:px-7">
-            <div className="mb-3 flex flex-wrap items-center justify-between gap-3"><div className="flex items-baseline gap-3"><h2 className="text-sm font-semibold">Batch images ({batchCount})</h2><p className="text-xs text-gray-500">Choose the best image, then mark all examples on it.</p></div><div className="flex items-center gap-2"><label className="relative hidden sm:block"><Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" /><input value={filter} onChange={(event) => setFilter(event.target.value)} placeholder="Jump to image…" className="h-9 w-56 rounded-lg border border-gray-200 pl-9 pr-3 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100" /></label><button type="button" aria-label="Previous images" onClick={() => scrollFilmstrip(-1)} className="flex h-9 w-9 items-center justify-center rounded-lg border border-gray-200"><ChevronLeft className="h-4 w-4" /></button><button type="button" aria-label="Next images" onClick={() => scrollFilmstrip(1)} className="flex h-9 w-9 items-center justify-center rounded-lg border border-gray-200"><ChevronRight className="h-4 w-4" /></button></div></div>
-            <div ref={filmstripRef} data-testid="teach-filmstrip" className="flex gap-2 overflow-x-auto pb-1">{visibleAssets.map((item) => <Thumbnail key={item.id} asset={item} active={item.id === assetId} demo={demo} onSelect={() => selectAsset(item)} />)}</div>
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-3"><div className="flex items-baseline gap-3"><h2 className="text-sm font-semibold">Batch images ({batchCount})</h2><p className="text-xs text-gray-500">Choose the best image, then mark all examples on it.</p></div><div className="flex items-center gap-2"><label className="relative hidden sm:block"><Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" /><input value={filter} onChange={(event) => setFilter(event.target.value)} disabled={batchLocked} placeholder="Jump to image…" className="h-9 w-56 rounded-lg border border-gray-200 pl-9 pr-3 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100 disabled:cursor-not-allowed disabled:bg-gray-50" /></label><button type="button" aria-label="Previous images" disabled={batchLocked} onClick={() => scrollFilmstrip(-1)} className="flex h-9 w-9 items-center justify-center rounded-lg border border-gray-200 disabled:cursor-not-allowed disabled:opacity-50"><ChevronLeft className="h-4 w-4" /></button><button type="button" aria-label="Next images" disabled={batchLocked} onClick={() => scrollFilmstrip(1)} className="flex h-9 w-9 items-center justify-center rounded-lg border border-gray-200 disabled:cursor-not-allowed disabled:opacity-50"><ChevronRight className="h-4 w-4" /></button></div></div>
+            <div ref={filmstripRef} data-testid="teach-filmstrip" className="flex gap-2 overflow-x-auto pb-1">{visibleAssets.map((item) => <Thumbnail key={item.id} asset={item} active={item.id === assetId} demo={demo} disabled={batchLocked} onSelect={() => selectAsset(item)} />)}</div>
           </section>
 
           <footer className="sticky bottom-0 z-20 bg-white px-5 pb-3 pt-3 shadow-[0_-8px_30px_rgba(15,23,42,0.06)] lg:px-7">
             <div className="mb-3 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3.5 py-2.5 text-sm text-amber-950"><ShieldCheck className="mt-0.5 h-4 w-4 flex-none text-amber-600" /><span><strong>Safety first:</strong> Matches are suggestions for review. They are never used for spraying automatically.</span></div>
-            <div className="flex flex-wrap items-center justify-between gap-3"><div className="flex w-full gap-2 sm:w-auto"><button type="button" onClick={() => setBoxes([])} disabled={!boxes.length} className="inline-flex h-11 flex-1 items-center justify-center gap-2 rounded-lg border border-gray-200 px-3 text-sm font-medium text-gray-700 disabled:opacity-40 sm:flex-none sm:px-4"><Trash2 className="h-4 w-4" />Clear examples</button><Link href="/review-queue" className="inline-flex h-11 flex-1 items-center justify-center gap-2 rounded-lg border border-gray-200 px-3 text-sm font-medium text-gray-700 sm:flex-none sm:px-4"><Eye className="h-4 w-4" />Open review</Link></div><button type="button" onClick={searchBatch} disabled={submitting || boxes.length < 3 || !asset} className="inline-flex h-12 w-full min-w-0 items-center justify-center gap-2 rounded-lg bg-gradient-to-r from-emerald-500 to-blue-500 px-4 text-sm font-semibold text-white shadow-sm hover:from-emerald-600 hover:to-blue-600 disabled:cursor-not-allowed disabled:from-gray-300 disabled:to-gray-300 sm:w-auto sm:min-w-[330px] sm:px-6">{submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}{submitting ? "Starting search…" : `Search this batch${batchCount ? ` (${batchCount})` : ""}`} {!submitting && <ArrowRight className="h-4 w-4" />}</button></div>
+            <div className="flex flex-wrap items-center justify-between gap-3"><div className="flex w-full gap-2 sm:w-auto"><button type="button" onClick={() => setBoxes([])} disabled={!boxes.length || batchLocked} className="inline-flex h-11 flex-1 items-center justify-center gap-2 rounded-lg border border-gray-200 px-3 text-sm font-medium text-gray-700 disabled:opacity-40 sm:flex-none sm:px-4"><Trash2 className="h-4 w-4" />Clear examples</button><Link href="/review-queue" className="inline-flex h-11 flex-1 items-center justify-center gap-2 rounded-lg border border-gray-200 px-3 text-sm font-medium text-gray-700 sm:flex-none sm:px-4"><Eye className="h-4 w-4" />Review queue</Link></div><button type="button" onClick={searchBatch} disabled={submitting || batchBusy || boxes.length < 3 || !asset} className="inline-flex h-12 w-full min-w-0 items-center justify-center gap-2 rounded-lg bg-gradient-to-r from-emerald-500 to-blue-500 px-4 text-sm font-semibold text-white shadow-sm hover:from-emerald-600 hover:to-blue-600 disabled:cursor-not-allowed disabled:from-gray-300 disabled:to-gray-300 sm:w-auto sm:min-w-[330px] sm:px-6">{submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}{submitting ? "Starting search…" : batchBusy ? "Search in progress" : `Search this batch${batchCount ? ` (${batchCount})` : ""}`} {!submitting && !batchBusy && <ArrowRight className="h-4 w-4" />}</button></div>
           </footer>
         </main>
       </div>

--- a/docs/TEACH_JOB_LIFECYCLE_EVIDENCE.md
+++ b/docs/TEACH_JOB_LIFECYCLE_EVIDENCE.md
@@ -1,0 +1,53 @@
+# Teach AI job lifecycle evidence
+
+Date: 13 July 2026
+Branch: `codex/agri-teach-job-lifecycle`
+
+## Verified model route
+
+The guided Teach workspace submits `concept_propagation` jobs to `POST /api/sam3/v2/batch`.
+
+That V2 service calls `awsSam3Service` directly. For concept propagation it:
+
+1. warms the concept service;
+2. creates one concept exemplar per operator-drawn source box;
+3. applies those exemplars to each target image;
+4. refines returned candidate boxes with SAM3 box prompts when possible; and
+5. persists every result as a review suggestion.
+
+The concept service uses `SAM3_CONCEPT_PORT`, defaulting to port `8002`, and calls `/warmup`, `/api/v1/exemplars/create`, and `/api/v1/exemplars/apply`. Warm-up reports both `sam3_loaded` and `dino_loaded`.
+
+The repository also contains a separate Roboflow SAM3 orchestrator, but the V2 batch service does not import or call it. There is no YOLO or Roboflow provider fallback in the Teach V2 batch route.
+
+## Recovery behaviour
+
+Two same-pipeline recovery paths exist and are now reported separately:
+
+- **Candidate expansion:** SAM3 + DINO reruns concept matching with the lower-threshold high-recall profile when strict matching returns too few candidates.
+- **Unrefined candidate preservation:** if SAM3 box refinement fails, the concept candidates can still be preserved as pending review suggestions with an explicit warning.
+
+Neither path changes to YOLO or Roboflow. Neither path bypasses human review.
+
+## Implemented lifecycle
+
+- Teach stores the submitted batch ID, project, target, poll URL, and submission time in same-origin local storage.
+- A queued or processing job restores after page refresh and resumes polling.
+- The operator sees processed images, suggestion count, translated processing stage, connection failures, and terminal failures.
+- Technical details expose the recorded model route, review profile, runtime evidence, and any same-model recovery.
+- A completed job creates or reuses a review session scoped to that exact batch ID and navigates to `/review?sessionId=...`.
+- Project, target, source image, examples, and filmstrip controls stay locked while a saved job is active so the UI cannot imply that a submitted job has changed.
+- Operators can discard an inaccessible saved job or start again after completion or failure.
+
+## Verification completed
+
+- Focused lifecycle and SAM3 tests: 23 passed.
+- Full unit suite: 82 passed across 15 files.
+- Production build with `NEXT_PUBLIC_GUIDED_OPERATOR_FLOW=true`: passed.
+- Changed implementation files: no TypeScript errors when filtered from `tsc --noEmit`.
+- Full repository TypeScript check: still fails on pre-existing route, Prisma JSON, EXIF, and generated Next route-type errors outside this change.
+- In-app browser: `/teach?demo=1` rendered successfully with the approved filmstrip layout, safety boundary, existing navigation, no visible layout regression, and no warnings or errors in a fresh stable tab.
+- Automated browser specifications were added for submit, poll, refresh restore, exact review-session payload/navigation, and inaccessible-job recovery. They require the repository's Playwright runner and were not executed during this pass.
+
+## Proof boundary
+
+This branch proves the application contracts locally. It does **not** prove a live GPU worker is currently healthy because the local environment has no `SAM3_INSTANCE_ID`, and no real customer batch was executed. A post-deploy authenticated canary batch is still required to prove live SAM3 + DINO runtime behaviour end to end.

--- a/e2e/teach-workspace.spec.ts
+++ b/e2e/teach-workspace.spec.ts
@@ -1,5 +1,40 @@
 import { expect, test } from "@playwright/test";
 
+const projectId = "cproject00000000000000000000";
+const assetIds = Array.from({ length: 4 }, (_, index) => `casset00000000000000000000${index}`);
+
+async function mockTeachProject(page: import("@playwright/test").Page) {
+  await page.route("**/api/projects?**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ projects: [{ id: projectId, name: "Lifecycle Test", _count: { assets: assetIds.length } }] }),
+    });
+  });
+  await page.route("**/api/assets?**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        assets: assetIds.map((id, index) => ({
+          id,
+          fileName: `Lifecycle_${index + 1}.jpg`,
+          storageUrl: "/demo/lantana-batch-aerial.jpg",
+          imageWidth: 1536,
+          imageHeight: 1024,
+        })),
+      }),
+    });
+  });
+  await page.route("**/api/assets/*/signed-url", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ url: "/demo/lantana-batch-aerial.jpg", storageType: "local" }),
+    });
+  });
+}
+
 test.describe("Guided Teach AI workspace", () => {
   test("marks examples and queues a review-gated demo search", async ({ page }) => {
     await page.goto("/teach?demo=1");
@@ -49,5 +84,135 @@ test.describe("Guided Teach AI workspace", () => {
     for (let index = 0; index < 4; index += 1) await canvas.press("ArrowDown");
     await canvas.press("Enter");
     await expect(page.getByText("1 of 3–8 examples marked")).toBeVisible();
+  });
+
+  test("restores a live job, reports execution truth, and opens its exact review session", async ({ page }) => {
+    await mockTeachProject(page);
+    let statusCalls = 0;
+    let reviewPayload: Record<string, unknown> | null = null;
+
+    await page.route("**/api/sam3/v2/batch", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          batchJobId: "cbatch000000000000000000000",
+          pollUrl: "/api/sam3/v2/batch/cbatch000000000000000000000",
+          mode: "concept_propagation",
+          status: "QUEUED",
+          totalImages: 4,
+        }),
+      });
+    });
+    await page.route("**/api/sam3/v2/batch/cbatch000000000000000000000?includeAnnotations=false", async (route) => {
+      statusCalls += 1;
+      const completed = statusCalls > 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          batchJob: {
+            id: "cbatch000000000000000000000",
+            projectId,
+            weedType: "Lantana",
+            mode: "concept_propagation",
+            status: completed ? "COMPLETED" : "PROCESSING",
+            processedImages: completed ? 4 : 2,
+            totalImages: 4,
+            detectionsFound: completed ? 18 : 7,
+            latestStage: completed ? "terminal" : "run_sam3",
+            terminalState: completed ? "completed" : null,
+            completedWithWarnings: false,
+          },
+          summary: { total: 18, pending: 18, accepted: 0, rejected: 0 },
+          execution: {
+            providerRoute: "aws_sam3_v2_direct",
+            providerLabel: "AWS SAM3",
+            pipeline: "sam3_dino_concept",
+            pipelineLabel: "SAM3 + DINO concept propagation",
+            externalProviderFallback: false,
+            runtimeConfirmed: true,
+            reviewProfile: "high_recall",
+            backendModes: ["concept_ensemble_refined"],
+            candidateExpansionAssets: 1,
+            refinementFallbackAssets: 0,
+            degradedAssets: 1,
+            warnings: [],
+          },
+        }),
+      });
+    });
+    await page.route("**/api/review", async (route) => {
+      reviewPayload = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ session: { id: "creview00000000000000000000" } }),
+      });
+    });
+
+    await page.goto("/teach");
+    const canvas = page.getByTestId("teach-image-canvas");
+    const bounds = await canvas.boundingBox();
+    expect(bounds).not.toBeNull();
+    if (!bounds) return;
+    for (const offset of [0.2, 0.4, 0.6]) {
+      await page.mouse.move(bounds.x + bounds.width * offset, bounds.y + bounds.height * 0.35);
+      await page.mouse.down();
+      await page.mouse.move(bounds.x + bounds.width * (offset + 0.07), bounds.y + bounds.height * 0.47);
+      await page.mouse.up();
+    }
+    await page.getByRole("button", { name: "Search this batch (4)" }).click();
+    await expect(page.getByText("Searching image 3 of 4")).toBeVisible();
+
+    const storedRun = await page.evaluate(() => window.localStorage.getItem("agri:teach-batch-run:v1"));
+    expect(storedRun).toContain("cbatch000000000000000000000");
+
+    await page.reload();
+    await expect(page.getByText("Ready for review", { exact: true })).toBeVisible();
+    await page.getByText("Technical details").click();
+    await expect(page.getByText(/SAM3 \+ DINO concept propagation/)).toBeVisible();
+    await expect(page.getByText(/None — no YOLO or Roboflow provider fallback/)).toBeVisible();
+    await expect(page.getByText(/Same-model recovery used on 1 image/)).toBeVisible();
+
+    await page.getByRole("button", { name: "Review these suggestions" }).click();
+    await expect(page).toHaveURL(/\/review\?sessionId=creview00000000000000000000/);
+    expect(reviewPayload).toMatchObject({
+      projectId,
+      workflowType: "batch_review",
+      weedTypeFilter: "Lantana",
+      batchJobIds: ["cbatch000000000000000000000"],
+    });
+  });
+
+  test("lets an operator discard an inaccessible restored job", async ({ page }) => {
+    await mockTeachProject(page);
+    await page.addInitScript(({ key, run }) => {
+      window.localStorage.setItem(key, JSON.stringify(run));
+    }, {
+      key: "agri:teach-batch-run:v1",
+      run: {
+        batchJobId: "cbatch000000000000000000009",
+        pollUrl: "/api/sam3/v2/batch/cbatch000000000000000000009",
+        projectId,
+        target: "Lantana",
+        submittedAt: "2026-07-13T00:00:00.000Z",
+      },
+    });
+    await page.route("**/api/sam3/v2/batch/cbatch000000000000000000009?includeAnnotations=false", async (route) => {
+      await route.fulfill({
+        status: 403,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Access denied for this saved search." }),
+      });
+    });
+
+    await page.goto("/teach");
+    await expect(page.getByText("Access denied for this saved search.")).toBeVisible();
+    await page.getByRole("button", { name: "Discard saved search" }).click();
+    await expect(page.getByText("Previous search cleared. Your examples are ready to use again.")).toBeVisible();
+    await expect.poll(() => page.evaluate(() => window.localStorage.getItem("agri:teach-batch-run:v1"))).toBeNull();
   });
 });

--- a/lib/services/sam3-batch-v2.ts
+++ b/lib/services/sam3-batch-v2.ts
@@ -241,6 +241,7 @@ export interface Sam3BatchV2StageLogEntry {
   visualCropSource?: 'operator' | 'operator_crops' | 'server_built_crops' | 'source_detections' | 'concept_exemplar';
   backendMode?: string;
   backendWarning?: string;
+  candidateExpansionUsed?: boolean;
   detectionCount?: number;
   candidateCount?: number;
   conceptExemplarCount?: number;
@@ -436,6 +437,7 @@ interface AssetInferenceResult {
   errorMessage?: string;
   backendMode?: string;
   backendWarning?: string;
+  candidateExpansionUsed?: boolean;
   candidateCount?: number;
   refinementBoxCount?: number;
   refinementDetectionCount?: number;
@@ -453,6 +455,11 @@ interface ConceptRefinementResult {
 interface ConceptExemplarRef {
   exemplarId: string;
   sourceBoxIndex?: number;
+}
+
+interface ConceptCandidateResult {
+  detections: SAM3ConceptDetection[];
+  candidateExpansionUsed: boolean;
 }
 
 interface GpuAdmissionResult {
@@ -1528,6 +1535,7 @@ export class Sam3BatchV2Service {
           visualCropSource: prepared.mode === 'visual_crop_match' ? prepared.visualCropSource : undefined,
           backendMode: result.backendMode,
           backendWarning: result.backendWarning,
+          candidateExpansionUsed: result.candidateExpansionUsed,
           candidateCount: result.candidateCount,
           conceptExemplarCount:
             prepared.mode === 'concept_propagation' ? conceptExemplars.length : undefined,
@@ -1728,7 +1736,7 @@ export class Sam3BatchV2Service {
       };
     }
 
-    const candidates = await this.getConceptCandidatesWithFallback({
+    const candidateResult = await this.getConceptCandidatesWithFallback({
       asset,
       imageBuffer,
       exemplarId,
@@ -1741,7 +1749,7 @@ export class Sam3BatchV2Service {
       asset,
       imageBuffer,
       className,
-      candidates
+      candidateResult.detections
     );
 
     return {
@@ -1750,6 +1758,7 @@ export class Sam3BatchV2Service {
       outcome: refinement.detections.length > 0 ? 'success' : 'zero_detections',
       backendMode: refinement.usedCandidateFallback ? 'concept_candidates_unrefined' : 'concept_refined',
       backendWarning: refinement.backendWarning,
+      candidateExpansionUsed: candidateResult.candidateExpansionUsed,
       candidateCount: refinement.candidateCount,
       refinementBoxCount: refinement.refinementBoxCount,
       refinementDetectionCount: refinement.refinementDetectionCount,
@@ -1816,7 +1825,7 @@ export class Sam3BatchV2Service {
     // enters the pending review gate before export or YOLO training.
     const reviewProfile: Sam3BatchV2ReviewProfile = 'high_recall';
     const conceptOptions = buildBatchV2ConceptApplyOptions(reviewProfile);
-    const candidates = await this.getConceptCandidatesFromEnsemble({
+    const candidateResult = await this.getConceptCandidatesFromEnsemble({
       asset,
       imageBuffer,
       exemplars: exemplarRefs,
@@ -1828,7 +1837,7 @@ export class Sam3BatchV2Service {
       asset,
       imageBuffer,
       weedType,
-      candidates
+      candidateResult.detections
     );
 
     return {
@@ -1839,6 +1848,7 @@ export class Sam3BatchV2Service {
         ? 'concept_ensemble_candidates_unrefined'
         : 'concept_ensemble_refined',
       backendWarning: refinement.backendWarning,
+      candidateExpansionUsed: candidateResult.candidateExpansionUsed,
       candidateCount: refinement.candidateCount,
       refinementBoxCount: refinement.refinementBoxCount,
       refinementDetectionCount: refinement.refinementDetectionCount,
@@ -1859,7 +1869,7 @@ export class Sam3BatchV2Service {
     primaryOptions: SAM3ConceptApplyOptions;
     reviewProfile?: Sam3BatchV2ReviewProfile;
     failureCode: string;
-  }): Promise<SAM3ConceptDetection[]> {
+  }): Promise<ConceptCandidateResult> {
     const minTargetCandidates = getBatchV2MinTargetCandidates(reviewProfile);
     const maxTargetCandidates = getBatchV2MaxTargetCandidates(reviewProfile);
     const primaryCandidates = await this.collectConceptCandidatesForExemplars({
@@ -1876,7 +1886,10 @@ export class Sam3BatchV2Service {
     );
 
     if (mergedPrimaryCandidates.length >= minTargetCandidates) {
-      return mergedPrimaryCandidates;
+      return {
+        detections: mergedPrimaryCandidates,
+        candidateExpansionUsed: false,
+      };
     }
 
     const fallbackOptions = buildBatchV2ConceptFallbackApplyOptions(reviewProfile);
@@ -1902,7 +1915,10 @@ export class Sam3BatchV2Service {
       );
     }
 
-    return mergedCandidates;
+    return {
+      detections: mergedCandidates,
+      candidateExpansionUsed: true,
+    };
   }
 
   private async collectConceptCandidatesForExemplars({
@@ -1963,12 +1979,15 @@ export class Sam3BatchV2Service {
     primaryOptions: SAM3ConceptApplyOptions;
     reviewProfile?: Sam3BatchV2ReviewProfile;
     failureCode: string;
-  }): Promise<SAM3ConceptDetection[]> {
+  }): Promise<ConceptCandidateResult> {
     const minTargetCandidates = getBatchV2MinTargetCandidates(reviewProfile);
     const maxTargetCandidates = getBatchV2MaxTargetCandidates(reviewProfile);
     const primaryCandidates = filterBatchV2ConceptDetections(primaryDetections, primaryOptions);
     if (primaryCandidates.length >= minTargetCandidates) {
-      return dedupeAndLimitConceptDetections(primaryCandidates, primaryOptions, maxTargetCandidates);
+      return {
+        detections: dedupeAndLimitConceptDetections(primaryCandidates, primaryOptions, maxTargetCandidates),
+        candidateExpansionUsed: false,
+      };
     }
 
     const fallbackOptions = buildBatchV2ConceptFallbackApplyOptions(reviewProfile);
@@ -2008,7 +2027,10 @@ export class Sam3BatchV2Service {
       );
     }
 
-    return mergedCandidates;
+    return {
+      detections: mergedCandidates,
+      candidateExpansionUsed: true,
+    };
   }
 
   private async refineConceptDetectionsWithBoxPrompts(

--- a/lib/utils/sam3-batch-execution.ts
+++ b/lib/utils/sam3-batch-execution.ts
@@ -1,0 +1,71 @@
+export interface Sam3ExecutionStageEntry {
+  stage?: string;
+  status?: string;
+  assetId?: string;
+  modeUsed?: string;
+  reviewProfile?: string;
+  backendMode?: string;
+  backendWarning?: string;
+  candidateExpansionUsed?: boolean;
+}
+
+export interface Sam3BatchExecutionSummary {
+  providerRoute: 'aws_sam3_v2_direct';
+  providerLabel: 'AWS SAM3';
+  pipeline: 'sam3_dino_concept' | 'sam3_visual_crops';
+  pipelineLabel: string;
+  externalProviderFallback: false;
+  runtimeConfirmed: boolean;
+  reviewProfile: string | null;
+  backendModes: string[];
+  candidateExpansionAssets: number;
+  refinementFallbackAssets: number;
+  degradedAssets: number;
+  warnings: string[];
+}
+
+export function summarizeSam3BatchExecution(
+  stageLogs: Sam3ExecutionStageEntry[][],
+  mode: string | null | undefined
+): Sam3BatchExecutionSummary {
+  const entries = stageLogs.flat();
+  const assetEntries = entries.filter((entry) => entry.stage === 'run_sam3' && entry.assetId);
+  const backendModes = Array.from(
+    new Set(assetEntries.map((entry) => entry.backendMode).filter((value): value is string => Boolean(value)))
+  );
+  const warnings = Array.from(
+    new Set(assetEntries.map((entry) => entry.backendWarning).filter((value): value is string => Boolean(value)))
+  );
+  const candidateExpansionAssetIds = new Set(
+    assetEntries.filter((entry) => entry.candidateExpansionUsed).map((entry) => entry.assetId as string)
+  );
+  const refinementFallbackAssetIds = new Set(
+    assetEntries
+      .filter((entry) => entry.backendMode?.includes('candidates_unrefined'))
+      .map((entry) => entry.assetId as string)
+  );
+  const degradedAssetIds = new Set([
+    ...candidateExpansionAssetIds,
+    ...refinementFallbackAssetIds,
+    ...assetEntries.filter((entry) => entry.backendWarning).map((entry) => entry.assetId as string),
+  ]);
+  const reviewProfile = [...assetEntries]
+    .reverse()
+    .find((entry) => entry.reviewProfile)?.reviewProfile || null;
+  const conceptPipeline = mode === 'concept_propagation';
+
+  return {
+    providerRoute: 'aws_sam3_v2_direct',
+    providerLabel: 'AWS SAM3',
+    pipeline: conceptPipeline ? 'sam3_dino_concept' : 'sam3_visual_crops',
+    pipelineLabel: conceptPipeline ? 'SAM3 + DINO concept propagation' : 'SAM3 visual crop matching',
+    externalProviderFallback: false,
+    runtimeConfirmed: assetEntries.some((entry) => entry.status === 'completed' || entry.status === 'failed'),
+    reviewProfile,
+    backendModes,
+    candidateExpansionAssets: candidateExpansionAssetIds.size,
+    refinementFallbackAssets: refinementFallbackAssetIds.size,
+    degradedAssets: degradedAssetIds.size,
+    warnings,
+  };
+}

--- a/lib/utils/teach-batch-run.ts
+++ b/lib/utils/teach-batch-run.ts
@@ -1,0 +1,104 @@
+import type { Sam3BatchExecutionSummary } from '@/lib/utils/sam3-batch-execution';
+
+export const TEACH_BATCH_RUN_STORAGE_KEY = 'agri:teach-batch-run:v1';
+
+export interface TeachBatchRun {
+  batchJobId: string;
+  pollUrl: string;
+  projectId: string;
+  target: string;
+  submittedAt: string;
+  reviewSessionId?: string;
+}
+
+export interface TeachBatchJobStatus {
+  id: string;
+  projectId: string;
+  weedType: string;
+  status: string;
+  mode?: string | null;
+  processedImages: number;
+  totalImages: number;
+  detectionsFound: number;
+  errorMessage?: string | null;
+  latestStage?: string | null;
+  terminalState?: string | null;
+  completedWithWarnings?: boolean;
+}
+
+export interface TeachBatchStatusResponse {
+  batchJob: TeachBatchJobStatus;
+  summary?: {
+    total: number;
+    pending: number;
+    accepted: number;
+    rejected: number;
+  };
+  execution?: Sam3BatchExecutionSummary;
+}
+
+export function parseTeachBatchRun(value: string | null): TeachBatchRun | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as Partial<TeachBatchRun>;
+    const expectedPollUrl = typeof parsed.batchJobId === 'string'
+      ? `/api/sam3/v2/batch/${parsed.batchJobId}`
+      : null;
+    if (
+      typeof parsed.batchJobId !== 'string' ||
+      !/^[A-Za-z0-9_-]+$/.test(parsed.batchJobId) ||
+      typeof parsed.pollUrl !== 'string' ||
+      parsed.pollUrl !== expectedPollUrl ||
+      typeof parsed.projectId !== 'string' ||
+      typeof parsed.target !== 'string' ||
+      typeof parsed.submittedAt !== 'string'
+    ) {
+      return null;
+    }
+    return {
+      batchJobId: parsed.batchJobId,
+      pollUrl: parsed.pollUrl,
+      projectId: parsed.projectId,
+      target: parsed.target,
+      submittedAt: parsed.submittedAt,
+      ...(typeof parsed.reviewSessionId === 'string'
+        ? { reviewSessionId: parsed.reviewSessionId }
+        : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function isTeachBatchTerminal(status: string | null | undefined): boolean {
+  return Boolean(status && ['COMPLETED', 'FAILED', 'CANCELLED'].includes(status));
+}
+
+export function getTeachBatchProgress(processed: number, total: number): number {
+  if (!Number.isFinite(processed) || !Number.isFinite(total) || total <= 0) return 0;
+  return Math.max(0, Math.min(100, Math.round((processed / total) * 100)));
+}
+
+export function describeTeachBatchStage(status: TeachBatchJobStatus): string {
+  if (status.status === 'QUEUED') return 'Waiting for an inference worker';
+  if (status.status === 'FAILED') return 'Search failed';
+  if (status.status === 'CANCELLED') return 'Search cancelled';
+  if (status.status === 'COMPLETED') {
+    return status.completedWithWarnings ? 'Ready for review with warnings' : 'Ready for review';
+  }
+
+  switch (status.latestStage) {
+    case 'prepare':
+      return 'Preparing source examples';
+    case 'estimate':
+      return 'Checking processing requirements';
+    case 'admit':
+      return 'Waiting for GPU capacity';
+    case 'run_sam3':
+      return `Searching image ${Math.min(status.processedImages + 1, status.totalImages)} of ${status.totalImages}`;
+    case 'persist':
+      return 'Preparing review suggestions';
+    default:
+      return 'Searching the image batch';
+  }
+}

--- a/tests/unit/sam3-batch-execution.test.ts
+++ b/tests/unit/sam3-batch-execution.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { summarizeSam3BatchExecution } from '@/lib/utils/sam3-batch-execution';
+
+describe('summarizeSam3BatchExecution', () => {
+  it('reports the direct SAM3 and DINO route without an external provider fallback', () => {
+    const summary = summarizeSam3BatchExecution(
+      [[
+        {
+          stage: 'run_sam3',
+          status: 'completed',
+          assetId: 'asset-1',
+          modeUsed: 'concept_propagation',
+          reviewProfile: 'high_recall',
+          backendMode: 'concept_ensemble_refined',
+        },
+      ]],
+      'concept_propagation'
+    );
+
+    expect(summary).toMatchObject({
+      providerRoute: 'aws_sam3_v2_direct',
+      providerLabel: 'AWS SAM3',
+      pipeline: 'sam3_dino_concept',
+      externalProviderFallback: false,
+      runtimeConfirmed: true,
+      reviewProfile: 'high_recall',
+      backendModes: ['concept_ensemble_refined'],
+      degradedAssets: 0,
+    });
+  });
+
+  it('separates same-model candidate expansion from unrefined result fallback', () => {
+    const summary = summarizeSam3BatchExecution(
+      [[
+        {
+          stage: 'run_sam3',
+          status: 'completed',
+          assetId: 'asset-1',
+          candidateExpansionUsed: true,
+          backendMode: 'concept_ensemble_refined',
+        },
+        {
+          stage: 'run_sam3',
+          status: 'completed',
+          assetId: 'asset-2',
+          backendMode: 'concept_ensemble_candidates_unrefined',
+          backendWarning: 'Box refinement failed; saved candidates for review.',
+        },
+      ]],
+      'concept_propagation'
+    );
+
+    expect(summary).toMatchObject({
+      externalProviderFallback: false,
+      candidateExpansionAssets: 1,
+      refinementFallbackAssets: 1,
+      degradedAssets: 2,
+      warnings: ['Box refinement failed; saved candidates for review.'],
+    });
+  });
+});

--- a/tests/unit/sam3-batch-v2.test.ts
+++ b/tests/unit/sam3-batch-v2.test.ts
@@ -281,6 +281,7 @@ describe('sam3-batch-v2', () => {
     expect(result).toMatchObject({
       assetId: 'asset-target',
       outcome: 'success',
+      candidateExpansionUsed: true,
       detections: [
         {
           bbox: [20, 25, 40, 45],
@@ -425,6 +426,7 @@ describe('sam3-batch-v2', () => {
     expect(result).toMatchObject({
       assetId: 'asset-target',
       outcome: 'success',
+      candidateExpansionUsed: true,
       detections: [
         {
           bbox: [20, 25, 40, 45],
@@ -580,6 +582,7 @@ describe('sam3-batch-v2', () => {
     expect(result).toMatchObject({
       assetId: 'asset-target',
       outcome: 'success',
+      candidateExpansionUsed: true,
       detections: [
         {
           bbox: [20, 25, 40, 45],
@@ -714,6 +717,7 @@ describe('sam3-batch-v2', () => {
       assetId: 'asset-target',
       outcome: 'success',
       backendMode: 'concept_ensemble_refined',
+      candidateExpansionUsed: false,
       candidateCount: 60,
       detections: [
         {

--- a/tests/unit/teach-batch-run.test.ts
+++ b/tests/unit/teach-batch-run.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  describeTeachBatchStage,
+  getTeachBatchProgress,
+  isTeachBatchTerminal,
+  parseTeachBatchRun,
+} from '@/lib/utils/teach-batch-run';
+
+describe('Teach batch run utilities', () => {
+  it('restores only traceable v2 batch records', () => {
+    expect(parseTeachBatchRun(JSON.stringify({
+      batchJobId: 'batch-1',
+      pollUrl: '/api/sam3/v2/batch/batch-1',
+      projectId: 'project-1',
+      target: 'Lantana',
+      submittedAt: '2026-07-13T00:00:00.000Z',
+      reviewSessionId: 'review-1',
+    }))).toMatchObject({ batchJobId: 'batch-1', reviewSessionId: 'review-1' });
+
+    expect(parseTeachBatchRun(JSON.stringify({
+      batchJobId: 'batch-1',
+      pollUrl: 'https://untrusted.example/batch-1',
+      projectId: 'project-1',
+      target: 'Lantana',
+      submittedAt: '2026-07-13T00:00:00.000Z',
+    }))).toBeNull();
+
+    expect(parseTeachBatchRun(JSON.stringify({
+      batchJobId: 'batch-1',
+      pollUrl: '/api/sam3/v2/batch/batch-1/../../review',
+      projectId: 'project-1',
+      target: 'Lantana',
+      submittedAt: '2026-07-13T00:00:00.000Z',
+    }))).toBeNull();
+  });
+
+  it('clamps progress and identifies terminal states', () => {
+    expect(getTeachBatchProgress(45, 100)).toBe(45);
+    expect(getTeachBatchProgress(120, 100)).toBe(100);
+    expect(getTeachBatchProgress(1, 0)).toBe(0);
+    expect(isTeachBatchTerminal('COMPLETED')).toBe(true);
+    expect(isTeachBatchTerminal('PROCESSING')).toBe(false);
+  });
+
+  it('translates technical stages into operator language', () => {
+    expect(describeTeachBatchStage({
+      id: 'batch-1',
+      projectId: 'project-1',
+      weedType: 'Lantana',
+      status: 'PROCESSING',
+      processedImages: 17,
+      totalImages: 100,
+      detectionsFound: 41,
+      latestStage: 'run_sam3',
+    })).toBe('Searching image 18 of 100');
+  });
+});


### PR DESCRIPTION
## What changed

- persists the Teach batch ID, project, target, and poll URL so progress recovers after refresh
- adds operator-facing queued, processing, completed, failed, and connection-recovery states
- creates an exact batch-scoped review session before navigating to Review
- exposes execution evidence from the V2 status API, including the direct SAM3 + DINO route and same-model recovery modes
- records candidate-expansion use separately from unrefined-candidate preservation
- adds unit and browser specifications plus a repository-grounded evidence note

## Why

The previous guided Teach screen could submit a job but did not preserve or explain its lifecycle. Operators could not reliably tell which model path ran, recover after a refresh, or open the review queue scoped to the submitted batch.

## Safety boundary

This does not trigger training, spray exports, production flags, or customer batches. Suggestions remain review-gated. The V2 Teach path has no YOLO or Roboflow provider fallback.

## Verification

- `npm run test:unit` — 82 tests passed
- focused lifecycle/SAM3 suite — 23 tests passed
- `npm run lint` — passed; four existing warnings remain
- `NEXT_PUBLIC_GUIDED_OPERATOR_FLOW=true npm run build` — passed
- changed files produced no TypeScript errors when filtered from `npx tsc --noEmit`
- in-app browser render of `/teach?demo=1` — stable, no fresh-tab warnings or errors

Automated browser specifications were added for submission, polling, refresh recovery, exact review navigation, and inaccessible-job recovery, but the Playwright runner was not executed in this pass.

## Remaining proof

Local contracts are proven. A post-deploy authenticated canary batch is still required to prove live SAM3 + DINO worker health because this environment has no `SAM3_INSTANCE_ID` and no real customer batch was run.