### PR TITLE
Allow cold concept warmups on fallback GPUs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,9 @@ SAM3_DISABLE_AUTO_SHUTDOWN="false"     # Explicitly disable SAM3 auto-shutdown s
 # SAM3 Concept Propagation Service (DINOv2 + SAM3)
 # Runs alongside the legacy SAM3 /segment service.
 SAM3_CONCEPT_PORT="8002"
+# Cold GPU hosts can take several minutes to load SAM3 and DINOv2.
+# SAM3_CONCEPT_WARMUP_TIMEOUT_MS="900000"
+# SAM3_CONCEPT_REQUEST_TIMEOUT_MS="180000"
 # Optional: override full URL (skip EC2 IP discovery)
 # SAM3_CONCEPT_API_URL="http://localhost:8002"
 # Optional: API key for concept propagation service

--- a/docs/SAM3_VISUAL_CROPS_STATUS.md
+++ b/docs/SAM3_VISUAL_CROPS_STATUS.md
@@ -14,6 +14,8 @@
 ## Key Environment Variables
 - `SAM3_CONCEPT_API_URL` or `SAM3_CONCEPT_URL` (optional, full base URL to port 8002)
 - `SAM3_CONCEPT_PORT` (default `8002`)
+- `SAM3_CONCEPT_WARMUP_TIMEOUT_MS` (default `900000`; cold model load only)
+- `SAM3_CONCEPT_REQUEST_TIMEOUT_MS` (default `180000`; exemplar create/apply requests)
 - `SAM3_SERVICE_URL` or `SAM3_API_URL` (used to derive concept URL when not explicitly set)
 - `SAM3_CONCEPT_API_KEY` or `SAM3_API_KEY` (used as `X-API-Key`)
 - `SAM3_EC2_INSTANCE_ID`, `SAM3_EC2_REGION`, `SAM3_EC2_PORT` (AWS instance config)

--- a/lib/services/sam3-concept.ts
+++ b/lib/services/sam3-concept.ts
@@ -13,7 +13,6 @@ const SAM3_CONCEPT_API_KEY =
   process.env.SAM3_CONCEPT_API_KEY ||
   process.env.SAM3_API_KEY ||
   process.env.NDSD_SAM3_SERVICE_API_KEY;
-const REQUEST_TIMEOUT_MS = 180000;
 
 const parseOptionalNumber = (value: string | undefined): number | undefined => {
   if (!value) return undefined;
@@ -26,6 +25,11 @@ const parseOptionalInt = (value: string | undefined): number | undefined => {
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) ? parsed : undefined;
 };
+
+const REQUEST_TIMEOUT_MS =
+  parseOptionalInt(process.env.SAM3_CONCEPT_REQUEST_TIMEOUT_MS) ?? 180000;
+const WARMUP_TIMEOUT_MS =
+  parseOptionalInt(process.env.SAM3_CONCEPT_WARMUP_TIMEOUT_MS) ?? 900000;
 
 const DEFAULT_SIMILARITY_THRESHOLD = parseOptionalNumber(
   process.env.SAM3_CONCEPT_SIMILARITY_THRESHOLD
@@ -278,7 +282,7 @@ class SAM3ConceptService {
       fetch(`${resolvedBaseUrl}/warmup`, {
         method: 'POST',
         headers: this.buildHeaders(),
-        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        signal: AbortSignal.timeout(WARMUP_TIMEOUT_MS),
       })
     );
 


### PR DESCRIPTION
## Summary
- give cold SAM3 plus DINO concept warmup a dedicated 15-minute timeout
- keep ordinary exemplar requests at the existing 3-minute timeout
- document both timeout controls

## Evidence
- live g4dn.4xlarge T4 warmup completed successfully but required about 10 minutes end-to-end
- npm run test:unit: 92 passed
- targeted lint: clean
- npm run build: passed

## Safety
This changes request timing only. It does not alter labels, training, review state, or spray exports.