### PR TITLE
Release visible labelling data defaults

### DIFF
--- a/app/review-queue/page.tsx
+++ b/app/review-queue/page.tsx
@@ -29,7 +29,7 @@ interface ReviewSession {
 
 export default function ReviewQueuePage() {
   const [sessions, setSessions] = useState<ReviewSession[]>([]);
-  const [filter, setFilter] = useState<QueueFilter>("me");
+  const [filter, setFilter] = useState<QueueFilter>("all");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState<string | null>(null);

--- a/components/teach/TeachWorkspace.tsx
+++ b/components/teach/TeachWorkspace.tsx
@@ -171,8 +171,9 @@ export default function TeachWorkspace() {
         if (cancelled) return;
         const nextProjects: Project[] = data.projects || [];
         const requested = searchParams.get("projectId");
+        const defaultProject = nextProjects.find((item) => (item._count?.assets || 0) > 0) || nextProjects[0];
         setProjects(nextProjects);
-        setProjectId(nextProjects.some((item) => item.id === requested) ? requested || "" : nextProjects[0]?.id || "");
+        setProjectId(nextProjects.some((item) => item.id === requested) ? requested || "" : defaultProject?.id || "");
       } catch (loadError) {
         if (!cancelled) setError(loadError instanceof Error ? loadError.message : "Projects could not be loaded.");
       } finally {

--- a/e2e/teach-workspace.spec.ts
+++ b/e2e/teach-workspace.spec.ts
@@ -36,6 +36,52 @@ async function mockTeachProject(page: import("@playwright/test").Page) {
 }
 
 test.describe("Guided Teach AI workspace", () => {
+  test("defaults to the first project that contains images", async ({ page }) => {
+    const emptyProjectId = "cproject00000000000000000001";
+    await page.route("**/api/projects?**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          projects: [
+            { id: emptyProjectId, name: "Empty New Project", _count: { assets: 0 } },
+            { id: projectId, name: "Project With Images", _count: { assets: assetIds.length } },
+          ],
+        }),
+      });
+    });
+    await page.route("**/api/assets?**", async (route) => {
+      const requestedProjectId = new URL(route.request().url()).searchParams.get("projectId");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          assets: requestedProjectId === projectId
+            ? assetIds.map((id, index) => ({
+                id,
+                fileName: `Default_${index + 1}.jpg`,
+                storageUrl: "/demo/lantana-batch-aerial.jpg",
+                imageWidth: 1536,
+                imageHeight: 1024,
+              }))
+            : [],
+        }),
+      });
+    });
+    await page.route("**/api/assets/*/signed-url", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ url: "/demo/lantana-batch-aerial.jpg", storageType: "local" }),
+      });
+    });
+
+    await page.goto("/teach");
+
+    await expect(page.getByRole("combobox", { name: "Project" })).toHaveValue(projectId);
+    await expect(page.getByText("Batch images (4)")).toBeVisible();
+  });
+
   test("marks examples and queues a review-gated demo search", async ({ page }) => {
     await page.goto("/teach?demo=1");
 

--- a/e2e/workflows.spec.ts
+++ b/e2e/workflows.spec.ts
@@ -82,17 +82,25 @@ test.describe("Workflow UI Coverage", () => {
     await expect(page.getByRole("heading", { name: "Autotest Plan" })).toBeVisible();
   });
 
-  test("orthomosaic and review queue screens show expected actions", async ({ page }) => {
+  test("orthomosaic screen shows expected actions", async ({ page }) => {
     await page.goto("/orthomosaics");
     await expect(page.getByText("Upload New Orthomosaic")).toBeVisible();
     await expect(page.getByRole("button", { name: "View Map" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Add to Map" })).toBeVisible();
+  });
 
+  test("review queue reveals all sessions by default", async ({ page }) => {
+    const initialQueueRequest = page.waitForRequest((request) =>
+      request.url().includes("/api/review/queue")
+    );
     await page.goto("/review-queue");
+    const queueRequestUrl = new URL((await initialQueueRequest).url());
+    expect(queueRequestUrl.searchParams.get("assigned")).toBe("all");
+    await expect(page.getByText("North Farm Survey")).toBeVisible();
+    await expect(page.getByRole("link", { name: "Open Review" })).toBeVisible();
+
     await page.getByRole("button", { name: "Unassigned" }).click();
     await expect(page.getByText("North Farm Survey")).toBeVisible();
     await expect(page.getByRole("button", { name: "Assign to me" })).toBeVisible();
-    await page.getByRole("button", { name: "All Sessions" }).click();
-    await expect(page.getByRole("link", { name: "Open Review" })).toBeVisible();
   });
 });


### PR DESCRIPTION
## What changed

Promotes the reviewed and merged PR #206 from `main` to `production`:

- Teach AI defaults to the first accessible project containing images.
- Review Queue opens on **All Sessions** so historical unassigned queues are visible.
- Includes focused browser regression coverage for both defaults.

## Why

Existing images and review sessions were intact, but the previous defaults made them appear missing: Teach selected the newest empty project, while Review Queue opened on an empty personal-assignment filter.

## Safety

This release contains no database migration, deletion logic, data mutation, training action, or spray-output change.

## Validation

- PR #206 reviewed clean and merged to `main`
- PR #206 and post-merge `main` Quality Gates passed
- Exact production merge: focused Teach and Review browser regressions passed (2/2)
- Earlier branch validation: 82 unit tests, lint, and production build passed