### PR TITLE
Fix SAM3 GPU cold-start readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,7 @@ REDIS_URL="redis://localhost:6379"
 # AWS EC2 SAM3 Instance (primary backend)
 # The instance auto-starts when needed and stops after idle timeout
 SAM3_INSTANCE_ID=""                    # e.g., "i-04a662566087d9c4f"
+SAM3_STARTUP_TIMEOUT_MS="480000"        # Keep cold-start searches active while GPU and models initialise
 SAM3_PORT="8000"                       # Port the SAM3 API runs on
 SAM3_IDLE_TIMEOUT_MS="3600000"         # Auto-shutdown after 1 hour idle (ms)
 SAM3_SHARED_INSTANCE="false"           # Set true when SAM3 shares a host/GPU with YOLO

--- a/lib/services/aws-sam3.ts
+++ b/lib/services/aws-sam3.ts
@@ -29,7 +29,18 @@ const SAM3_CONCEPT_API_KEY =
   process.env.NDSD_SAM3_SERVICE_API_KEY;
 const IDLE_TIMEOUT_MS = parseInt(process.env.SAM3_IDLE_TIMEOUT_MS || '3600000'); // 1 hour default
 const MAX_IMAGE_SIZE = 2048;
-const STARTUP_TIMEOUT_MS = 180000; // 3 minutes to start and warm up
+export const DEFAULT_SAM3_STARTUP_TIMEOUT_MS = 480000;
+
+export function resolveSam3StartupTimeoutMs(value = process.env.SAM3_STARTUP_TIMEOUT_MS): number {
+  if (!value) return DEFAULT_SAM3_STARTUP_TIMEOUT_MS;
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 60000
+    ? parsed
+    : DEFAULT_SAM3_STARTUP_TIMEOUT_MS;
+}
+
+const STARTUP_TIMEOUT_MS = resolveSam3StartupTimeoutMs();
 const HEALTH_CHECK_INTERVAL_MS = 5000; // Check every 5 seconds during startup
 const CONCEPT_REQUEST_TIMEOUT_MS = 180000;
 

--- a/services/sam3-service/host/README.md
+++ b/services/sam3-service/host/README.md
@@ -1,0 +1,36 @@
+# SAM3 GPU cold-start guard
+
+`sam3-gpu-ready.service` fixes the EC2 stop/start race where Docker can restore
+`sam3-service` before the NVIDIA runtime is usable. In that state the host GPU
+is healthy, but PyTorch inside the restored container reports zero CUDA devices
+until the container is restarted.
+
+The guard runs once per boot and:
+
+1. waits for `nvidia-smi` on the host;
+2. waits for Docker to restore the existing `sam3-service` container;
+3. restarts the container after CUDA is available;
+4. verifies CUDA from PyTorch inside the container;
+5. waits for `/api/v1/status` to report the primary SAM3 model loaded on CUDA.
+
+It is ordered before `sam3-concept.service`, so the primary and concept models
+do not race to initialise the GPU during boot.
+
+Install without interrupting the current service:
+
+```bash
+sudo ./install-startup-guard.sh
+```
+
+Install and run the guard immediately:
+
+```bash
+sudo ./install-startup-guard.sh --start
+```
+
+The installer is idempotent. Verify it with:
+
+```bash
+systemctl status sam3-gpu-ready.service
+journalctl -u sam3-gpu-ready.service -b
+```

--- a/services/sam3-service/host/install-startup-guard.sh
+++ b/services/sam3-service/host/install-startup-guard.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+  printf 'Run this installer as root.\n' >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+install -m 0755 "${SCRIPT_DIR}/sam3-gpu-ready.sh" /usr/local/sbin/sam3-gpu-ready
+install -m 0644 "${SCRIPT_DIR}/sam3-gpu-ready.service" /etc/systemd/system/sam3-gpu-ready.service
+
+systemctl daemon-reload
+systemctl enable sam3-gpu-ready.service
+
+if [[ "${1:-}" == "--start" ]]; then
+  systemctl restart sam3-gpu-ready.service
+fi
+
+printf 'Installed and enabled sam3-gpu-ready.service\n'

--- a/services/sam3-service/host/sam3-gpu-ready.service
+++ b/services/sam3-service/host/sam3-gpu-ready.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Wait for NVIDIA and restore the SAM3 GPU container
+After=network-online.target docker.service nvidia_gpu_settings_service.service
+Wants=network-online.target nvidia_gpu_settings_service.service
+Requires=docker.service
+Before=sam3-concept.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/sam3-gpu-ready
+RemainAfterExit=yes
+TimeoutStartSec=660
+Restart=on-failure
+RestartSec=15
+
+[Install]
+WantedBy=multi-user.target

--- a/services/sam3-service/host/sam3-gpu-ready.sh
+++ b/services/sam3-service/host/sam3-gpu-ready.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+CONTAINER_NAME="${SAM3_CONTAINER_NAME:-sam3-service}"
+SERVICE_URL="${SAM3_PRIMARY_SERVICE_URL:-http://127.0.0.1:8000}"
+GPU_TIMEOUT_SECONDS="${SAM3_GPU_READY_TIMEOUT_SECONDS:-300}"
+MODEL_TIMEOUT_SECONDS="${SAM3_MODEL_READY_TIMEOUT_SECONDS:-300}"
+POLL_INTERVAL_SECONDS="${SAM3_READY_POLL_INTERVAL_SECONDS:-5}"
+
+log() {
+  printf '[sam3-gpu-ready] %s\n' "$*"
+}
+
+wait_until() {
+  local timeout_seconds="$1"
+  local description="$2"
+  shift 2
+
+  local deadline=$((SECONDS + timeout_seconds))
+  until "$@"; do
+    if (( SECONDS >= deadline )); then
+      log "Timed out waiting for ${description} after ${timeout_seconds}s"
+      return 1
+    fi
+    sleep "$POLL_INTERVAL_SECONDS"
+  done
+}
+
+host_gpu_ready() {
+  nvidia-smi -L >/dev/null 2>&1
+}
+
+container_exists() {
+  docker inspect "$CONTAINER_NAME" >/dev/null 2>&1
+}
+
+container_cuda_ready() {
+  docker exec "$CONTAINER_NAME" python3 -c \
+    'import torch; raise SystemExit(0 if torch.cuda.is_available() and torch.cuda.device_count() > 0 else 1)' \
+    >/dev/null 2>&1
+}
+
+model_ready() {
+  curl --fail --silent --show-error --max-time 5 \
+    "${SERVICE_URL}/api/v1/status" |
+    python3 -c \
+      'import json, sys; data = json.load(sys.stdin); raise SystemExit(0 if data.get("predictor", {}).get("model_loaded") is True and data.get("device") == "cuda" else 1)' \
+    >/dev/null 2>&1
+}
+
+main() {
+  log "Waiting for the host NVIDIA runtime"
+  wait_until "$GPU_TIMEOUT_SECONDS" "host NVIDIA runtime" host_gpu_ready || return 1
+
+  log "Waiting for Docker container ${CONTAINER_NAME}"
+  wait_until "$GPU_TIMEOUT_SECONDS" "Docker container ${CONTAINER_NAME}" container_exists || return 1
+
+  if [[ "$(docker inspect --format '{{.State.Running}}' "$CONTAINER_NAME")" == "true" ]]; then
+    log "Restarting ${CONTAINER_NAME} after CUDA became available"
+    docker restart "$CONTAINER_NAME" >/dev/null
+  else
+    log "Starting ${CONTAINER_NAME} after CUDA became available"
+    docker start "$CONTAINER_NAME" >/dev/null
+  fi
+
+  log "Verifying CUDA from inside ${CONTAINER_NAME}"
+  wait_until "$GPU_TIMEOUT_SECONDS" "container CUDA visibility" container_cuda_ready || return 1
+
+  log "Waiting for the primary SAM3 model"
+  wait_until "$MODEL_TIMEOUT_SECONDS" "primary SAM3 model" model_ready || return 1
+
+  log "Primary SAM3 is ready on CUDA"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/tests/shell/sam3-gpu-ready.test.sh
+++ b/tests/shell/sam3-gpu-ready.test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=../../services/sam3-service/host/sam3-gpu-ready.sh
+source "${REPO_ROOT}/services/sam3-service/host/sam3-gpu-ready.sh"
+
+events=""
+
+record() {
+  events="${events}${events:+,}$1"
+}
+
+host_gpu_ready() {
+  record host-gpu
+}
+
+container_exists() {
+  record container-exists
+}
+
+container_cuda_ready() {
+  record container-cuda
+}
+
+model_ready() {
+  record model-ready
+}
+
+docker() {
+  if [[ "$1" == "inspect" && "$2" == "--format" ]]; then
+    record inspect-running
+    printf 'true\n'
+    return
+  fi
+
+  if [[ "$1" == "restart" && "$2" == "sam3-service" ]]; then
+    record restart
+    return
+  fi
+
+  printf 'Unexpected docker call: %s\n' "$*" >&2
+  return 1
+}
+
+GPU_TIMEOUT_SECONDS=1
+MODEL_TIMEOUT_SECONDS=1
+POLL_INTERVAL_SECONDS=0
+
+main >/dev/null
+
+expected="host-gpu,container-exists,restart,container-cuda,model-ready"
+if [[ "$events" != "$expected" ]]; then
+  printf 'Expected event order %s, got %s\n' "$expected" "$events" >&2
+  exit 1
+fi
+
+events=""
+host_gpu_ready() {
+  record host-not-ready
+  return 1
+}
+GPU_TIMEOUT_SECONDS=0
+
+if main >/dev/null 2>&1; then
+  printf 'Expected the guard to fail when the host GPU never becomes ready\n' >&2
+  exit 1
+fi
+
+if [[ "$events" != "host-not-ready" ]]; then
+  printf 'Guard continued past the failed host readiness gate: %s\n' "$events" >&2
+  exit 1
+fi
+
+printf 'sam3-gpu-ready tests passed\n'

--- a/tests/unit/aws-sam3-startup.test.ts
+++ b/tests/unit/aws-sam3-startup.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_SAM3_STARTUP_TIMEOUT_MS,
+  resolveSam3StartupTimeoutMs,
+} from '@/lib/services/aws-sam3';
+
+describe('SAM3 cold-start timeout', () => {
+  it('allows eight minutes for GPU and model readiness by default', () => {
+    expect(DEFAULT_SAM3_STARTUP_TIMEOUT_MS).toBe(480000);
+    expect(resolveSam3StartupTimeoutMs(undefined)).toBe(480000);
+  });
+
+  it('accepts a configured startup timeout of at least one minute', () => {
+    expect(resolveSam3StartupTimeoutMs('60000')).toBe(60000);
+    expect(resolveSam3StartupTimeoutMs('720000')).toBe(720000);
+  });
+
+  it('falls back safely for invalid or dangerously short values', () => {
+    expect(resolveSam3StartupTimeoutMs('not-a-number')).toBe(480000);
+    expect(resolveSam3StartupTimeoutMs('59999')).toBe(480000);
+  });
+});


### PR DESCRIPTION
## What changed

- add an idempotent systemd boot guard that waits for host NVIDIA readiness before restarting the persisted `sam3-service` container
- verify CUDA inside the container and the primary SAM3 model before allowing the concept service to start
- extend the configurable application cold-start window from 3 minutes to an 8-minute default
- add shell coverage for guard ordering/fail-closed behaviour and unit coverage for timeout configuration

## Root cause

After an EC2 stop/start, Docker could restore `sam3-service` before the NVIDIA runtime was usable. The host GPU was healthy, but PyTorch inside the container saw zero CUDA devices until the container was restarted. The batch then hit the fixed 3-minute startup timeout and became terminally failed before inference.

## Impact

The first Teach search after a stopped GPU instance can remain active through GPU/model warmup and should no longer require a manual container restart.

## Verification

- `bash tests/shell/sam3-gpu-ready.test.sh`
- `npm run test:unit` — 85/85 tests passed
- `npm run build`
- `systemd-analyze verify` on the live Ubuntu SAM3 host (only an unrelated existing Snap warning)

## Live acceptance gate

After merge/deploy: install the guard, stop the SAM3 EC2 instance, then run the first 10-image Teach search without manual runtime intervention.