### PR TITLE
Georeferencing validation harness + golden projection fixtures (georef PR 1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "worker:temporal": "tsx -r tsconfig-paths/register workers/temporal-worker.ts",
     "worker:temporal:dev": "tsx -r tsconfig-paths/register --env-file=.env workers/temporal-worker.ts",
     "calibrate:camera-profile": "tsx -r tsconfig-paths/register scripts/calibrate-camera-profile.ts",
+    "georef:harness": "node --import tsx -r tsconfig-paths/register scripts/georef-harness.ts",
     "feature:dataset-versions": "tsx -r tsconfig-paths/register scripts/feature-dataset-versions.ts",
     "migrate:model-weights": "tsx -r tsconfig-paths/register scripts/migrate-model-weights.ts",
     "sam3:replay": "tsx -r tsconfig-paths/register scripts/sam3-replay.ts",

--- a/scripts/georef-harness.ts
+++ b/scripts/georef-harness.ts
@@ -1,0 +1,646 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { PrismaClient, type Prisma } from '@prisma/client';
+
+type ParsedArgs = {
+  projectId?: string;
+  outputDir: string;
+  fixedElevationM: number;
+  limit?: number;
+  help: boolean;
+};
+
+type GeoPoint = { lat: number; lon: number };
+
+type EdgeName = 'midLeft' | 'midRight' | 'midTop' | 'midBottom';
+
+type ProjectedEdge = {
+  pixel: { x: number; y: number };
+  geo: GeoPoint | null;
+  offsetFromCentreM: {
+    east: number;
+    north: number;
+    radial: number;
+  } | null;
+};
+
+type HarnessRow = {
+  assetId: string;
+  fileName: string;
+  projectId: string;
+  projectName: string;
+  flightSession: string;
+  elevation: {
+    source: 'lrf_target_alt_metadata' | 'fixed_elevation';
+    metres: number;
+  };
+  imageSize: { width: number; height: number };
+  centrePixel: { x: number; y: number };
+  centreProjection: GeoPoint | null;
+  lrfTarget: GeoPoint & { distanceM: number };
+  centreErrorM: number | null;
+  edges: Record<EdgeName, ProjectedEdge>;
+};
+
+type FlightReport = {
+  generatedAt: string;
+  projectionPath: 'pixelToGeoWithDSM_photogrammetry_lrf_removed';
+  networkElevationDisabled: true;
+  project: { id: string; name: string };
+  flightSession: string;
+  summary: {
+    count: number;
+    projectedCount: number;
+    failedCount: number;
+    p50CentreErrorM: number | null;
+    p90CentreErrorM: number | null;
+    worst5: Array<{ assetId: string; fileName: string; centreErrorM: number }>;
+  };
+  rows: HarnessRow[];
+};
+
+const assetSelect = {
+  id: true,
+  fileName: true,
+  projectId: true,
+  flightSession: true,
+  gpsLatitude: true,
+  gpsLongitude: true,
+  altitude: true,
+  gimbalPitch: true,
+  gimbalRoll: true,
+  gimbalYaw: true,
+  cameraFov: true,
+  imageWidth: true,
+  imageHeight: true,
+  lrfDistance: true,
+  lrfTargetLat: true,
+  lrfTargetLon: true,
+  metadata: true,
+  project: {
+    select: {
+      id: true,
+      name: true,
+    },
+  },
+} satisfies Prisma.AssetSelect;
+
+type AssetRow = Prisma.AssetGetPayload<{ select: typeof assetSelect }>;
+
+const LRF_METADATA_KEYS = [
+  'LRFTargetDistance',
+  'drone-dji:LRFTargetDistance',
+  'LRFTargetLat',
+  'drone-dji:LRFTargetLat',
+  'LRFTargetLon',
+  'drone-dji:LRFTargetLon',
+  'LRFTargetAlt',
+  'drone-dji:LRFTargetAlt',
+] as const;
+
+const GPS_LATITUDE_KEYS = [
+  'GpsLatitude',
+  'GPSLatitude',
+  'Latitude',
+  'latitude',
+  'drone-dji:GPSLatitude',
+  'drone-dji:GpsLatitude',
+] as const;
+const GPS_LONGITUDE_KEYS = [
+  'GpsLongitude',
+  'GPSLongitude',
+  'Longitude',
+  'longitude',
+  'drone-dji:GPSLongitude',
+  'drone-dji:GpsLongitude',
+] as const;
+const GIMBAL_PITCH_KEYS = [
+  'GimbalPitchDegree',
+  'drone-dji:GimbalPitchDegree',
+] as const;
+const GIMBAL_ROLL_KEYS = [
+  'GimbalRollDegree',
+  'drone-dji:GimbalRollDegree',
+] as const;
+const GIMBAL_YAW_KEYS = [
+  'GimbalYawDegree',
+  'FlightYawDegree',
+  'drone-dji:GimbalYawDegree',
+  'drone-dji:FlightYawDegree',
+] as const;
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const valueFor = (flag: string): string | undefined => {
+    const index = argv.indexOf(flag);
+    return index >= 0 ? argv[index + 1] : undefined;
+  };
+
+  const fixedElevationRaw = valueFor('--fixed-elevation');
+  const fixedElevationM = fixedElevationRaw == null ? 0 : Number(fixedElevationRaw);
+  if (!Number.isFinite(fixedElevationM)) {
+    throw new Error('--fixed-elevation must be a finite number in metres');
+  }
+
+  const limitRaw = valueFor('--limit');
+  const limit = limitRaw == null ? undefined : Number(limitRaw);
+  if (limit != null && (!Number.isInteger(limit) || limit <= 0)) {
+    throw new Error('--limit must be a positive integer');
+  }
+
+  const outputArg = valueFor('--output-dir');
+  const outputDir = path.resolve(
+    outputArg ?? path.join(os.tmpdir(), 'agri-drone-ops-georef-harness')
+  );
+
+  return {
+    projectId: valueFor('--project'),
+    outputDir,
+    fixedElevationM,
+    limit,
+    help: argv.includes('--help') || argv.includes('-h'),
+  };
+}
+
+function printHelp(): void {
+  console.log(
+    [
+      'Usage: npm run georef:harness -- [options]',
+      '',
+      'Measures the current photogrammetric projection against stored LRF targets.',
+      'All elevation HTTP is intercepted locally; this script never calls the network.',
+      '',
+      'Options:',
+      '  --project <id>             Restrict assets to one project',
+      '  --limit <count>            Limit source assets for a quick sample',
+      '  --fixed-elevation <metres> Offline elevation when LRFTargetAlt is absent (default: 0)',
+      '  --output-dir <path>        Report directory (default: OS temp directory)',
+      '  --help                     Show this help',
+    ].join('\n')
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function readNumber(metadata: Record<string, unknown>, keys: readonly string[]): number | null {
+  for (const key of keys) {
+    const value = toFiniteNumber(metadata[key]);
+    if (value != null) return value;
+  }
+  return null;
+}
+
+function withoutLrfMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
+  const copy = { ...metadata };
+  for (const key of LRF_METADATA_KEYS) delete copy[key];
+  return copy;
+}
+
+function haversineDistanceM(a: GeoPoint, b: GeoPoint): number {
+  const earthRadiusM = 6_371_000;
+  const radians = Math.PI / 180;
+  const dLat = (b.lat - a.lat) * radians;
+  const dLon = (b.lon - a.lon) * radians;
+  const sinLat = Math.sin(dLat / 2);
+  const sinLon = Math.sin(dLon / 2);
+  const value =
+    sinLat * sinLat +
+    Math.cos(a.lat * radians) *
+      Math.cos(b.lat * radians) *
+      sinLon *
+      sinLon;
+  return earthRadiusM * 2 * Math.atan2(Math.sqrt(value), Math.sqrt(1 - value));
+}
+
+function offsetFromCentre(centre: GeoPoint, edge: GeoPoint): {
+  east: number;
+  north: number;
+  radial: number;
+} {
+  const radians = Math.PI / 180;
+  const east =
+    (edge.lon - centre.lon) * 111111 * Math.cos(centre.lat * radians);
+  const north = (edge.lat - centre.lat) * 111111;
+  return {
+    east,
+    north,
+    radial: haversineDistanceM(centre, edge),
+  };
+}
+
+function percentile(values: number[], quantile: number): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const position = (sorted.length - 1) * quantile;
+  const lower = Math.floor(position);
+  const upper = Math.ceil(position);
+  if (lower === upper) return sorted[lower];
+  const weight = position - lower;
+  return sorted[lower] * (1 - weight) + sorted[upper] * weight;
+}
+
+function slug(value: string): string {
+  const result = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+  return result || 'unassigned';
+}
+
+function formatMetric(value: number | null): string {
+  return value == null ? 'n/a' : value.toFixed(3);
+}
+
+function buildReport(rows: HarnessRow[], generatedAt: string): FlightReport {
+  const first = rows[0];
+  const successfulRows = rows.filter(
+    (row): row is HarnessRow & { centreErrorM: number } => row.centreErrorM != null
+  );
+  const errors = successfulRows.map((row) => row.centreErrorM);
+  const worst5 = [...successfulRows]
+    .sort((a, b) => b.centreErrorM - a.centreErrorM)
+    .slice(0, 5)
+    .map((row) => ({
+      assetId: row.assetId,
+      fileName: row.fileName,
+      centreErrorM: row.centreErrorM,
+    }));
+
+  return {
+    generatedAt,
+    projectionPath: 'pixelToGeoWithDSM_photogrammetry_lrf_removed',
+    networkElevationDisabled: true,
+    project: { id: first.projectId, name: first.projectName },
+    flightSession: first.flightSession,
+    summary: {
+      count: rows.length,
+      projectedCount: successfulRows.length,
+      failedCount: rows.length - successfulRows.length,
+      p50CentreErrorM: percentile(errors, 0.5),
+      p90CentreErrorM: percentile(errors, 0.9),
+      worst5,
+    },
+    rows,
+  };
+}
+
+function renderMarkdown(report: FlightReport): string {
+  const lines = [
+    `# Georeferencing harness: ${report.project.name} / ${report.flightSession}`,
+    '',
+    `Generated: ${report.generatedAt}`,
+    '',
+    `Projection path: \`${report.projectionPath}\``,
+    '',
+    'LRF fields were removed from a copy of each asset before projection. Elevation HTTP was replaced with the deterministic per-row value shown below.',
+    '',
+    '## Summary',
+    '',
+    `- Count: ${report.summary.count}`,
+    `- Projected: ${report.summary.projectedCount}`,
+    `- Failed: ${report.summary.failedCount}`,
+    `- Centre error p50: ${formatMetric(report.summary.p50CentreErrorM)} m`,
+    `- Centre error p90: ${formatMetric(report.summary.p90CentreErrorM)} m`,
+    '',
+    '## Worst 5 centre-pixel errors',
+    '',
+    '| Asset ID | File | Error (m) |',
+    '|---|---|---:|',
+    ...report.summary.worst5.map(
+      (row) => `| ${row.assetId} | ${row.fileName.replaceAll('|', '\\|')} | ${row.centreErrorM.toFixed(3)} |`
+    ),
+    ...(report.summary.worst5.length === 0 ? ['| n/a | no successful projections | n/a |'] : []),
+    '',
+    '## Asset comparison rows',
+    '',
+    '| Asset ID | Elevation source | Elev. (m) | Centre error (m) | Left (m) | Right (m) | Top (m) | Bottom (m) |',
+    '|---|---|---:|---:|---:|---:|---:|---:|',
+    ...report.rows.map((row) => {
+      const edge = (name: EdgeName): string =>
+        formatMetric(row.edges[name].offsetFromCentreM?.radial ?? null);
+      return `| ${row.assetId} | ${row.elevation.source} | ${row.elevation.metres.toFixed(3)} | ${formatMetric(row.centreErrorM)} | ${edge('midLeft')} | ${edge('midRight')} | ${edge('midTop')} | ${edge('midBottom')} |`;
+    }),
+    '',
+    'Signed east/north edge offsets and projected coordinates are retained in the matching JSON report.',
+    '',
+  ];
+  return lines.join('\n');
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  if (!process.env.DATABASE_URL) {
+    console.log('[georef-harness] No database configured: DATABASE_URL is not set.');
+    console.log(
+      '[georef-harness] Set DATABASE_URL to the Prisma MySQL database, then rerun `npm run georef:harness`.'
+    );
+    console.log(
+      '[georef-harness] No reports were written; this is the expected zero-data/offline checkout path.'
+    );
+    return;
+  }
+
+  let offlineElevationM = args.fixedElevationM;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({ results: [{ elevation: offlineElevationM }] }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+
+  const prisma = new PrismaClient();
+  try {
+    const [georeferencing, precision, elevation] = await Promise.all([
+      import('@/lib/utils/georeferencing'),
+      import('@/lib/utils/precision-georeferencing'),
+      import('@/lib/services/elevation'),
+    ]);
+    const elevationInternals = elevation.elevationService as unknown as {
+      clearCache(): void;
+      minRequestInterval: number;
+    };
+    elevationInternals.minRequestInterval = 0;
+
+    const sourceAssets = await prisma.asset.findMany({
+      where: {
+        ...(args.projectId ? { projectId: args.projectId } : {}),
+      },
+      select: assetSelect,
+      orderBy: [{ projectId: 'asc' }, { flightSession: 'asc' }, { id: 'asc' }],
+      ...(args.limit ? { take: args.limit } : {}),
+    });
+
+    if (sourceAssets.length === 0) {
+      console.log('[georef-harness] The selected database/project contains zero assets.');
+      console.log(
+        '[georef-harness] Upload or point DATABASE_URL at historical DJI assets, then rerun the command.'
+      );
+      return;
+    }
+
+    const exclusionCounts = new Map<string, number>();
+    const exclude = (reason: string): void => {
+      exclusionCounts.set(reason, (exclusionCounts.get(reason) ?? 0) + 1);
+    };
+    const eligible: Array<{
+      asset: AssetRow;
+      metadata: Record<string, unknown>;
+      width: number;
+      height: number;
+      altitude: number;
+      gpsLatitude: number;
+      gpsLongitude: number;
+      gimbalPitch: number;
+      gimbalRoll: number;
+      gimbalYaw: number;
+      lrfDistance: number;
+      lrfTargetLat: number;
+      lrfTargetLon: number;
+    }> = [];
+
+    for (const asset of sourceAssets) {
+      const metadata = asRecord(asset.metadata);
+      const gpsLatitude =
+        toFiniteNumber(asset.gpsLatitude) ?? readNumber(metadata, GPS_LATITUDE_KEYS);
+      const gpsLongitude =
+        toFiniteNumber(asset.gpsLongitude) ?? readNumber(metadata, GPS_LONGITUDE_KEYS);
+      const lrfDistance =
+        toFiniteNumber(asset.lrfDistance) ??
+        readNumber(metadata, ['LRFTargetDistance', 'drone-dji:LRFTargetDistance']);
+      const lrfTargetLat =
+        toFiniteNumber(asset.lrfTargetLat) ??
+        readNumber(metadata, ['LRFTargetLat', 'drone-dji:LRFTargetLat']);
+      const lrfTargetLon =
+        toFiniteNumber(asset.lrfTargetLon) ??
+        readNumber(metadata, ['LRFTargetLon', 'drone-dji:LRFTargetLon']);
+      if (
+        gpsLatitude == null ||
+        gpsLongitude == null ||
+        lrfDistance == null ||
+        lrfDistance <= 0 ||
+        lrfTargetLat == null ||
+        lrfTargetLon == null
+      ) {
+        exclude('missing GPS or LRF target latitude, longitude, or distance');
+        continue;
+      }
+      if (!precision.getPrecisionMetadataStatus(metadata).hasCalibration) {
+        exclude('missing calibrated focal length or optical centre metadata');
+        continue;
+      }
+      const gimbalPitch =
+        toFiniteNumber(asset.gimbalPitch) ?? readNumber(metadata, GIMBAL_PITCH_KEYS);
+      const gimbalRoll =
+        toFiniteNumber(asset.gimbalRoll) ?? readNumber(metadata, GIMBAL_ROLL_KEYS);
+      const gimbalYaw =
+        toFiniteNumber(asset.gimbalYaw) ?? readNumber(metadata, GIMBAL_YAW_KEYS);
+      if (
+        gimbalPitch == null ||
+        gimbalRoll == null ||
+        gimbalYaw == null
+      ) {
+        exclude('missing gimbal pitch, roll, or yaw');
+        continue;
+      }
+      const dimensions = georeferencing.resolveProjectionImageDimensions(
+        asset.imageWidth,
+        asset.imageHeight,
+        metadata
+      );
+      if (dimensions.imageWidth == null || dimensions.imageHeight == null) {
+        exclude('missing image dimensions');
+        continue;
+      }
+      const altitude = georeferencing.resolveProjectionAltitude(asset.altitude, metadata);
+      if (altitude == null) {
+        exclude('missing projection altitude');
+        continue;
+      }
+      eligible.push({
+        asset,
+        metadata,
+        width: dimensions.imageWidth,
+        height: dimensions.imageHeight,
+        altitude,
+        gpsLatitude,
+        gpsLongitude,
+        gimbalPitch,
+        gimbalRoll,
+        gimbalYaw,
+        lrfDistance,
+        lrfTargetLat,
+        lrfTargetLon,
+      });
+    }
+
+    if (eligible.length === 0) {
+      console.log(
+        `[georef-harness] Scanned ${sourceAssets.length} assets, but none had all GPS, LRF, gimbal, calibration, dimension, and altitude inputs.`
+      );
+      for (const [reason, count] of exclusionCounts) {
+        console.log(`[georef-harness] Excluded ${count}: ${reason}.`);
+      }
+      console.log(
+        '[georef-harness] Calibration requires CalibratedFocalLength plus CalibratedOpticalCenterX/Y in Asset.metadata.'
+      );
+      return;
+    }
+
+    console.log(
+      `[georef-harness] Projecting ${eligible.length} assets through the current photogrammetric path with elevation HTTP disabled.`
+    );
+
+    const rows: HarnessRow[] = [];
+    for (const item of eligible) {
+      const {
+        asset,
+        metadata,
+        width,
+        height,
+        altitude,
+        gpsLatitude,
+        gpsLongitude,
+        gimbalPitch,
+        gimbalRoll,
+        gimbalYaw,
+        lrfDistance,
+        lrfTargetLat,
+        lrfTargetLon,
+      } = item;
+      const lrfTarget = {
+        lat: lrfTargetLat,
+        lon: lrfTargetLon,
+        distanceM: lrfDistance,
+      };
+      const lrfTargetAltitude = readNumber(metadata, [
+        'LRFTargetAlt',
+        'drone-dji:LRFTargetAlt',
+      ]);
+      offlineElevationM = lrfTargetAltitude ?? args.fixedElevationM;
+      elevationInternals.clearCache();
+
+      const projectionAsset = {
+        gpsLatitude,
+        gpsLongitude,
+        altitude,
+        gimbalPitch,
+        gimbalRoll,
+        gimbalYaw,
+        cameraFov: asset.cameraFov,
+        imageWidth: width,
+        imageHeight: height,
+        metadata: withoutLrfMetadata(metadata),
+        lrfDistance: null,
+        lrfTargetLat: null,
+        lrfTargetLon: null,
+      };
+      const centrePixel = { x: width / 2, y: height / 2 };
+      const edgePixels: Record<EdgeName, { x: number; y: number }> = {
+        midLeft: { x: 0, y: height / 2 },
+        midRight: { x: width, y: height / 2 },
+        midTop: { x: width / 2, y: 0 },
+        midBottom: { x: width / 2, y: height },
+      };
+
+      const centreProjection = await georeferencing.pixelToGeoWithDSM(
+        projectionAsset,
+        centrePixel
+      );
+      const projectedEdges = await Promise.all(
+        (Object.entries(edgePixels) as Array<[EdgeName, { x: number; y: number }]>).map(
+          async ([name, pixel]) => [
+            name,
+            await georeferencing.pixelToGeoWithDSM(projectionAsset, pixel),
+          ] as const
+        )
+      );
+      const edges = Object.fromEntries(
+        projectedEdges.map(([name, geo]) => [
+          name,
+          {
+            pixel: edgePixels[name],
+            geo,
+            offsetFromCentreM:
+              centreProjection && geo ? offsetFromCentre(centreProjection, geo) : null,
+          },
+        ])
+      ) as Record<EdgeName, ProjectedEdge>;
+
+      rows.push({
+        assetId: asset.id,
+        fileName: asset.fileName,
+        projectId: asset.project.id,
+        projectName: asset.project.name,
+        flightSession: asset.flightSession?.trim() || 'unassigned',
+        elevation: {
+          source: lrfTargetAltitude == null ? 'fixed_elevation' : 'lrf_target_alt_metadata',
+          metres: offlineElevationM,
+        },
+        imageSize: { width, height },
+        centrePixel,
+        centreProjection,
+        lrfTarget,
+        centreErrorM: centreProjection
+          ? haversineDistanceM(centreProjection, lrfTarget)
+          : null,
+        edges,
+      });
+    }
+
+    const groups = new Map<string, HarnessRow[]>();
+    for (const row of rows) {
+      const key = `${row.projectId}\u0000${row.flightSession}`;
+      groups.set(key, [...(groups.get(key) ?? []), row]);
+    }
+
+    await fs.mkdir(args.outputDir, { recursive: true });
+    const generatedAt = new Date().toISOString();
+    for (const groupRows of groups.values()) {
+      const report = buildReport(groupRows, generatedAt);
+      const fileStem = [
+        slug(report.project.name),
+        slug(report.project.id),
+        slug(report.flightSession),
+      ].join('--');
+      const jsonPath = path.join(args.outputDir, `${fileStem}.json`);
+      const markdownPath = path.join(args.outputDir, `${fileStem}.md`);
+      await Promise.all([
+        fs.writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8'),
+        fs.writeFile(markdownPath, renderMarkdown(report), 'utf8'),
+      ]);
+      console.log(
+        `[georef-harness] ${report.project.name} / ${report.flightSession}: count=${report.summary.count}, p50=${formatMetric(report.summary.p50CentreErrorM)}m, p90=${formatMetric(report.summary.p90CentreErrorM)}m`
+      );
+      console.log(`[georef-harness] JSON: ${jsonPath}`);
+      console.log(`[georef-harness] Markdown: ${markdownPath}`);
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`[georef-harness] Failed: ${message}`);
+  process.exitCode = 1;
+});

--- a/scripts/georef-harness.ts
+++ b/scripts/georef-harness.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -33,7 +34,10 @@ type HarnessRow = {
   flightSession: string;
   elevation: {
     source: 'lrf_target_alt_metadata' | 'fixed_elevation';
+    /** Elevation the projection actually used (after service fallbacks). */
     metres: number;
+    /** Elevation the harness asked the stub to serve. */
+    requestedMetres: number;
   };
   imageSize: { width: number; height: number };
   centrePixel: { x: number; y: number };
@@ -253,12 +257,16 @@ function percentile(values: number[], quantile: number): number | null {
 }
 
 function slug(value: string): string {
-  const result = value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 60);
-  return result || 'unassigned';
+  const base =
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 52) || 'unassigned';
+  // Distinct raw values must never share an output path, even when they
+  // differ only by case, punctuation, or truncated characters.
+  const digest = createHash('sha1').update(value).digest('hex').slice(0, 7);
+  return `${base}-${digest}`;
 }
 
 function formatMetric(value: number | null): string {
@@ -593,7 +601,12 @@ async function main(): Promise<void> {
         flightSession: asset.flightSession?.trim() || 'unassigned',
         elevation: {
           source: lrfTargetAltitude == null ? 'fixed_elevation' : 'lrf_target_alt_metadata',
-          metres: offlineElevationM,
+          // getTerrainElevation applies `result?.elevation || 100`, so a
+          // stubbed elevation of exactly 0 reaches the projection as 100 m.
+          // Record what the projection actually used, not just what we asked
+          // for. PR 3 fixes the accessor's falsy fallback itself.
+          metres: offlineElevationM || 100,
+          requestedMetres: offlineElevationM,
         },
         imageSize: { width, height },
         centrePixel,

--- a/tests/unit/projection-fixtures.test.ts
+++ b/tests/unit/projection-fixtures.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/services/elevation', () => ({
+  getTerrainElevation: vi.fn(async () => 0),
+}));
+
+import {
+  precisionPixelToGeo,
+  type PrecisionGeoreferenceParams,
+} from '@/lib/utils/precision-georeferencing';
+
+type ReferenceInput = {
+  px: number;
+  py: number;
+  f: number;
+  cx: number;
+  cy: number;
+  pitchDeg: number;
+  yawDeg: number;
+  rollDeg: number;
+  heightM: number;
+  lat0: number;
+  lon0: number;
+};
+
+type ReferenceResult = {
+  lat: number;
+  lon: number;
+  offsetEastM: number;
+  offsetNorthM: number;
+};
+
+/**
+ * Normative reference implementation for the future projection core.
+ *
+ * Keep this standalone and literal: it intentionally does not import any
+ * production projection helpers, so PR 2 can be checked against a fixed
+ * independent statement of the pixel/camera/ENU conventions.
+ */
+function referenceProject(input: ReferenceInput): ReferenceResult {
+  const radians = Math.PI / 180;
+  const pitch = input.pitchDeg * radians;
+  const yaw = input.yawDeg * radians;
+  const roll = input.rollDeg * radians;
+
+  // 1. Pixel -> camera ray. These normalized coordinates are already tangents.
+  const vx = (input.px - input.cx) / input.f;
+  const vy = (input.py - input.cy) / input.f;
+  const vz = 1;
+
+  // 2. Roll about the boresight.
+  const xPrime = vx * Math.cos(roll) - vy * Math.sin(roll);
+  const yPrime = vx * Math.sin(roll) + vy * Math.cos(roll);
+  const zPrime = vz;
+
+  // 3. Camera -> ENU for a north-facing level camera.
+  const east0 = xPrime;
+  const north0 = zPrime;
+  const up0 = -yPrime;
+
+  // 4. Pitch about the east axis.
+  const north1 = north0 * Math.cos(pitch) - up0 * Math.sin(pitch);
+  const up1 = north0 * Math.sin(pitch) + up0 * Math.cos(pitch);
+  const east1 = east0;
+
+  // 5. DJI compass yaw is clockwise-positive from north.
+  const east = north1 * Math.sin(yaw) + east1 * Math.cos(yaw);
+  const north = north1 * Math.cos(yaw) - east1 * Math.sin(yaw);
+  const up = up1;
+  const rayLength = Math.hypot(east, north, up);
+
+  if (up >= -0.05 * rayLength) {
+    throw new Error('NEAR_HORIZON');
+  }
+
+  // 6. Ground-plane intersection.
+  const t = input.heightM / -up;
+  const offsetEastM = t * east;
+  const offsetNorthM = t * north;
+
+  // 7. Small-offset geographic conversion.
+  const lat = input.lat0 + offsetNorthM / 111111;
+  const lon =
+    input.lon0 + offsetEastM / (111111 * Math.cos(input.lat0 * radians));
+
+  return { lat, lon, offsetEastM, offsetNorthM };
+}
+
+const goldenFixtures = [
+  { id: 'A', pitchDeg: -90, yawDeg: 0, px: 1000, py: 750, east: 0, north: 0 },
+  { id: 'B', pitchDeg: -90, yawDeg: 0, px: 1100, py: 750, east: 10, north: 0 },
+  { id: 'C', pitchDeg: -90, yawDeg: 90, px: 1100, py: 750, east: 0, north: -10 },
+  { id: 'D', pitchDeg: -90, yawDeg: 0, px: 1000, py: 850, east: 0, north: -10 },
+  { id: 'E', pitchDeg: -90, yawDeg: 180, px: 1100, py: 750, east: -10, north: 0 },
+  { id: 'F', pitchDeg: -45, yawDeg: 0, px: 1000, py: 750, east: 0, north: 100 },
+  { id: 'G', pitchDeg: -45, yawDeg: 0, px: 1000, py: 850, east: 0, north: 81.8182 },
+  { id: 'H', pitchDeg: -45, yawDeg: 270, px: 1000, py: 750, east: -100, north: 0 },
+] as const;
+
+const referenceDefaults = {
+  f: 1000,
+  cx: 1000,
+  cy: 750,
+  rollDeg: 0,
+  heightM: 100,
+  lat0: -26,
+  lon0: 153,
+};
+
+function expectWithinMillimetre(actual: number, expected: number): void {
+  expect(Math.abs(actual - expected)).toBeLessThanOrEqual(0.001);
+}
+
+describe('future projection-core golden fixtures', () => {
+  it.each(goldenFixtures)(
+    'fixture $id locks the normative offsets to +/-0.001 m',
+    (fixture) => {
+      const result = referenceProject({ ...referenceDefaults, ...fixture });
+
+      expectWithinMillimetre(result.offsetEastM, fixture.east);
+      expectWithinMillimetre(result.offsetNorthM, fixture.north);
+    }
+  );
+});
+
+const currentLrfParams: PrecisionGeoreferenceParams = {
+  imageWidth: 2000,
+  imageHeight: 1500,
+  calibratedFocalLength: 1000,
+  opticalCenterX: 1000,
+  opticalCenterY: 750,
+  droneLatitude: -26,
+  droneLongitude: 153,
+  droneAltitude: 30,
+  gimbalPitch: -90,
+  gimbalRoll: 0,
+  gimbalYaw: 0,
+  lrfTargetDistance: 100,
+  lrfTargetLatitude: -26,
+  lrfTargetLongitude: 153,
+  lrfTargetAltitude: 0,
+};
+
+function offsetsFromLrf(latitude: number, longitude: number): { east: number; north: number } {
+  return {
+    east:
+      (longitude - currentLrfParams.lrfTargetLongitude!) *
+      111111 *
+      Math.cos((currentLrfParams.lrfTargetLatitude! * Math.PI) / 180),
+    north:
+      (latitude - currentLrfParams.lrfTargetLatitude!) * 111111,
+  };
+}
+
+describe('current precision path known deviations (PR 1 characterization)', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  it('documents bug 1: normalized camera coordinates receive a second tan()', async () => {
+    const current = await precisionPixelToGeo(
+      { x: 1100, y: 750 },
+      currentLrfParams
+    );
+
+    expect(current).not.toBeNull();
+    const offset = offsetsFromLrf(current!.latitude, current!.longitude);
+    expect(offset.east).toBeCloseTo(100 * Math.tan(0.1), 3);
+    expect(Math.abs(offset.east - 10)).toBeGreaterThan(0.03);
+  });
+
+  it('documents bug 2: vertical height is added to the LRF slant range', async () => {
+    const current = await precisionPixelToGeo(
+      { x: 1100, y: 750 },
+      { ...currentLrfParams, droneAltitude: 130 }
+    );
+
+    expect(current).not.toBeNull();
+    const offset = offsetsFromLrf(current!.latitude, current!.longitude);
+    expect(offset.east).toBeCloseTo(Math.SQRT2 * 100 * Math.tan(0.1), 3);
+    expect(offset.east).toBeGreaterThan(14);
+  });
+
+  it('documents bug 3: DJI yaw=90 rotates image-right north instead of south', async () => {
+    const current = await precisionPixelToGeo(
+      { x: 1100, y: 750 },
+      { ...currentLrfParams, gimbalYaw: 90 }
+    );
+
+    expect(current).not.toBeNull();
+    const offset = offsetsFromLrf(current!.latitude, current!.longitude);
+    expect(offset.north).toBeGreaterThan(10);
+    expect(offset.north).not.toBeCloseTo(-10, 3);
+  });
+});


### PR DESCRIPTION
## Summary
PR 1 of the georeferencing accuracy overhaul (spec: georef-fix). **No production georeferencing code is changed** — this PR makes the current accuracy measurable and locks the conventions for the PR 2 projection core.

- **8 golden fixtures** (`tests/unit/projection-fixtures.test.ts`): hand-computed pixel→ENU offsets at ±0.001 m tolerance, including fixture G (`ΔN = 100·0.9/1.1`) constructed to fail if the double-tan or slant-distance bugs are ever reintroduced.
- **Bug characterization tests**: the three known precision-path bugs (double-tan at `precision-georeferencing.ts:258`, slant-distance √2 inflation at `:247`, inverted yaw rotation at `:262`) are now executable tests, each isolated so it measures one bug at a time.
- **LRF self-check harness** (`npm run georef:harness`): projects each asset's centre pixel through the photogrammetric path with LRF inputs removed, and measures haversine error against the LRF-measured ground truth. Reports p50/p90 per flight plus 4 edge-pixel offsets for before/after comparison. Fully offline (elevation HTTP stubbed, source recorded per row).

## Verification
- 11/11 tests pass, lint clean.
- Harness zero-data path verified (prints setup instructions instead of crashing).

## Next
Run the harness against a DB with historical DJI assets to quantify current production error, then PR 2 (projection core) must pass the golden fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)