### PR TITLE
Guard SAM3 review quality and training scope

### DIFF
--- a/app/api/review/[sessionId]/bulk-action/route.ts
+++ b/app/api/review/[sessionId]/bulk-action/route.ts
@@ -6,6 +6,11 @@ import { normalizeDetectionType } from '@/lib/utils/detection-types';
 type ReviewAction = 'accept' | 'reject';
 type ReviewSource = 'manual' | 'pending' | 'detection';
 
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry) => typeof entry === 'string') as string[];
+}
+
 function confidenceToEnum(confidence: number): 'CERTAIN' | 'LIKELY' | 'UNCERTAIN' {
   if (confidence >= 0.8) return 'CERTAIN';
   if (confidence >= 0.5) return 'LIKELY';
@@ -84,6 +89,34 @@ export async function POST(
 
     if (!membership) {
       return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+    }
+
+    if (session.workflowType === 'batch_review' && action === 'accept') {
+      const batchJobIds = toStringArray(session.batchJobIds);
+      const pendingItemIds = items
+        .filter((item) => item.source === 'pending')
+        .map((item) => item.itemId);
+      if (batchJobIds.length === 0 || pendingItemIds.length !== items.length) {
+        return NextResponse.json(
+          { error: 'SAM3 batch acceptance is limited to pending suggestions on one image.' },
+          { status: 400 }
+        );
+      }
+
+      const scopedItems = await prisma.pendingAnnotation.findMany({
+        where: {
+          id: { in: pendingItemIds },
+          batchJobId: { in: batchJobIds },
+        },
+        select: { id: true, assetId: true },
+      });
+      const scopedAssetIds = new Set(scopedItems.map((item) => item.assetId));
+      if (scopedItems.length !== pendingItemIds.length || scopedAssetIds.size !== 1) {
+        return NextResponse.json(
+          { error: 'SAM3 batch acceptance cannot span multiple images or jobs.' },
+          { status: 400 }
+        );
+      }
     }
 
     const now = new Date();

--- a/app/api/review/[sessionId]/bulk-action/route.ts
+++ b/app/api/review/[sessionId]/bulk-action/route.ts
@@ -107,6 +107,7 @@ export async function POST(
         where: {
           id: { in: pendingItemIds },
           batchJobId: { in: batchJobIds },
+          status: 'PENDING',
         },
         select: { id: true, assetId: true },
       });

--- a/app/api/review/[sessionId]/push/route.ts
+++ b/app/api/review/[sessionId]/push/route.ts
@@ -11,6 +11,7 @@ import { fetchImageSafely, isUrlAllowed } from '@/lib/utils/security';
 import { rescaleToOriginalWithMeta } from '@/lib/utils/georeferencing';
 import { buildTrainingAugmentationFromInput } from '@/lib/services/training-augmentation';
 import { resolveReviewSessionAssetIds } from '@/lib/services/review-session-assets';
+import { resolveTrainingReadyAssetIds } from '@/lib/services/review-training-readiness';
 import type { CenterBox, YOLOPreprocessingMeta } from '@/lib/types/detection';
 import type { AnnotationBox } from '@/types/roboflow';
 
@@ -133,8 +134,26 @@ export async function POST(
     if (assetIds.length === 0) {
       return NextResponse.json({ error: 'No assets available for this session' }, { status: 400 });
     }
+    const trainingAssetIds = await resolveTrainingReadyAssetIds(prisma, session, assetIds);
 
-    const results: Record<string, unknown> = {};
+    if (trainingAssetIds.length === 0) {
+      return NextResponse.json(
+        {
+          error:
+            session.workflowType === 'batch_review'
+              ? 'Review every SAM3 suggestion on at least one image before training. Images with pending suggestions are excluded.'
+              : 'No reviewed assets are available for training.',
+        },
+        { status: 400 }
+      );
+    }
+
+    const results: Record<string, unknown> = {
+      trainingScope: {
+        eligibleAssetCount: trainingAssetIds.length,
+        excludedIncompleteAssetCount: assetIds.length - trainingAssetIds.length,
+      },
+    };
 
     if (target === 'roboflow' || target === 'both') {
       const projectId = roboflowProjectId || session.roboflowProjectId || undefined;
@@ -149,7 +168,7 @@ export async function POST(
         where: {
           verified: true,
           session: {
-            assetId: { in: assetIds },
+            assetId: { in: trainingAssetIds },
           },
         },
         select: { id: true },
@@ -165,7 +184,7 @@ export async function POST(
 
       const detections = await prisma.detection.findMany({
         where: {
-          assetId: { in: assetIds },
+          assetId: { in: trainingAssetIds },
           rejected: false,
           OR: [{ verified: true }, { userCorrected: true }],
         },
@@ -279,7 +298,7 @@ export async function POST(
 
       const dataset = await datasetPreparation.prepareDataset(session.teamId, yoloConfig.datasetName, {
         projectId: session.projectId,
-        assetIds,
+        assetIds: trainingAssetIds,
         classes: dedupedClasses,
         classMapping: yoloConfig.classMapping,
         splitRatio: yoloConfig.splitRatio || { train: 0.7, val: 0.2, test: 0.1 },

--- a/app/review/page.tsx
+++ b/app/review/page.tsx
@@ -90,6 +90,7 @@ function ReviewPageContent() {
   const [exportLoading, setExportLoading] = useState(false);
   const [exportDefaultsInitialized, setExportDefaultsInitialized] = useState(false);
   const [summary, setSummary] = useState<ReviewSummary | null>(null);
+  const [currentReviewAssetId, setCurrentReviewAssetId] = useState<string | null>(null);
 
   const [showYoloModal, setShowYoloModal] = useState(false);
   const [pushMessage, setPushMessage] = useState<string | null>(null);
@@ -189,8 +190,14 @@ function ReviewPageContent() {
     : null;
 
   const bulkCandidates = useMemo(
-    () => filteredItems.filter((item) => item.status === 'pending'),
-    [filteredItems]
+    () =>
+      filteredItems.filter(
+        (item) =>
+          item.status === 'pending' &&
+          (session?.workflowType !== 'batch_review' ||
+            (item.source === 'pending' && item.assetId === currentReviewAssetId))
+      ),
+    [currentReviewAssetId, filteredItems, session?.workflowType]
   );
 
   const pendingItems = useMemo(
@@ -218,16 +225,44 @@ function ReviewPageContent() {
     (preset) => preset.value === minConfidence
   );
 
+  const trainingReadyAssetIds = useMemo(() => {
+    if (session?.workflowType !== 'batch_review') {
+      return new Set(items.filter((item) => item.status === 'accepted').map((item) => item.assetId));
+    }
+
+    const assetReviewState = new Map<string, { hasPending: boolean; hasAccepted: boolean }>();
+    for (const item of items) {
+      const state = assetReviewState.get(item.assetId) || { hasPending: false, hasAccepted: false };
+      if (item.status === 'pending') state.hasPending = true;
+      if (item.status === 'accepted') state.hasAccepted = true;
+      assetReviewState.set(item.assetId, state);
+    }
+
+    return new Set(
+      Array.from(assetReviewState.entries())
+        .filter(([, state]) => !state.hasPending && state.hasAccepted)
+        .map(([assetId]) => assetId)
+    );
+  }, [items, session?.workflowType]);
+
+  const trainingReadyAcceptedCount = useMemo(
+    () =>
+      items.filter(
+        (item) => item.status === 'accepted' && trainingReadyAssetIds.has(item.assetId)
+      ).length,
+    [items, trainingReadyAssetIds]
+  );
+
   const availableClasses = useMemo(() => {
     const counts = new Map<string, number>();
     for (const item of items) {
-      if (item.status !== 'accepted') continue;
+      if (item.status !== 'accepted' || !trainingReadyAssetIds.has(item.assetId)) continue;
       counts.set(item.className, (counts.get(item.className) || 0) + 1);
     }
     return Array.from(counts.entries())
       .map(([name, count]) => ({ name, count }))
       .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
-  }, [items]);
+  }, [items, trainingReadyAssetIds]);
 
   const visibleGeoWarningCount = useMemo(
     () => filteredItems.filter((item) => item.status === 'accepted' && !item.hasGeoData).length,
@@ -345,7 +380,8 @@ function ReviewPageContent() {
 
   const handleBulkAccept = useCallback(async () => {
     if (!sessionId || bulkCandidates.length === 0) return;
-    if (!window.confirm(`Accept ${bulkCandidates.length} visible pending predictions?`)) return;
+    const scope = session?.workflowType === 'batch_review' ? 'on this image' : 'in this view';
+    if (!window.confirm(`Accept ${bulkCandidates.length} visible pending predictions ${scope}?`)) return;
     setActionLoading(true);
     setActionError(null);
     try {
@@ -373,7 +409,7 @@ function ReviewPageContent() {
     } finally {
       setActionLoading(false);
     }
-  }, [bulkCandidates, loadItems, loadSession, sessionId]);
+  }, [bulkCandidates, loadItems, loadSession, session?.workflowType, sessionId]);
 
   const handleExport = useCallback(async () => {
     if (!sessionId || exportLoading) return;
@@ -502,7 +538,11 @@ function ReviewPageContent() {
               <Button
                 variant="outline"
                 onClick={() => handlePush('roboflow')}
-                disabled={pushLoading || !session?.roboflowProjectId}
+                disabled={
+                  pushLoading ||
+                  !session?.roboflowProjectId ||
+                  (session?.workflowType === 'batch_review' && availableClasses.length === 0)
+                }
               >
                 Push to Roboflow
               </Button>
@@ -710,8 +750,15 @@ function ReviewPageContent() {
                 onClick={handleBulkAccept}
                 disabled={actionLoading || bulkCandidates.length === 0}
               >
-                Accept visible pending ({bulkCandidates.length})
+                {session?.workflowType === 'batch_review'
+                  ? `Accept pending on this image (${bulkCandidates.length})`
+                  : `Accept visible pending (${bulkCandidates.length})`}
               </Button>
+              {session?.workflowType === 'batch_review' && (
+                <span className="max-w-sm rounded-md border border-sky-200 bg-sky-50 px-2 py-1 text-xs text-sky-800">
+                  This shortcut is limited to the current image. Images with pending suggestions stay out of training.
+                </span>
+              )}
               {minConfidence <= 72 && (
                 <span className="rounded-md border border-amber-200 bg-amber-50 px-2 py-1 text-xs text-amber-800">
                   High recall mode: expect more false positives to reject.
@@ -772,7 +819,13 @@ function ReviewPageContent() {
           </div>
         )}
 
-        <ReviewViewer assets={assets} items={filteredItems} onAction={handleAction} onEdit={handleEdit} />
+        <ReviewViewer
+          assets={assets}
+          items={filteredItems}
+          onAction={handleAction}
+          onEdit={handleEdit}
+          onCurrentAssetChange={setCurrentReviewAssetId}
+        />
 
         {/* Next Steps Card - shown when there are accepted items */}
         {(summary?.acceptedCount ?? 0) > 0 && (
@@ -785,7 +838,10 @@ function ReviewPageContent() {
                     Ready for next steps
                   </div>
                   <p className="text-xs text-gray-600 mt-1">
-                    {summary?.acceptedCount ?? 0} accepted annotations can be exported or used for training.
+                    {summary?.acceptedCount ?? 0} accepted annotations are available for approved export.{' '}
+                    {session?.workflowType === 'batch_review'
+                      ? `${trainingReadyAcceptedCount} accepted annotations across ${trainingReadyAssetIds.size} fully reviewed image${trainingReadyAssetIds.size === 1 ? '' : 's'} are eligible for training.`
+                      : `${trainingReadyAcceptedCount} accepted annotations are eligible for training.`}
                   </p>
                 </div>
                 <div className="flex flex-wrap gap-2">

--- a/components/review/ReviewViewer.tsx
+++ b/components/review/ReviewViewer.tsx
@@ -75,9 +75,16 @@ interface ReviewViewerProps {
   assets?: ReviewItemAsset[];
   onAction: (item: ReviewItem, action: 'accept' | 'reject' | 'correct' | 'restore', correctedClass?: string) => Promise<void>;
   onEdit: (item: ReviewItem) => void;
+  onCurrentAssetChange?: (assetId: string | null) => void;
 }
 
-export function ReviewViewer({ items, assets = [], onAction, onEdit }: ReviewViewerProps) {
+export function ReviewViewer({
+  items,
+  assets = [],
+  onAction,
+  onEdit,
+  onCurrentAssetChange,
+}: ReviewViewerProps) {
   const groupedAssets = useMemo(() => {
     const map = new Map<string, { asset: ReviewItemAsset; items: ReviewItem[] }>();
     for (const asset of assets) {
@@ -108,6 +115,10 @@ export function ReviewViewer({ items, assets = [], onAction, onEdit }: ReviewVie
 
   const currentGroup = groupedAssets[currentIndex];
   const currentItems = currentGroup?.items || [];
+
+  useEffect(() => {
+    onCurrentAssetChange?.(currentGroup?.asset.id ?? null);
+  }, [currentGroup?.asset.id, onCurrentAssetChange]);
 
   useEffect(() => {
     setZoomLevel(1);

--- a/lib/services/review-training-readiness.ts
+++ b/lib/services/review-training-readiness.ts
@@ -1,0 +1,51 @@
+interface ReviewTrainingPrisma {
+  pendingAnnotation: {
+    findMany(args: {
+      where: {
+        assetId: { in: string[] };
+        batchJobId: { in: string[] };
+        status: 'PENDING';
+      };
+      select: { assetId: true };
+      distinct: ['assetId'];
+    }): Promise<Array<{ assetId: string }>>;
+  };
+}
+
+interface ReviewTrainingSession {
+  workflowType: string;
+  batchJobIds?: unknown;
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry) => typeof entry === 'string') as string[];
+}
+
+export async function resolveTrainingReadyAssetIds(
+  prisma: ReviewTrainingPrisma,
+  session: ReviewTrainingSession,
+  assetIds: string[]
+): Promise<string[]> {
+  if (session.workflowType !== 'batch_review') {
+    return assetIds;
+  }
+
+  const batchJobIds = toStringArray(session.batchJobIds);
+  if (assetIds.length === 0 || batchJobIds.length === 0) {
+    return [];
+  }
+
+  const incompleteAssets = await prisma.pendingAnnotation.findMany({
+    where: {
+      assetId: { in: assetIds },
+      batchJobId: { in: batchJobIds },
+      status: 'PENDING',
+    },
+    select: { assetId: true },
+    distinct: ['assetId'],
+  });
+  const incompleteAssetIds = new Set(incompleteAssets.map((entry) => entry.assetId));
+
+  return assetIds.filter((assetId) => !incompleteAssetIds.has(assetId));
+}

--- a/lib/services/sam3-batch-v2.ts
+++ b/lib/services/sam3-batch-v2.ts
@@ -104,7 +104,7 @@ export const SAM3_BATCH_V2_SOURCE_DETECTION_MIN_ANCHOR_OVERLAP = Math.max(
 );
 export const SAM3_BATCH_V2_FINAL_NMS_THRESHOLD = Math.max(
   0,
-  Math.min(1, parseOptionalNumber(process.env.SAM3_REVIEW_FINAL_NMS_IOU) ?? 0.35)
+  Math.min(1, parseOptionalNumber(process.env.SAM3_REVIEW_FINAL_NMS_IOU) ?? 0.5)
 );
 export const SAM3_BATCH_V2_FINAL_CONTAINMENT_THRESHOLD = Math.max(
   0,

--- a/lib/services/sam3-batch-v2.ts
+++ b/lib/services/sam3-batch-v2.ts
@@ -20,6 +20,7 @@ import {
   type Sam3BatchJobKind,
 } from '@/lib/utils/sam3-batch-jobs';
 import { scaleExemplarBoxes, type BoxCoordinate } from '@/lib/utils/exemplar-scaling';
+import { filterSam3ReviewDetections } from '@/lib/utils/sam3-review-quality';
 import { fetchImageSafely } from '@/lib/utils/security';
 
 const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
@@ -100,6 +101,22 @@ export const SAM3_BATCH_V2_SOURCE_DETECTION_MIN_ANCHOR_OVERLAP = Math.max(
     1,
     parseOptionalNumber(process.env.SAM3_SOURCE_DETECTION_MIN_ANCHOR_OVERLAP) ?? 0.2
   )
+);
+export const SAM3_BATCH_V2_FINAL_NMS_THRESHOLD = Math.max(
+  0,
+  Math.min(1, parseOptionalNumber(process.env.SAM3_REVIEW_FINAL_NMS_IOU) ?? 0.35)
+);
+export const SAM3_BATCH_V2_FINAL_CONTAINMENT_THRESHOLD = Math.max(
+  0,
+  Math.min(1, parseOptionalNumber(process.env.SAM3_REVIEW_CONTAINMENT_THRESHOLD) ?? 0.82)
+);
+export const SAM3_BATCH_V2_MAX_EXEMPLAR_DIMENSION_RATIO = Math.max(
+  1,
+  parseOptionalNumber(process.env.SAM3_REVIEW_MAX_DIMENSION_RATIO) ?? 2.5
+);
+export const SAM3_BATCH_V2_MAX_EXEMPLAR_AREA_RATIO = Math.max(
+  1,
+  parseOptionalNumber(process.env.SAM3_REVIEW_MAX_AREA_RATIO) ?? 5
 );
 export function resolveBatchV2ReviewProfileForMode(
   mode: Sam3BatchV2Mode
@@ -247,6 +264,10 @@ export interface Sam3BatchV2StageLogEntry {
   conceptExemplarCount?: number;
   refinementBoxCount?: number;
   refinementDetectionCount?: number;
+  qualityInputCount?: number;
+  duplicateSuppressedCount?: number;
+  geometryFilteredCount?: number;
+  qualityOutputCount?: number;
   durationMs?: number;
   gpuMemoryMb?: number;
   estimatedMemoryMb?: number;
@@ -413,6 +434,8 @@ interface PreparedBatchContext {
   textPrompt: string;
   sourceAssetId: string;
   sourceImageBuffer: Buffer;
+  sourceImageWidth?: number;
+  sourceImageHeight?: number;
   exemplars: BoxCoordinate[];
   exemplarSourceWidth?: number;
   exemplarSourceHeight?: number;
@@ -441,6 +464,10 @@ interface AssetInferenceResult {
   candidateCount?: number;
   refinementBoxCount?: number;
   refinementDetectionCount?: number;
+  qualityInputCount?: number;
+  duplicateSuppressedCount?: number;
+  geometryFilteredCount?: number;
+  qualityOutputCount?: number;
 }
 
 interface ConceptRefinementResult {
@@ -1193,6 +1220,8 @@ export class Sam3BatchV2Service {
       textPrompt: data.textPrompt?.trim().substring(0, 100) || data.weedType,
       sourceAssetId,
       sourceImageBuffer,
+      sourceImageWidth: sourceAsset.imageWidth ?? data.exemplarSourceWidth,
+      sourceImageHeight: sourceAsset.imageHeight ?? data.exemplarSourceHeight,
       exemplars: data.exemplars,
       exemplarSourceWidth: data.exemplarSourceWidth,
       exemplarSourceHeight: data.exemplarSourceHeight,
@@ -1513,7 +1542,13 @@ export class Sam3BatchV2Service {
         if (prepared.mode === 'visual_crop_match') {
           result = await this.runVisualCropMatch(asset, imageBuffer, prepared);
         } else {
-          result = await this.runConceptPropagation(asset, imageBuffer, conceptExemplars, prepared.weedType);
+          result = await this.runConceptPropagation(
+            asset,
+            imageBuffer,
+            conceptExemplars,
+            prepared.weedType,
+            prepared
+          );
         }
 
         await this.appendStageLog(batchJobId, stageLog, {
@@ -1541,6 +1576,10 @@ export class Sam3BatchV2Service {
             prepared.mode === 'concept_propagation' ? conceptExemplars.length : undefined,
           refinementBoxCount: result.refinementBoxCount,
           refinementDetectionCount: result.refinementDetectionCount,
+          qualityInputCount: result.qualityInputCount,
+          duplicateSuppressedCount: result.duplicateSuppressedCount,
+          geometryFilteredCount: result.geometryFilteredCount,
+          qualityOutputCount: result.qualityOutputCount,
           durationMs: this.now().getTime() - runStartedAt,
         });
       } catch (error) {
@@ -1808,7 +1847,8 @@ export class Sam3BatchV2Service {
     asset: AssetRecord,
     imageBuffer: Buffer,
     conceptExemplars: string | ConceptExemplarRef[] | null,
-    weedType: string
+    weedType: string,
+    qualityContext?: PreparedBatchContext
   ): Promise<AssetInferenceResult> {
     const exemplarRefs = normalizeConceptExemplarRefs(conceptExemplars);
     if (exemplarRefs.length === 0) {
@@ -1839,19 +1879,45 @@ export class Sam3BatchV2Service {
       weedType,
       candidateResult.detections
     );
+    const quality = filterSam3ReviewDetections({
+      detections: refinement.detections,
+      exemplars: qualityContext?.exemplars ?? [],
+      sourceWidth: qualityContext?.exemplarSourceWidth ?? qualityContext?.sourceImageWidth,
+      sourceHeight: qualityContext?.exemplarSourceHeight ?? qualityContext?.sourceImageHeight,
+      targetWidth: asset.imageWidth,
+      targetHeight: asset.imageHeight,
+      dedupeIouThreshold: SAM3_BATCH_V2_FINAL_NMS_THRESHOLD,
+      containmentThreshold: SAM3_BATCH_V2_FINAL_CONTAINMENT_THRESHOLD,
+      maxDimensionRatio: SAM3_BATCH_V2_MAX_EXEMPLAR_DIMENSION_RATIO,
+      maxAreaRatio: SAM3_BATCH_V2_MAX_EXEMPLAR_AREA_RATIO,
+    });
+    const qualityWarning = [
+      quality.stats.duplicateSuppressedCount > 0
+        ? `${quality.stats.duplicateSuppressedCount} duplicate refined detection(s) suppressed.`
+        : null,
+      quality.stats.geometryFilteredCount > 0
+        ? `${quality.stats.geometryFilteredCount} implausibly large or invalid refined detection(s) suppressed.`
+        : null,
+    ]
+      .filter(Boolean)
+      .join(' ');
 
     return {
       assetId: asset.id,
-      detections: refinement.detections,
-      outcome: refinement.detections.length > 0 ? 'success' : 'zero_detections',
+      detections: quality.detections,
+      outcome: quality.detections.length > 0 ? 'success' : 'zero_detections',
       backendMode: refinement.usedCandidateFallback
         ? 'concept_ensemble_candidates_unrefined'
         : 'concept_ensemble_refined',
-      backendWarning: refinement.backendWarning,
+      backendWarning: [refinement.backendWarning, qualityWarning].filter(Boolean).join(' ') || undefined,
       candidateExpansionUsed: candidateResult.candidateExpansionUsed,
       candidateCount: refinement.candidateCount,
       refinementBoxCount: refinement.refinementBoxCount,
       refinementDetectionCount: refinement.refinementDetectionCount,
+      qualityInputCount: quality.stats.inputCount,
+      duplicateSuppressedCount: quality.stats.duplicateSuppressedCount,
+      geometryFilteredCount: quality.stats.geometryFilteredCount,
+      qualityOutputCount: quality.stats.outputCount,
     };
   }
 

--- a/lib/utils/sam3-review-quality.ts
+++ b/lib/utils/sam3-review-quality.ts
@@ -37,7 +37,7 @@ export interface Sam3ReviewQualityResult {
   stats: Sam3ReviewQualityStats;
 }
 
-const DEFAULT_DEDUPE_IOU_THRESHOLD = 0.35;
+const DEFAULT_DEDUPE_IOU_THRESHOLD = 0.5;
 const DEFAULT_CONTAINMENT_THRESHOLD = 0.82;
 const DEFAULT_MAX_DIMENSION_RATIO = 2.5;
 const DEFAULT_MAX_AREA_RATIO = 5;

--- a/lib/utils/sam3-review-quality.ts
+++ b/lib/utils/sam3-review-quality.ts
@@ -1,0 +1,227 @@
+export interface Sam3ReviewDetection {
+  bbox: [number, number, number, number];
+  polygon: [number, number][];
+  confidence: number;
+  similarity?: number;
+}
+
+export interface Sam3ReviewExemplarBox {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+export interface Sam3ReviewQualityOptions {
+  detections: Sam3ReviewDetection[];
+  exemplars: Sam3ReviewExemplarBox[];
+  sourceWidth?: number | null;
+  sourceHeight?: number | null;
+  targetWidth?: number | null;
+  targetHeight?: number | null;
+  dedupeIouThreshold?: number;
+  containmentThreshold?: number;
+  maxDimensionRatio?: number;
+  maxAreaRatio?: number;
+}
+
+export interface Sam3ReviewQualityStats {
+  inputCount: number;
+  duplicateSuppressedCount: number;
+  geometryFilteredCount: number;
+  outputCount: number;
+}
+
+export interface Sam3ReviewQualityResult {
+  detections: Sam3ReviewDetection[];
+  stats: Sam3ReviewQualityStats;
+}
+
+const DEFAULT_DEDUPE_IOU_THRESHOLD = 0.35;
+const DEFAULT_CONTAINMENT_THRESHOLD = 0.82;
+const DEFAULT_MAX_DIMENSION_RATIO = 2.5;
+const DEFAULT_MAX_AREA_RATIO = 5;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function boxArea(box: [number, number, number, number]): number {
+  return Math.max(0, box[2] - box[0]) * Math.max(0, box[3] - box[1]);
+}
+
+function intersectionArea(
+  first: [number, number, number, number],
+  second: [number, number, number, number]
+): number {
+  return boxArea([
+    Math.max(first[0], second[0]),
+    Math.max(first[1], second[1]),
+    Math.min(first[2], second[2]),
+    Math.min(first[3], second[3]),
+  ]);
+}
+
+function boxIou(
+  first: [number, number, number, number],
+  second: [number, number, number, number]
+): number {
+  const intersection = intersectionArea(first, second);
+  const union = boxArea(first) + boxArea(second) - intersection;
+  return union > 0 ? intersection / union : 0;
+}
+
+function boxContainment(
+  first: [number, number, number, number],
+  second: [number, number, number, number]
+): number {
+  const smallerArea = Math.min(boxArea(first), boxArea(second));
+  return smallerArea > 0 ? intersectionArea(first, second) / smallerArea : 0;
+}
+
+function detectionScore(detection: Sam3ReviewDetection): number {
+  return typeof detection.similarity === 'number' && Number.isFinite(detection.similarity)
+    ? detection.similarity
+    : Number.isFinite(detection.confidence)
+      ? detection.confidence
+      : 0;
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((left, right) => left - right);
+  const midpoint = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[midpoint - 1] + sorted[midpoint]) / 2
+    : sorted[midpoint];
+}
+
+function isPositiveFinite(value: number | null | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+function normalizeDetection(
+  detection: Sam3ReviewDetection,
+  targetWidth?: number | null,
+  targetHeight?: number | null
+): Sam3ReviewDetection | null {
+  const [rawX1, rawY1, rawX2, rawY2] = detection.bbox;
+  if (![rawX1, rawY1, rawX2, rawY2].every(Number.isFinite)) return null;
+
+  const x1 = isPositiveFinite(targetWidth) ? clamp(rawX1, 0, targetWidth) : rawX1;
+  const y1 = isPositiveFinite(targetHeight) ? clamp(rawY1, 0, targetHeight) : rawY1;
+  const x2 = isPositiveFinite(targetWidth) ? clamp(rawX2, 0, targetWidth) : rawX2;
+  const y2 = isPositiveFinite(targetHeight) ? clamp(rawY2, 0, targetHeight) : rawY2;
+  const bbox: [number, number, number, number] = [x1, y1, x2, y2];
+
+  if (boxArea(bbox) <= 0) return null;
+
+  return {
+    ...detection,
+    bbox,
+    polygon: detection.polygon.map(([x, y]) => [
+      isPositiveFinite(targetWidth) ? clamp(x, 0, targetWidth) : x,
+      isPositiveFinite(targetHeight) ? clamp(y, 0, targetHeight) : y,
+    ]),
+  };
+}
+
+function buildExpectedGeometry(options: Sam3ReviewQualityOptions): {
+  width: number;
+  height: number;
+  area: number;
+} | null {
+  if (
+    !isPositiveFinite(options.sourceWidth) ||
+    !isPositiveFinite(options.sourceHeight) ||
+    !isPositiveFinite(options.targetWidth) ||
+    !isPositiveFinite(options.targetHeight)
+  ) {
+    return null;
+  }
+
+  const sourceWidth = options.sourceWidth;
+  const sourceHeight = options.sourceHeight;
+  const targetWidth = options.targetWidth;
+  const targetHeight = options.targetHeight;
+  const scaledBoxes = options.exemplars.flatMap((box) => {
+    const width = Math.abs(box.x2 - box.x1) * (targetWidth / sourceWidth);
+    const height = Math.abs(box.y2 - box.y1) * (targetHeight / sourceHeight);
+    if (!isPositiveFinite(width) || !isPositiveFinite(height)) return [];
+    return [{ width, height, area: width * height }];
+  });
+  const scaledWidths = scaledBoxes.map((box) => box.width);
+  const scaledHeights = scaledBoxes.map((box) => box.height);
+  const scaledAreas = scaledBoxes.map((box) => box.area);
+
+  const width = median(scaledWidths);
+  const height = median(scaledHeights);
+  const area = median(scaledAreas);
+  if (!isPositiveFinite(width) || !isPositiveFinite(height) || !isPositiveFinite(area)) {
+    return null;
+  }
+
+  return { width, height, area };
+}
+
+export function filterSam3ReviewDetections(
+  options: Sam3ReviewQualityOptions
+): Sam3ReviewQualityResult {
+  const stats: Sam3ReviewQualityStats = {
+    inputCount: options.detections.length,
+    duplicateSuppressedCount: 0,
+    geometryFilteredCount: 0,
+    outputCount: 0,
+  };
+  const expected = buildExpectedGeometry(options);
+  const maxDimensionRatio = options.maxDimensionRatio ?? DEFAULT_MAX_DIMENSION_RATIO;
+  const maxAreaRatio = options.maxAreaRatio ?? DEFAULT_MAX_AREA_RATIO;
+
+  const geometrySafe = options.detections.flatMap((detection) => {
+    const normalized = normalizeDetection(detection, options.targetWidth, options.targetHeight);
+    if (!normalized) {
+      stats.geometryFilteredCount += 1;
+      return [];
+    }
+
+    if (expected) {
+      const width = normalized.bbox[2] - normalized.bbox[0];
+      const height = normalized.bbox[3] - normalized.bbox[1];
+      const area = boxArea(normalized.bbox);
+      if (
+        width > expected.width * maxDimensionRatio ||
+        height > expected.height * maxDimensionRatio ||
+        area > expected.area * maxAreaRatio
+      ) {
+        stats.geometryFilteredCount += 1;
+        return [];
+      }
+    }
+
+    return [normalized];
+  });
+
+  const dedupeIouThreshold = options.dedupeIouThreshold ?? DEFAULT_DEDUPE_IOU_THRESHOLD;
+  const containmentThreshold = options.containmentThreshold ?? DEFAULT_CONTAINMENT_THRESHOLD;
+  const selected: Sam3ReviewDetection[] = [];
+
+  for (const detection of geometrySafe
+    .map((candidate, index) => ({ candidate, index }))
+    .sort((left, right) =>
+      detectionScore(right.candidate) - detectionScore(left.candidate) || left.index - right.index
+    )
+    .map(({ candidate }) => candidate)) {
+    const duplicate = selected.some((existing) =>
+      boxIou(existing.bbox, detection.bbox) >= dedupeIouThreshold ||
+      boxContainment(existing.bbox, detection.bbox) >= containmentThreshold
+    );
+    if (duplicate) {
+      stats.duplicateSuppressedCount += 1;
+      continue;
+    }
+    selected.push(detection);
+  }
+
+  stats.outputCount = selected.length;
+  return { detections: selected, stats };
+}

--- a/tests/unit/review-training-readiness.test.ts
+++ b/tests/unit/review-training-readiness.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveTrainingReadyAssetIds } from '@/lib/services/review-training-readiness';
+
+describe('review training readiness', () => {
+  it('leaves non-batch review assets unchanged', async () => {
+    const findMany = vi.fn();
+    const result = await resolveTrainingReadyAssetIds(
+      { pendingAnnotation: { findMany } },
+      { workflowType: 'standard_review' },
+      ['asset-a', 'asset-b']
+    );
+
+    expect(result).toEqual(['asset-a', 'asset-b']);
+    expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it('excludes batch images that still contain pending suggestions', async () => {
+    const findMany = vi.fn().mockResolvedValue([
+      { assetId: 'asset-a' },
+      { assetId: 'asset-c' },
+    ]);
+    const result = await resolveTrainingReadyAssetIds(
+      { pendingAnnotation: { findMany } },
+      { workflowType: 'batch_review', batchJobIds: ['batch-1'] },
+      ['asset-a', 'asset-b', 'asset-c']
+    );
+
+    expect(result).toEqual(['asset-b']);
+    expect(findMany).toHaveBeenCalledWith({
+      where: {
+        assetId: { in: ['asset-a', 'asset-b', 'asset-c'] },
+        batchJobId: { in: ['batch-1'] },
+        status: 'PENDING',
+      },
+      select: { assetId: true },
+      distinct: ['assetId'],
+    });
+  });
+
+  it('fails closed for old batch sessions without job scope', async () => {
+    const findMany = vi.fn();
+    const result = await resolveTrainingReadyAssetIds(
+      { pendingAnnotation: { findMany } },
+      { workflowType: 'batch_review', batchJobIds: [] },
+      ['asset-a']
+    );
+
+    expect(result).toEqual([]);
+    expect(findMany).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/sam3-review-quality.test.ts
+++ b/tests/unit/sam3-review-quality.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { filterSam3ReviewDetections } from '@/lib/utils/sam3-review-quality';
+
+const polygonFor = (bbox: [number, number, number, number]): [number, number][] => [
+  [bbox[0], bbox[1]],
+  [bbox[2], bbox[1]],
+  [bbox[2], bbox[3]],
+  [bbox[0], bbox[3]],
+];
+
+describe('SAM3 review quality guardrails', () => {
+  it('keeps the highest-scoring box and suppresses overlapping or contained duplicates', () => {
+    const boxes: Array<[number, number, number, number]> = [
+      [100, 100, 140, 140],
+      [102, 102, 139, 139],
+      [98, 98, 143, 143],
+      [180, 100, 220, 140],
+    ];
+    const result = filterSam3ReviewDetections({
+      detections: boxes.map((bbox, index) => ({
+        bbox,
+        polygon: polygonFor(bbox),
+        confidence: [0.91, 0.87, 0.84, 0.88][index],
+      })),
+      exemplars: [{ x1: 10, y1: 10, x2: 50, y2: 50 }],
+    });
+
+    expect(result.detections.map((detection) => detection.bbox)).toEqual([
+      [100, 100, 140, 140],
+      [180, 100, 220, 140],
+    ]);
+    expect(result.stats).toEqual({
+      inputCount: 4,
+      duplicateSuppressedCount: 2,
+      geometryFilteredCount: 0,
+      outputCount: 2,
+    });
+  });
+
+  it('drops implausibly large boxes while preserving similarly scaled saplings', () => {
+    const valid: [number, number, number, number] = [500, 400, 545, 445];
+    const adjacent: [number, number, number, number] = [580, 405, 620, 448];
+    const oversized: [number, number, number, number] = [700, 350, 880, 500];
+    const result = filterSam3ReviewDetections({
+      detections: [valid, adjacent, oversized].map((bbox, index) => ({
+        bbox,
+        polygon: polygonFor(bbox),
+        confidence: [0.86, 0.84, 0.93][index],
+      })),
+      exemplars: [
+        { x1: 100, y1: 100, x2: 140, y2: 140 },
+        { x1: 180, y1: 100, x2: 225, y2: 145 },
+        { x1: 260, y1: 100, x2: 302, y2: 142 },
+      ],
+      sourceWidth: 4000,
+      sourceHeight: 3000,
+      targetWidth: 4000,
+      targetHeight: 3000,
+    });
+
+    expect(result.detections.map((detection) => detection.bbox)).toEqual([valid, adjacent]);
+    expect(result.stats.geometryFilteredCount).toBe(1);
+    expect(result.stats.duplicateSuppressedCount).toBe(0);
+  });
+});

--- a/tests/unit/sam3-review-quality.test.ts
+++ b/tests/unit/sam3-review-quality.test.ts
@@ -37,6 +37,22 @@ describe('SAM3 review quality guardrails', () => {
     });
   });
 
+  it('keeps nearby same-sized objects when overlap is below the final NMS threshold', () => {
+    const first: [number, number, number, number] = [100, 100, 140, 140];
+    const nearby: [number, number, number, number] = [117, 100, 157, 140];
+    const result = filterSam3ReviewDetections({
+      detections: [first, nearby].map((bbox, index) => ({
+        bbox,
+        polygon: polygonFor(bbox),
+        confidence: [0.91, 0.89][index],
+      })),
+      exemplars: [{ x1: 10, y1: 10, x2: 50, y2: 50 }],
+    });
+
+    expect(result.detections.map((detection) => detection.bbox)).toEqual([first, nearby]);
+    expect(result.stats.duplicateSuppressedCount).toBe(0);
+  });
+
   it('drops implausibly large boxes while preserving similarly scaled saplings', () => {
     const valid: [number, number, number, number] = [500, 400, 545, 445];
     const adjacent: [number, number, number, number] = [580, 405, 620, 448];


### PR DESCRIPTION
## What changed

- suppress duplicate refined SAM3 detections before they enter the review queue
- reject invalid and implausibly oversized boxes using source-exemplar geometry scaled to each target image
- record per-image quality-filter counts in the SAM3 v2 stage log
- exclude batch images with any pending SAM3 suggestions from Roboflow and YOLO training
- scope bulk acceptance to the currently viewed image and enforce that boundary server-side
- show training eligibility separately from approved spray-export counts

## Why

The 10-image pine sapling canary produced overlapping and oversized boxes, while partially reviewed images could be treated as fully labelled training images. That risks teaching YOLO false positives and false background negatives.

## User impact

Reviewers retain a fast per-image acceptance action, but cannot accidentally accept predictions across the whole batch. Accepted detections remain available for approved spray export; an image becomes training-eligible only after all SAM3 suggestions on that image have been resolved.

## Validation

- `npm run test:unit` — 97 tests passed
- `npm run build` — production build completed
- `git diff --cached --check` — clean

## Follow-up release test

After deployment, rerun the same cold-start 10-image pine sapling canary and compare duplicate suppression, oversized-box suppression, retained true positives, and missed saplings against the v296 run.