### PR TITLE
Per-instance refinement client: 1:1 provenance, 400-candidate budget, satellite retrieval (PR 2b client)

### DIFF
--- a/lib/services/aws-sam3.ts
+++ b/lib/services/aws-sam3.ts
@@ -215,6 +215,42 @@ export interface SAM3SegmentResult {
   errorCode?: 'NOT_CONFIGURED' | 'NOT_READY' | 'API_ERROR' | 'TIMEOUT' | 'NETWORK_ERROR' | 'UNSUPPORTED';
 }
 
+export interface SAM3RefineInstancePrompt {
+  id: string;
+  box: [number, number, number, number];
+  positive_points?: [number, number][];
+  negative_points?: [number, number][];
+}
+
+export interface SAM3RefineInstancesRequest {
+  image: string;
+  instances: SAM3RefineInstancePrompt[];
+  return_polygons: true;
+  decode_batch?: number;
+  polygon_resolution?: number;
+  score_threshold?: number;
+}
+
+export interface SAM3RefinedInstance {
+  id: string;
+  polygon: [number, number][] | null;
+  bbox_from_mask: [number, number, number, number] | null;
+  predicted_iou: number;
+  score: number;
+}
+
+export interface SAM3RefineInstancesResponse {
+  instances: SAM3RefinedInstance[];
+  image_size: [number, number];
+}
+
+export interface SAM3RefineInstancesResult {
+  success: boolean;
+  response: SAM3RefineInstancesResponse | null;
+  error?: string;
+  errorCode?: 'NOT_CONFIGURED' | 'NOT_READY' | 'API_ERROR' | 'TIMEOUT' | 'NETWORK_ERROR';
+}
+
 export type SAM3ApiFlavor = 'legacy' | 'modern' | 'unknown';
 
 // Point-based prediction interfaces (for click-to-segment)
@@ -267,6 +303,9 @@ export interface SAM3ConceptExemplarResponse {
   className: string;
   numCrops: number;
   createdAt?: string;
+  embeddingBackend?: string;
+  backendFallback?: boolean;
+  backendWarning?: string;
 }
 
 export interface SAM3ConceptApplyOptions {
@@ -276,11 +315,17 @@ export interface SAM3ConceptApplyOptions {
   maxBoxSize?: number;
   nmsThreshold?: number;
   returnPolygons?: boolean;
+  sizeFilterMinRatio?: number;
+  sizeFilterMaxRatio?: number;
+  embeddingBackend?: string;
 }
 
 export interface SAM3ConceptApplyResponse {
   detections: SAM3ConceptDetection[];
   processingTimeMs: number;
+  embeddingBackend?: string;
+  backendFallback?: boolean;
+  backendWarning?: string;
 }
 
 export interface SAM3ConceptResult<T> {
@@ -1087,6 +1132,78 @@ class AWSSAM3Service {
   }
 
   /**
+   * Refine candidate boxes independently while preserving the caller's IDs.
+   * Coordinates and returned polygons remain in original-image space.
+   */
+  async refineInstances(
+    request: SAM3RefineInstancesRequest
+  ): Promise<SAM3RefineInstancesResult> {
+    if (!this.configured) {
+      return {
+        success: false,
+        response: null,
+        error: this.configError || 'AWS SAM3 not configured',
+        errorCode: 'NOT_CONFIGURED',
+      };
+    }
+
+    if (!this.instanceIp || this.instanceState !== 'ready') {
+      return {
+        success: false,
+        response: null,
+        error: `Instance not ready (state: ${this.instanceState})`,
+        errorCode: 'NOT_READY',
+      };
+    }
+
+    this.updateActivity();
+
+    try {
+      console.log(
+        `[AWS-SAM3] Calling /refine_instances with ${request.instances.length} instances`
+      );
+      const response = await fetch(
+        `http://${this.instanceIp}:${SAM3_PORT}/refine_instances`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(request),
+          signal: AbortSignal.timeout(120000),
+        }
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => 'Unknown error');
+        console.error(
+          `[AWS-SAM3] Instance refinement failed: ${response.status} - ${errorText}`
+        );
+        return {
+          success: false,
+          response: null,
+          error: `SAM3 API error: ${response.status} - ${errorText.substring(0, 200)}`,
+          errorCode: 'API_ERROR',
+        };
+      }
+
+      const result = await response.json() as SAM3RefineInstancesResponse;
+      console.log(
+        `[AWS-SAM3] Instance refinement returned ${result.instances.length} instances`
+      );
+      return { success: true, response: result };
+    } catch (error) {
+      const isTimeout = error instanceof Error && error.name === 'TimeoutError';
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      console.error('[AWS-SAM3] Instance refinement error:', errorMessage);
+      return {
+        success: false,
+        response: null,
+        error: errorMessage,
+        errorCode: isTimeout ? 'TIMEOUT' : 'NETWORK_ERROR',
+      };
+    }
+  }
+
+  /**
    * Call the SAM3 /segment endpoint for point-based segmentation
    * SAM3 v0.6.0 uses /segment for all segmentation (points converted to boxes internally)
    *
@@ -1521,6 +1638,7 @@ class AWSSAM3Service {
     boxes: SAM3ConceptBox[];
     className: string;
     imageId?: string;
+    embeddingBackend?: string;
   }): Promise<SAM3ConceptResult<SAM3ConceptExemplarResponse>> {
     if (!this.configured) {
       return {
@@ -1545,17 +1663,37 @@ class AWSSAM3Service {
       const { buffer, scaling } = await this.resizeImage(request.imageBuffer);
       const scaledBoxes = this.scaleConceptBoxesToResized(request.boxes, scaling);
 
-      const response = await fetch(`${baseUrl}/api/v1/exemplars/create`, {
-        method: 'POST',
-        headers: this.buildConceptHeaders(),
-        body: JSON.stringify({
+      const buildPayload = (embeddingBackend = request.embeddingBackend) => ({
           image: buffer.toString('base64'),
           boxes: scaledBoxes,
           class_name: request.className,
           image_id: request.imageId,
-        }),
-        signal: AbortSignal.timeout(CONCEPT_REQUEST_TIMEOUT_MS),
+          ...(embeddingBackend ? { embedding_backend: embeddingBackend } : {}),
       });
+      const sendRequest = (embeddingBackend = request.embeddingBackend) =>
+        fetch(`${baseUrl}/api/v1/exemplars/create`, {
+          method: 'POST',
+          headers: this.buildConceptHeaders(),
+          body: JSON.stringify(buildPayload(embeddingBackend)),
+          signal: AbortSignal.timeout(CONCEPT_REQUEST_TIMEOUT_MS),
+        });
+
+      let response = await sendRequest();
+      let embeddingBackend = request.embeddingBackend;
+      let backendFallback = false;
+      let backendWarning: string | undefined;
+      if (
+        response.status === 400 &&
+        request.embeddingBackend &&
+        request.embeddingBackend !== 'dinov2_vits14'
+      ) {
+        backendFallback = true;
+        embeddingBackend = 'dinov2_vits14';
+        backendWarning =
+          `Concept exemplar backend ${request.embeddingBackend} was rejected; ` +
+          'retried with dinov2_vits14.';
+        response = await sendRequest(embeddingBackend);
+      }
 
       if (!response.ok) {
         const errorText = await response.text().catch(() => 'Unknown error');
@@ -1576,6 +1714,9 @@ class AWSSAM3Service {
           className: String(result.class_name || request.className),
           numCrops: Number(result.num_crops || request.boxes.length),
           createdAt: typeof result.created_at === 'string' ? result.created_at : undefined,
+          embeddingBackend,
+          backendFallback,
+          backendWarning,
         },
       };
     } catch (error) {
@@ -1640,13 +1781,44 @@ class AWSSAM3Service {
       if (request.options?.nmsThreshold != null) {
         payload.nms_threshold = request.options.nmsThreshold;
       }
+      if (request.options?.sizeFilterMinRatio != null) {
+        payload.size_filter_min_ratio = request.options.sizeFilterMinRatio;
+      }
+      if (request.options?.sizeFilterMaxRatio != null) {
+        payload.size_filter_max_ratio = request.options.sizeFilterMaxRatio;
+      }
+      if (request.options?.embeddingBackend) {
+        payload.embedding_backend = request.options.embeddingBackend;
+      }
 
-      const response = await fetch(`${baseUrl}/api/v1/exemplars/apply`, {
-        method: 'POST',
-        headers: this.buildConceptHeaders(),
-        body: JSON.stringify(payload),
-        signal: AbortSignal.timeout(CONCEPT_REQUEST_TIMEOUT_MS),
-      });
+      const sendRequest = (embeddingBackend = request.options?.embeddingBackend) =>
+        fetch(`${baseUrl}/api/v1/exemplars/apply`, {
+          method: 'POST',
+          headers: this.buildConceptHeaders(),
+          body: JSON.stringify({
+            ...payload,
+            ...(embeddingBackend ? { embedding_backend: embeddingBackend } : {}),
+          }),
+          signal: AbortSignal.timeout(CONCEPT_REQUEST_TIMEOUT_MS),
+        });
+
+      let response = await sendRequest();
+      let embeddingBackend = request.options?.embeddingBackend;
+      let backendFallback = false;
+      let backendWarning: string | undefined;
+      if (
+        response.status === 400 &&
+        embeddingBackend &&
+        embeddingBackend !== 'dinov2_vits14'
+      ) {
+        backendFallback = true;
+        const rejectedBackend = embeddingBackend;
+        embeddingBackend = 'dinov2_vits14';
+        backendWarning =
+          `Retrieval backend ${rejectedBackend} was rejected for exemplar ` +
+          `${request.exemplarId}; retried with dinov2_vits14.`;
+        response = await sendRequest(embeddingBackend);
+      }
 
       if (!response.ok) {
         const errorText = await response.text().catch(() => 'Unknown error');
@@ -1673,6 +1845,9 @@ class AWSSAM3Service {
         data: {
           detections,
           processingTimeMs: Number(result.processing_time_ms || 0),
+          embeddingBackend,
+          backendFallback,
+          backendWarning,
         },
       };
     } catch (error) {

--- a/lib/services/sam3-batch-v2.ts
+++ b/lib/services/sam3-batch-v2.ts
@@ -11,6 +11,7 @@ import {
   awsSam3Service,
   type SAM3ConceptApplyOptions,
   type SAM3ConceptDetection,
+  type SAM3RefineInstancePrompt,
 } from '@/lib/services/aws-sam3';
 import { S3Service } from '@/lib/services/s3';
 import { normalizeDetectionType } from '@/lib/utils/detection-types';
@@ -41,6 +42,35 @@ export const SAM3_BATCH_V2_GPU_MEMORY_THRESHOLD_MB = 12 * 1024;
 export const SAM3_BATCH_V2_MODEL_OVERHEAD_MB = 4096;
 export const SAM3_BATCH_V2_VEGETATION_FLOOR = 0.15;
 export const SAM3_BATCH_V2_VEGETATION_ALARM_MEDIAN = 0.3;
+export const SAM3_BATCH_V2_INSTANCE_REFINEMENT_CHUNK_SIZE = 200;
+export const SAM3_BATCH_V2_DEFAULT_CANDIDATE_BUDGET = 400;
+export const SAM3_BATCH_V2_DEFAULT_RETRIEVAL_BACKEND = 'dinov3_vitl16_sat';
+
+export type Sam3BatchV2RefineMode = 'instances' | 'concept';
+
+export function resolveBatchV2RefineMode(
+  value: string | undefined = process.env.SAM3_REFINE_MODE
+): Sam3BatchV2RefineMode {
+  return value?.trim().toLowerCase() === 'concept' ? 'concept' : 'instances';
+}
+
+export function resolveBatchV2CandidateBudget(
+  value: string | undefined = process.env.SAM3_CANDIDATE_BUDGET
+): number {
+  const parsed = value ? Number.parseInt(value, 10) : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : SAM3_BATCH_V2_DEFAULT_CANDIDATE_BUDGET;
+}
+
+export function resolveBatchV2RetrievalBackend(
+  refineMode: Sam3BatchV2RefineMode = resolveBatchV2RefineMode(),
+  value: string | undefined = process.env.SAM3_RETRIEVAL_BACKEND
+): string | undefined {
+  const configured = value?.trim();
+  return configured ||
+    (refineMode === 'instances' ? SAM3_BATCH_V2_DEFAULT_RETRIEVAL_BACKEND : undefined);
+}
 
 const parseOptionalNumber = (value: string | undefined): number | undefined => {
   if (!value) return undefined;
@@ -125,16 +155,24 @@ export function resolveBatchV2ReviewProfileForMode(
 }
 
 export function getBatchV2MinTargetCandidates(
-  profile: Sam3BatchV2ReviewProfile = 'balanced'
+  profile: Sam3BatchV2ReviewProfile = 'balanced',
+  refineMode: Sam3BatchV2RefineMode = resolveBatchV2RefineMode()
 ): number {
+  if (refineMode === 'instances') {
+    return resolveBatchV2CandidateBudget();
+  }
   return profile === 'high_recall'
     ? SAM3_BATCH_V2_HIGH_RECALL_MIN_TARGET_CANDIDATES
     : SAM3_BATCH_V2_MIN_TARGET_CANDIDATES;
 }
 
 export function getBatchV2MaxTargetCandidates(
-  profile: Sam3BatchV2ReviewProfile = 'balanced'
+  profile: Sam3BatchV2ReviewProfile = 'balanced',
+  refineMode: Sam3BatchV2RefineMode = resolveBatchV2RefineMode()
 ): number {
+  if (refineMode === 'instances') {
+    return resolveBatchV2CandidateBudget();
+  }
   return profile === 'high_recall'
     ? SAM3_BATCH_V2_HIGH_RECALL_MAX_TARGET_CANDIDATES
     : SAM3_BATCH_V2_MAX_TARGET_CANDIDATES;
@@ -144,15 +182,28 @@ export function buildBatchV2ConceptApplyOptions(
   profile: Sam3BatchV2ReviewProfile = 'balanced'
 ): SAM3ConceptApplyOptions {
   const highRecall = profile === 'high_recall';
+  const refineMode = resolveBatchV2RefineMode();
+  const instancesMode = refineMode === 'instances';
   return {
     returnPolygons: true,
     similarityThreshold: highRecall
       ? SAM3_BATCH_V2_HIGH_RECALL_SIMILARITY_THRESHOLD
       : SAM3_BATCH_V2_DEFAULT_SIMILARITY_THRESHOLD,
-    topK: highRecall ? SAM3_BATCH_V2_HIGH_RECALL_TOP_K : SAM3_BATCH_V2_DEFAULT_TOP_K,
+    topK: instancesMode
+      ? resolveBatchV2CandidateBudget()
+      : highRecall
+        ? SAM3_BATCH_V2_HIGH_RECALL_TOP_K
+        : SAM3_BATCH_V2_DEFAULT_TOP_K,
     minBoxSize: SAM3_BATCH_V2_DEFAULT_MIN_BOX_SIZE,
     maxBoxSize: SAM3_BATCH_V2_DEFAULT_MAX_BOX_SIZE,
     nmsThreshold: SAM3_BATCH_V2_DEFAULT_NMS_THRESHOLD,
+    ...(instancesMode
+      ? {
+          sizeFilterMinRatio: 0.2,
+          sizeFilterMaxRatio: 2.5,
+          embeddingBackend: resolveBatchV2RetrievalBackend(refineMode),
+        }
+      : {}),
   };
 }
 
@@ -160,17 +211,28 @@ export function buildBatchV2ConceptFallbackApplyOptions(
   profile: Sam3BatchV2ReviewProfile = 'balanced'
 ): SAM3ConceptApplyOptions {
   const highRecall = profile === 'high_recall';
+  const refineMode = resolveBatchV2RefineMode();
+  const instancesMode = refineMode === 'instances';
   return {
     returnPolygons: true,
     similarityThreshold: highRecall
       ? SAM3_BATCH_V2_HIGH_RECALL_FALLBACK_SIMILARITY_THRESHOLD
       : SAM3_BATCH_V2_FALLBACK_SIMILARITY_THRESHOLD,
-    topK: highRecall
-      ? SAM3_BATCH_V2_HIGH_RECALL_FALLBACK_TOP_K
-      : SAM3_BATCH_V2_FALLBACK_TOP_K,
+    topK: instancesMode
+      ? resolveBatchV2CandidateBudget()
+      : highRecall
+        ? SAM3_BATCH_V2_HIGH_RECALL_FALLBACK_TOP_K
+        : SAM3_BATCH_V2_FALLBACK_TOP_K,
     minBoxSize: SAM3_BATCH_V2_DEFAULT_MIN_BOX_SIZE,
     maxBoxSize: SAM3_BATCH_V2_DEFAULT_MAX_BOX_SIZE,
     nmsThreshold: SAM3_BATCH_V2_DEFAULT_NMS_THRESHOLD,
+    ...(instancesMode
+      ? {
+          sizeFilterMinRatio: 0.2,
+          sizeFilterMaxRatio: 2.5,
+          embeddingBackend: resolveBatchV2RetrievalBackend(refineMode),
+        }
+      : {}),
   };
 }
 
@@ -264,6 +326,11 @@ export interface Sam3BatchV2StageLogEntry {
   conceptExemplarCount?: number;
   refinementBoxCount?: number;
   refinementDetectionCount?: number;
+  refinementMode?: Sam3BatchV2RefineMode;
+  candidateBudget?: number;
+  refineSentInstances?: number;
+  refineRefinedInstances?: number;
+  refineRejectedInstances?: number;
   vegetationPrior?: boolean;
   exemplarGreenMedian?: number;
   vegetationThreshold?: number;
@@ -398,13 +465,41 @@ interface AwsSam3Like {
     error?: string;
     errorCode?: string;
   }>;
+  refineInstances?(request: {
+    image: string;
+    instances: SAM3RefineInstancePrompt[];
+    return_polygons: true;
+    decode_batch?: number;
+    polygon_resolution?: number;
+    score_threshold?: number;
+  }): Promise<{
+    success: boolean;
+    response: {
+      instances: Array<{
+        id: string;
+        polygon: [number, number][] | null;
+        bbox_from_mask: [number, number, number, number] | null;
+        predicted_iou: number;
+        score: number;
+      }>;
+      image_size: [number, number];
+    } | null;
+    error?: string;
+    errorCode?: string;
+  }>;
   warmupConceptService(): Promise<{ success: boolean; data: { sam3Loaded: boolean; dinoLoaded: boolean } | null; error?: string }>;
   createConceptExemplar(request: {
     imageBuffer: Buffer;
     boxes: BoxCoordinate[];
     className: string;
     imageId?: string;
-  }): Promise<{ success: boolean; data: { exemplarId: string } | null; error?: string; errorCode?: string }>;
+    embeddingBackend?: string;
+  }): Promise<{
+    success: boolean;
+    data: { exemplarId: string; backendWarning?: string } | null;
+    error?: string;
+    errorCode?: string;
+  }>;
   applyConceptExemplar(request: {
     exemplarId: string;
     imageBuffer: Buffer;
@@ -415,6 +510,7 @@ interface AwsSam3Like {
     data: {
       detections: SAM3ConceptDetection[];
       processingTimeMs: number;
+      backendWarning?: string;
     } | null;
     error?: string;
     errorCode?: string;
@@ -451,6 +547,7 @@ interface PreparedBatchContext {
   operatorCropCount: number;
   vegetationPrior: boolean;
   exemplarGreenMedian: number;
+  exemplarDiameter: number;
 }
 
 interface AssetInferenceResult {
@@ -470,6 +567,11 @@ interface AssetInferenceResult {
   candidateCount?: number;
   refinementBoxCount?: number;
   refinementDetectionCount?: number;
+  refinementMode?: Sam3BatchV2RefineMode;
+  candidateBudget?: number;
+  refineSentInstances?: number;
+  refineRefinedInstances?: number;
+  refineRejectedInstances?: number;
   vegetationThreshold?: number;
   vegetationGatedCandidates?: number;
   vegetationRecenteredCandidates?: number;
@@ -485,6 +587,11 @@ interface ConceptRefinementResult {
   candidateCount: number;
   refinementBoxCount: number;
   refinementDetectionCount: number;
+  refinementMode?: Sam3BatchV2RefineMode;
+  candidateBudget?: number;
+  refineSentInstances?: number;
+  refineRefinedInstances?: number;
+  refineRejectedInstances?: number;
   vegetationThreshold?: number;
   vegetationGatedCandidates?: number;
   vegetationRecenteredCandidates?: number;
@@ -500,6 +607,7 @@ interface ConceptRefinementResult {
 interface VegetationPriorContext {
   enabled: boolean;
   exemplarGreenMedian: number;
+  exemplarDiameter?: number;
 }
 
 interface VegetationCandidateResult {
@@ -509,6 +617,7 @@ interface VegetationCandidateResult {
   threshold: number;
   gatedCount: number;
   recenteredCount: number;
+  promptPoints: Map<SAM3ConceptDetection, [number, number]>;
 }
 
 interface VegetationMaskResult {
@@ -523,11 +632,13 @@ interface VegetationMaskResult {
 interface ConceptExemplarRef {
   exemplarId: string;
   sourceBoxIndex?: number;
+  backendWarning?: string;
 }
 
 interface ConceptCandidateResult {
   detections: SAM3ConceptDetection[];
   candidateExpansionUsed: boolean;
+  backendWarning?: string;
 }
 
 interface GpuAdmissionResult {
@@ -793,9 +904,14 @@ function dedupeAndLimitConceptDetections(
       ? options.nmsThreshold
       : SAM3_BATCH_V2_DEFAULT_NMS_THRESHOLD;
   const selected: SAM3ConceptDetection[] = [];
+  const instancesMode = resolveBatchV2RefineMode() === 'instances';
 
   for (const detection of [...detections].sort(
-    (left, right) => conceptDetectionScore(right) - conceptDetectionScore(left)
+    (left, right) =>
+      conceptDetectionScore(right) - conceptDetectionScore(left) ||
+      (instancesMode
+        ? conceptCandidateKey(left).localeCompare(conceptCandidateKey(right))
+        : 0)
   )) {
     if (selected.some((candidate) => bboxIou(candidate.bbox, detection.bbox) > nmsThreshold)) {
       continue;
@@ -830,6 +946,91 @@ function bestConceptCandidateMatchForBbox(
 
 function conceptCandidateKey(candidate: SAM3ConceptDetection): string {
   return `${candidate.bbox.join(',')}:${conceptDetectionScore(candidate).toFixed(6)}`;
+}
+
+function combineBackendWarnings(...warnings: Array<string | undefined>): string | undefined {
+  const unique = [...new Set(warnings.flatMap((warning) => warning ? [warning] : []))];
+  return unique.length > 0 ? unique.join(' ') : undefined;
+}
+
+function bboxCentre(bbox: [number, number, number, number]): [number, number] {
+  return [(bbox[0] + bbox[2]) / 2, (bbox[1] + bbox[3]) / 2];
+}
+
+function medianBoxDiameter(boxes: BoxCoordinate[]): number {
+  return median(
+    boxes.map((box) => Math.max(box.x2 - box.x1, box.y2 - box.y1))
+  );
+}
+
+function medianCandidateDiameter(candidates: SAM3ConceptDetection[]): number {
+  return median(
+    candidates.map((candidate) =>
+      Math.max(candidate.bbox[2] - candidate.bbox[0], candidate.bbox[3] - candidate.bbox[1])
+    )
+  );
+}
+
+function buildInstanceRefinementPrompts(
+  assetId: string,
+  candidates: SAM3ConceptDetection[],
+  promptPoints?: Map<SAM3ConceptDetection, [number, number]>,
+  exemplarDiameter?: number
+): {
+  prompts: SAM3RefineInstancePrompt[];
+  candidateById: Map<string, SAM3ConceptDetection>;
+} {
+  const centres = candidates.map((candidate) =>
+    promptPoints?.get(candidate) ?? bboxCentre(candidate.bbox)
+  );
+  const neighbourRadius = 2 * (
+    exemplarDiameter && exemplarDiameter > 0
+      ? exemplarDiameter
+      : medianCandidateDiameter(candidates)
+  );
+  const candidateById = new Map<string, SAM3ConceptDetection>();
+  const prompts = candidates.map((candidate, index) => {
+    const baseId = `${assetId}:${conceptCandidateKey(candidate)}`;
+    let id = baseId;
+    let duplicateIndex = 1;
+    while (candidateById.has(id)) {
+      id = `${baseId}:${duplicateIndex}`;
+      duplicateIndex += 1;
+    }
+    candidateById.set(id, candidate);
+    const centre = centres[index];
+    const negativePoints = centres
+      .map((otherCentre, otherIndex) => ({
+        centre: otherCentre,
+        otherIndex,
+        distance: Math.hypot(otherCentre[0] - centre[0], otherCentre[1] - centre[1]),
+      }))
+      .filter((entry) =>
+        entry.otherIndex !== index && entry.distance <= neighbourRadius
+      )
+      .sort((left, right) =>
+        left.distance - right.distance || left.otherIndex - right.otherIndex
+      )
+      .slice(0, 4)
+      .map((entry) => entry.centre);
+
+    return {
+      id,
+      box: candidate.bbox,
+      positive_points: [centre],
+      ...(negativePoints.length > 0 ? { negative_points: negativePoints } : {}),
+    };
+  });
+
+  return { prompts, candidateById };
+}
+
+function chunkItems<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
 }
 
 function normalizeConceptExemplarRefs(
@@ -1120,6 +1321,7 @@ export class Sam3BatchV2Service {
       0.5 * exemplarGreenMedian
     );
     const surviving: SAM3ConceptDetection[] = [];
+    const promptPoints = new Map<SAM3ConceptDetection, [number, number]>();
     let recenteredCount = 0;
 
     for (const candidate of candidates) {
@@ -1129,15 +1331,18 @@ export class Sam3BatchV2Service {
       const centre = await greenestBlobCentre(imageBuffer, candidate.bbox);
       if (!centre) {
         surviving.push(candidate);
+        promptPoints.set(candidate, bboxCentre(candidate.bbox));
         continue;
       }
 
       const bbox = recenterBbox(candidate.bbox, centre, imageWidth, imageHeight);
-      surviving.push({
+      const recenteredCandidate = {
         ...candidate,
         bbox,
         polygon: normalizePolygon(undefined, bbox),
-      });
+      };
+      surviving.push(recenteredCandidate);
+      promptPoints.set(recenteredCandidate, centre);
       recenteredCount += 1;
     }
 
@@ -1148,6 +1353,7 @@ export class Sam3BatchV2Service {
       threshold,
       gatedCount: candidates.length - surviving.length,
       recenteredCount,
+      promptPoints,
     };
   }
 
@@ -1568,6 +1774,7 @@ export class Sam3BatchV2Service {
       operatorCropCount: data.mode === 'visual_crop_match' ? normalizedCrops.length : 0,
       vegetationPrior,
       exemplarGreenMedian,
+      exemplarDiameter: medianBoxDiameter(data.exemplars),
     };
   }
 
@@ -1887,6 +2094,7 @@ export class Sam3BatchV2Service {
             {
               enabled: prepared.vegetationPrior,
               exemplarGreenMedian: prepared.exemplarGreenMedian,
+              exemplarDiameter: prepared.exemplarDiameter,
             }
           );
         }
@@ -1916,6 +2124,11 @@ export class Sam3BatchV2Service {
             prepared.mode === 'concept_propagation' ? conceptExemplars.length : undefined,
           refinementBoxCount: result.refinementBoxCount,
           refinementDetectionCount: result.refinementDetectionCount,
+          refinementMode: result.refinementMode,
+          candidateBudget: result.candidateBudget,
+          refineSentInstances: result.refineSentInstances,
+          refineRefinedInstances: result.refineRefinedInstances,
+          refineRejectedInstances: result.refineRejectedInstances,
           vegetationThreshold: result.vegetationThreshold,
           vegetationGatedCandidates: result.vegetationGatedCandidates,
           vegetationRecenteredCandidates: result.vegetationRecenteredCandidates,
@@ -2126,6 +2339,7 @@ export class Sam3BatchV2Service {
       exemplarId,
       primaryDetections: result.data.detections,
       primaryOptions: conceptOptions,
+      primaryBackendWarning: result.data.backendWarning,
       reviewProfile,
       failureCode: 'VISUAL_MATCH_EXEMPLAR_FALLBACK_FAILED',
     });
@@ -2134,7 +2348,8 @@ export class Sam3BatchV2Service {
       imageBuffer,
       className,
       candidateResult.detections,
-      vegetation
+      vegetation,
+      getBatchV2MaxTargetCandidates(reviewProfile)
     );
 
     return {
@@ -2142,11 +2357,19 @@ export class Sam3BatchV2Service {
       detections: refinement.detections,
       outcome: refinement.detections.length > 0 ? 'success' : 'zero_detections',
       backendMode: refinement.usedCandidateFallback ? 'concept_candidates_unrefined' : 'concept_refined',
-      backendWarning: refinement.backendWarning,
+      backendWarning: combineBackendWarnings(
+        candidateResult.backendWarning,
+        refinement.backendWarning
+      ),
       candidateExpansionUsed: candidateResult.candidateExpansionUsed,
       candidateCount: refinement.candidateCount,
       refinementBoxCount: refinement.refinementBoxCount,
       refinementDetectionCount: refinement.refinementDetectionCount,
+      refinementMode: refinement.refinementMode,
+      candidateBudget: refinement.candidateBudget,
+      refineSentInstances: refinement.refineSentInstances,
+      refineRefinedInstances: refinement.refineRefinedInstances,
+      refineRejectedInstances: refinement.refineRejectedInstances,
       vegetationThreshold: refinement.vegetationThreshold,
       vegetationGatedCandidates: refinement.vegetationGatedCandidates,
       vegetationRecenteredCandidates: refinement.vegetationRecenteredCandidates,
@@ -2165,11 +2388,13 @@ export class Sam3BatchV2Service {
 
     for (let index = 0; index < prepared.exemplars.length; index += 1) {
       const sourceBox = prepared.exemplars[index];
+      const embeddingBackend = resolveBatchV2RetrievalBackend();
       const exemplarResult = await this.awsSam3Service.createConceptExemplar({
         imageBuffer: prepared.sourceImageBuffer,
         boxes: [sourceBox],
         className: prepared.weedType,
         imageId: `${prepared.sourceAssetId}-box-${index + 1}`,
+        ...(embeddingBackend ? { embeddingBackend } : {}),
       });
 
       if (!exemplarResult.success || !exemplarResult.data?.exemplarId) {
@@ -2183,6 +2408,7 @@ export class Sam3BatchV2Service {
       exemplars.push({
         exemplarId: exemplarResult.data.exemplarId,
         sourceBoxIndex: index,
+        backendWarning: exemplarResult.data.backendWarning,
       });
     }
 
@@ -2232,7 +2458,8 @@ export class Sam3BatchV2Service {
       imageBuffer,
       weedType,
       candidateResult.detections,
-      vegetation
+      vegetation,
+      getBatchV2MaxTargetCandidates(reviewProfile)
     );
 
     return {
@@ -2242,11 +2469,19 @@ export class Sam3BatchV2Service {
       backendMode: refinement.usedCandidateFallback
         ? 'concept_ensemble_candidates_unrefined'
         : 'concept_ensemble_refined',
-      backendWarning: refinement.backendWarning,
+      backendWarning: combineBackendWarnings(
+        candidateResult.backendWarning,
+        refinement.backendWarning
+      ),
       candidateExpansionUsed: candidateResult.candidateExpansionUsed,
       candidateCount: refinement.candidateCount,
       refinementBoxCount: refinement.refinementBoxCount,
       refinementDetectionCount: refinement.refinementDetectionCount,
+      refinementMode: refinement.refinementMode,
+      candidateBudget: refinement.candidateBudget,
+      refineSentInstances: refinement.refineSentInstances,
+      refineRefinedInstances: refinement.refineRefinedInstances,
+      refineRejectedInstances: refinement.refineRejectedInstances,
       vegetationThreshold: refinement.vegetationThreshold,
       vegetationGatedCandidates: refinement.vegetationGatedCandidates,
       vegetationRecenteredCandidates: refinement.vegetationRecenteredCandidates,
@@ -2275,7 +2510,7 @@ export class Sam3BatchV2Service {
   }): Promise<ConceptCandidateResult> {
     const minTargetCandidates = getBatchV2MinTargetCandidates(reviewProfile);
     const maxTargetCandidates = getBatchV2MaxTargetCandidates(reviewProfile);
-    const primaryCandidates = await this.collectConceptCandidatesForExemplars({
+    const primaryResult = await this.collectConceptCandidatesForExemplars({
       asset,
       imageBuffer,
       exemplars,
@@ -2283,7 +2518,7 @@ export class Sam3BatchV2Service {
       failureCode,
     });
     const mergedPrimaryCandidates = dedupeAndLimitConceptDetections(
-      primaryCandidates,
+      primaryResult.detections,
       primaryOptions,
       maxTargetCandidates
     );
@@ -2292,11 +2527,12 @@ export class Sam3BatchV2Service {
       return {
         detections: mergedPrimaryCandidates,
         candidateExpansionUsed: false,
+        backendWarning: primaryResult.backendWarning,
       };
     }
 
     const fallbackOptions = buildBatchV2ConceptFallbackApplyOptions(reviewProfile);
-    const fallbackCandidates = await this.collectConceptCandidatesForExemplars({
+    const fallbackResult = await this.collectConceptCandidatesForExemplars({
       asset,
       imageBuffer,
       exemplars,
@@ -2304,12 +2540,12 @@ export class Sam3BatchV2Service {
       failureCode: 'CONCEPT_FALLBACK_FAILED',
     });
     const mergedCandidates = dedupeAndLimitConceptDetections(
-      [...mergedPrimaryCandidates, ...fallbackCandidates],
+      [...mergedPrimaryCandidates, ...fallbackResult.detections],
       fallbackOptions,
       maxTargetCandidates
     );
 
-    if (fallbackCandidates.length > 0) {
+    if (fallbackResult.detections.length > 0) {
       console.warn(
         `[SAM3 V2] Target ${asset.id} used ensemble fallback concept threshold ` +
           `${fallbackOptions.similarityThreshold} after strict threshold ` +
@@ -2321,6 +2557,10 @@ export class Sam3BatchV2Service {
     return {
       detections: mergedCandidates,
       candidateExpansionUsed: true,
+      backendWarning: combineBackendWarnings(
+        primaryResult.backendWarning,
+        fallbackResult.backendWarning
+      ),
     };
   }
 
@@ -2336,8 +2576,9 @@ export class Sam3BatchV2Service {
     exemplars: ConceptExemplarRef[];
     options: SAM3ConceptApplyOptions;
     failureCode: string;
-  }): Promise<SAM3ConceptDetection[]> {
+  }): Promise<{ detections: SAM3ConceptDetection[]; backendWarning?: string }> {
     const candidates: SAM3ConceptDetection[] = [];
+    const backendWarnings = exemplars.map((exemplar) => exemplar.backendWarning);
 
     for (const exemplar of exemplars) {
       const result = await this.awsSam3Service.applyConceptExemplar({
@@ -2361,9 +2602,13 @@ export class Sam3BatchV2Service {
       }
 
       candidates.push(...filterBatchV2ConceptDetections(result.data.detections, options));
+      backendWarnings.push(result.data.backendWarning);
     }
 
-    return candidates;
+    return {
+      detections: candidates,
+      backendWarning: combineBackendWarnings(...backendWarnings),
+    };
   }
 
   private async getConceptCandidatesWithFallback({
@@ -2372,6 +2617,7 @@ export class Sam3BatchV2Service {
     exemplarId,
     primaryDetections,
     primaryOptions,
+    primaryBackendWarning,
     reviewProfile = 'balanced',
     failureCode,
   }: {
@@ -2380,16 +2626,26 @@ export class Sam3BatchV2Service {
     exemplarId: string;
     primaryDetections: SAM3ConceptDetection[];
     primaryOptions: SAM3ConceptApplyOptions;
+    primaryBackendWarning?: string;
     reviewProfile?: Sam3BatchV2ReviewProfile;
     failureCode: string;
   }): Promise<ConceptCandidateResult> {
     const minTargetCandidates = getBatchV2MinTargetCandidates(reviewProfile);
     const maxTargetCandidates = getBatchV2MaxTargetCandidates(reviewProfile);
     const primaryCandidates = filterBatchV2ConceptDetections(primaryDetections, primaryOptions);
-    if (primaryCandidates.length >= minTargetCandidates) {
+    const rankedPrimaryCandidates = dedupeAndLimitConceptDetections(
+      primaryCandidates,
+      primaryOptions,
+      maxTargetCandidates
+    );
+    const primaryCandidateCountForFloor = resolveBatchV2RefineMode() === 'instances'
+      ? rankedPrimaryCandidates.length
+      : primaryCandidates.length;
+    if (primaryCandidateCountForFloor >= minTargetCandidates) {
       return {
-        detections: dedupeAndLimitConceptDetections(primaryCandidates, primaryOptions, maxTargetCandidates),
+        detections: rankedPrimaryCandidates,
         candidateExpansionUsed: false,
+        backendWarning: primaryBackendWarning,
       };
     }
 
@@ -2425,7 +2681,7 @@ export class Sam3BatchV2Service {
       console.warn(
         `[SAM3 V2] Target ${asset.id} used fallback concept threshold ` +
           `${fallbackOptions.similarityThreshold} after strict threshold ` +
-          `${primaryOptions.similarityThreshold} returned ${primaryCandidates.length} ` +
+          `${primaryOptions.similarityThreshold} returned ${primaryCandidateCountForFloor} ` +
           `candidate(s), below target floor ${minTargetCandidates}.`
       );
     }
@@ -2433,10 +2689,262 @@ export class Sam3BatchV2Service {
     return {
       detections: mergedCandidates,
       candidateExpansionUsed: true,
+      backendWarning: combineBackendWarnings(
+        primaryBackendWarning,
+        fallbackResult.data.backendWarning
+      ),
     };
   }
 
   private async refineConceptDetectionsWithBoxPrompts(
+    asset: AssetRecord,
+    imageBuffer: Buffer,
+    className: string,
+    candidates: SAM3ConceptDetection[],
+    vegetation?: VegetationPriorContext,
+    candidateBudget?: number
+  ): Promise<ConceptRefinementResult> {
+    const refinementMode = resolveBatchV2RefineMode();
+    const result = refinementMode === 'instances'
+      ? await this.refineConceptDetectionsWithInstances(
+          asset,
+          imageBuffer,
+          candidates,
+          vegetation
+        )
+      : await this.refineConceptDetectionsWithLegacyBoxPrompts(
+          asset,
+          imageBuffer,
+          className,
+          candidates,
+          vegetation
+        );
+
+    return {
+      ...result,
+      refinementMode,
+      candidateBudget: candidateBudget ?? (
+        refinementMode === 'instances'
+          ? resolveBatchV2CandidateBudget()
+          : getBatchV2MaxTargetCandidates('balanced', 'concept')
+      ),
+      ...(refinementMode === 'instances'
+        ? {
+            refineSentInstances:
+              result.refineSentInstances ?? result.refinementBoxCount,
+            refineRefinedInstances: result.refineRefinedInstances ?? 0,
+            refineRejectedInstances: result.refineRejectedInstances ?? 0,
+          }
+        : {}),
+    };
+  }
+
+  private async refineConceptDetectionsWithInstances(
+    asset: AssetRecord,
+    imageBuffer: Buffer,
+    candidates: SAM3ConceptDetection[],
+    vegetation?: VegetationPriorContext
+  ): Promise<ConceptRefinementResult> {
+    if (candidates.length === 0) {
+      return {
+        detections: [],
+        candidateCount: 0,
+        refinementBoxCount: 0,
+        refinementDetectionCount: 0,
+        refineSentInstances: 0,
+        refineRefinedInstances: 0,
+        refineRejectedInstances: 0,
+      };
+    }
+
+    const originalCandidateCount = candidates.length;
+    const vegetationCandidates = vegetation?.enabled
+      ? await this.applyVegetationPriorToCandidates(
+          imageBuffer,
+          candidates,
+          vegetation.exemplarGreenMedian
+        )
+      : undefined;
+    const refinementCandidates = vegetationCandidates?.candidates ?? candidates;
+
+    if (refinementCandidates.length === 0) {
+      return {
+        detections: [],
+        candidateCount: originalCandidateCount,
+        refinementBoxCount: 0,
+        refinementDetectionCount: 0,
+        refineSentInstances: 0,
+        refineRefinedInstances: 0,
+        refineRejectedInstances: 0,
+        vegetationThreshold: vegetationCandidates?.threshold,
+        vegetationGatedCandidates: vegetationCandidates?.gatedCount,
+        vegetationRecenteredCandidates: vegetationCandidates?.recenteredCount,
+        vegetationGatedMasks: 0,
+        vegetationDeduplicatedMasks: 0,
+      };
+    }
+
+    const validCandidates = refinementCandidates.filter((candidate) =>
+      isValidBox({
+        x1: candidate.bbox[0],
+        y1: candidate.bbox[1],
+        x2: candidate.bbox[2],
+        y2: candidate.bbox[3],
+      })
+    );
+    const { prompts, candidateById } = buildInstanceRefinementPrompts(
+      asset.id,
+      validCandidates,
+      vegetationCandidates?.promptPoints,
+      vegetation?.exemplarDiameter
+    );
+
+    if (prompts.length === 0) {
+      return this.buildConceptCandidateFallbackResult(
+        asset.id,
+        imageBuffer,
+        refinementCandidates,
+        originalCandidateCount,
+        0,
+        0,
+        'SAM3 instance refinement could not build valid boxes.',
+        vegetationCandidates
+      );
+    }
+
+    try {
+      await this.ensureSam3ReadyForBoxRefinement(asset.id);
+    } catch (error) {
+      return this.buildConceptCandidateFallbackResult(
+        asset.id,
+        imageBuffer,
+        refinementCandidates,
+        originalCandidateCount,
+        0,
+        0,
+        error instanceof Error ? error.message : 'SAM3 instance refinement was not ready.',
+        vegetationCandidates
+      );
+    }
+
+    const responseById = new Map<string, {
+      id: string;
+      polygon: [number, number][] | null;
+      bbox_from_mask: [number, number, number, number] | null;
+      predicted_iou: number;
+      score: number;
+    }>();
+    let responseInstanceCount = 0;
+    const image = imageBuffer.toString('base64');
+    const refineInstances = this.awsSam3Service.refineInstances;
+    if (!refineInstances) {
+      return this.buildConceptCandidateFallbackResult(
+        asset.id,
+        imageBuffer,
+        refinementCandidates,
+        originalCandidateCount,
+        0,
+        0,
+        'SAM3 client does not support instance refinement.',
+        vegetationCandidates
+      );
+    }
+
+    for (const chunk of chunkItems(prompts, SAM3_BATCH_V2_INSTANCE_REFINEMENT_CHUNK_SIZE)) {
+      let result: Awaited<ReturnType<NonNullable<AwsSam3Like['refineInstances']>>>;
+      try {
+        result = await refineInstances.call(this.awsSam3Service, {
+          image,
+          instances: chunk,
+          return_polygons: true,
+          decode_batch: 32,
+          polygon_resolution: 2048,
+          score_threshold: 0.5,
+        });
+      } catch (error) {
+        return this.buildConceptCandidateFallbackResult(
+          asset.id,
+          imageBuffer,
+          refinementCandidates,
+          originalCandidateCount,
+          prompts.length,
+          responseInstanceCount,
+          error instanceof Error ? error.message : 'SAM3 instance refinement request failed.',
+          vegetationCandidates
+        );
+      }
+
+      if (!result.success || !result.response) {
+        return this.buildConceptCandidateFallbackResult(
+          asset.id,
+          imageBuffer,
+          refinementCandidates,
+          originalCandidateCount,
+          prompts.length,
+          responseInstanceCount,
+          result.error || 'SAM3 instance refinement returned no response.',
+          vegetationCandidates
+        );
+      }
+
+      responseInstanceCount += result.response.instances.length;
+      for (const instance of result.response.instances) {
+        responseById.set(instance.id, instance);
+      }
+    }
+
+    let rejectedInstances = 0;
+    const refinedDetections = prompts.flatMap((prompt) => {
+      const response = responseById.get(prompt.id);
+      const sourceCandidate = candidateById.get(prompt.id);
+      if (!response?.polygon || !sourceCandidate) {
+        rejectedInstances += 1;
+        return [];
+      }
+
+      const score = conceptDetectionScore(sourceCandidate);
+      return [{
+        bbox: response.bbox_from_mask ?? polygonBounds(response.polygon),
+        polygon: response.polygon,
+        confidence: score,
+        similarity:
+          typeof sourceCandidate.similarity === 'number'
+            ? sourceCandidate.similarity
+            : score,
+      }];
+    });
+
+    const maskHygiene = vegetationCandidates
+      ? await this.applyVegetationMaskHygiene(
+          asset.id,
+          imageBuffer,
+          refinedDetections,
+          vegetationCandidates.imageWidth,
+          vegetationCandidates.imageHeight,
+          vegetationCandidates.threshold
+        )
+      : undefined;
+
+    return {
+      detections: maskHygiene?.detections ?? refinedDetections,
+      candidateCount: originalCandidateCount,
+      refinementBoxCount: prompts.length,
+      refinementDetectionCount: responseInstanceCount,
+      refineSentInstances: prompts.length,
+      refineRefinedInstances: refinedDetections.length,
+      refineRejectedInstances: rejectedInstances,
+      vegetationThreshold: vegetationCandidates?.threshold,
+      vegetationGatedCandidates: vegetationCandidates?.gatedCount,
+      vegetationRecenteredCandidates: vegetationCandidates?.recenteredCount,
+      vegetationGatedMasks: maskHygiene?.gatedCount,
+      vegetationDeduplicatedMasks: maskHygiene?.deduplicatedCount,
+      maskGreenFractionP10: maskHygiene?.p10,
+      maskGreenFractionMedian: maskHygiene?.median,
+      maskGreenFractionP90: maskHygiene?.p90,
+    };
+  }
+
+  private async refineConceptDetectionsWithLegacyBoxPrompts(
     asset: AssetRecord,
     imageBuffer: Buffer,
     className: string,

--- a/lib/services/sam3-batch-v2.ts
+++ b/lib/services/sam3-batch-v2.ts
@@ -67,9 +67,12 @@ export function resolveBatchV2RetrievalBackend(
   refineMode: Sam3BatchV2RefineMode = resolveBatchV2RefineMode(),
   value: string | undefined = process.env.SAM3_RETRIEVAL_BACKEND
 ): string | undefined {
+  if (refineMode !== 'instances') {
+    return undefined;
+  }
+
   const configured = value?.trim();
-  return configured ||
-    (refineMode === 'instances' ? SAM3_BATCH_V2_DEFAULT_RETRIEVAL_BACKEND : undefined);
+  return configured || SAM3_BATCH_V2_DEFAULT_RETRIEVAL_BACKEND;
 }
 
 const parseOptionalNumber = (value: string | undefined): number | undefined => {
@@ -331,6 +334,7 @@ export interface Sam3BatchV2StageLogEntry {
   refineSentInstances?: number;
   refineRefinedInstances?: number;
   refineRejectedInstances?: number;
+  refineIncompleteChunks?: number;
   vegetationPrior?: boolean;
   exemplarGreenMedian?: number;
   vegetationThreshold?: number;
@@ -572,6 +576,7 @@ interface AssetInferenceResult {
   refineSentInstances?: number;
   refineRefinedInstances?: number;
   refineRejectedInstances?: number;
+  refineIncompleteChunks?: number;
   vegetationThreshold?: number;
   vegetationGatedCandidates?: number;
   vegetationRecenteredCandidates?: number;
@@ -592,6 +597,7 @@ interface ConceptRefinementResult {
   refineSentInstances?: number;
   refineRefinedInstances?: number;
   refineRejectedInstances?: number;
+  refineIncompleteChunks?: number;
   vegetationThreshold?: number;
   vegetationGatedCandidates?: number;
   vegetationRecenteredCandidates?: number;
@@ -1023,6 +1029,53 @@ function buildInstanceRefinementPrompts(
   });
 
   return { prompts, candidateById };
+}
+
+function scalePointToResized(
+  point: [number, number],
+  scaleFactor: number
+): [number, number] {
+  return [
+    Math.round(point[0] * scaleFactor),
+    Math.round(point[1] * scaleFactor),
+  ];
+}
+
+function scaleInstanceRefinementPrompt(
+  prompt: SAM3RefineInstancePrompt,
+  scaleFactor: number
+): SAM3RefineInstancePrompt {
+  if (scaleFactor === 1) {
+    return prompt;
+  }
+
+  const box = bboxToBoxCoordinate(prompt.box, scaleFactor);
+  return {
+    ...prompt,
+    box: [box.x1, box.y1, box.x2, box.y2],
+    positive_points: prompt.positive_points?.map((point) =>
+      scalePointToResized(point, scaleFactor)
+    ),
+    negative_points: prompt.negative_points?.map((point) =>
+      scalePointToResized(point, scaleFactor)
+    ),
+  };
+}
+
+function hasCompleteInstanceRefinementResponse(
+  prompts: SAM3RefineInstancePrompt[],
+  instances: Array<{ id: string }>
+): boolean {
+  const requestedIds = new Set(prompts.map((prompt) => prompt.id));
+  const responseCounts = new Map<string, number>();
+
+  for (const instance of instances) {
+    if (requestedIds.has(instance.id)) {
+      responseCounts.set(instance.id, (responseCounts.get(instance.id) ?? 0) + 1);
+    }
+  }
+
+  return prompts.every((prompt) => responseCounts.get(prompt.id) === 1);
 }
 
 function chunkItems<T>(items: T[], size: number): T[][] {
@@ -2129,6 +2182,7 @@ export class Sam3BatchV2Service {
           refineSentInstances: result.refineSentInstances,
           refineRefinedInstances: result.refineRefinedInstances,
           refineRejectedInstances: result.refineRejectedInstances,
+          refineIncompleteChunks: result.refineIncompleteChunks,
           vegetationThreshold: result.vegetationThreshold,
           vegetationGatedCandidates: result.vegetationGatedCandidates,
           vegetationRecenteredCandidates: result.vegetationRecenteredCandidates,
@@ -2370,6 +2424,7 @@ export class Sam3BatchV2Service {
       refineSentInstances: refinement.refineSentInstances,
       refineRefinedInstances: refinement.refineRefinedInstances,
       refineRejectedInstances: refinement.refineRejectedInstances,
+      refineIncompleteChunks: refinement.refineIncompleteChunks,
       vegetationThreshold: refinement.vegetationThreshold,
       vegetationGatedCandidates: refinement.vegetationGatedCandidates,
       vegetationRecenteredCandidates: refinement.vegetationRecenteredCandidates,
@@ -2482,6 +2537,7 @@ export class Sam3BatchV2Service {
       refineSentInstances: refinement.refineSentInstances,
       refineRefinedInstances: refinement.refineRefinedInstances,
       refineRejectedInstances: refinement.refineRejectedInstances,
+      refineIncompleteChunks: refinement.refineIncompleteChunks,
       vegetationThreshold: refinement.vegetationThreshold,
       vegetationGatedCandidates: refinement.vegetationGatedCandidates,
       vegetationRecenteredCandidates: refinement.vegetationRecenteredCandidates,
@@ -2734,6 +2790,7 @@ export class Sam3BatchV2Service {
               result.refineSentInstances ?? result.refinementBoxCount,
             refineRefinedInstances: result.refineRefinedInstances ?? 0,
             refineRejectedInstances: result.refineRejectedInstances ?? 0,
+            refineIncompleteChunks: result.refineIncompleteChunks ?? 0,
           }
         : {}),
     };
@@ -2812,8 +2869,10 @@ export class Sam3BatchV2Service {
       );
     }
 
+    let resized: Awaited<ReturnType<AwsSam3Like['resizeImage']>>;
     try {
       await this.ensureSam3ReadyForBoxRefinement(asset.id);
+      resized = await this.awsSam3Service.resizeImage(imageBuffer);
     } catch (error) {
       return this.buildConceptCandidateFallbackResult(
         asset.id,
@@ -2835,7 +2894,12 @@ export class Sam3BatchV2Service {
       score: number;
     }>();
     let responseInstanceCount = 0;
-    const image = imageBuffer.toString('base64');
+    let incompleteChunks = 0;
+    const incompletePromptIds = new Set<string>();
+    const image = resized.buffer.toString('base64');
+    const scaledPrompts = prompts.map((prompt) =>
+      scaleInstanceRefinementPrompt(prompt, resized.scaling.scaleFactor)
+    );
     const refineInstances = this.awsSam3Service.refineInstances;
     if (!refineInstances) {
       return this.buildConceptCandidateFallbackResult(
@@ -2850,62 +2914,99 @@ export class Sam3BatchV2Service {
       );
     }
 
-    for (const chunk of chunkItems(prompts, SAM3_BATCH_V2_INSTANCE_REFINEMENT_CHUNK_SIZE)) {
-      let result: Awaited<ReturnType<NonNullable<AwsSam3Like['refineInstances']>>>;
-      try {
-        result = await refineInstances.call(this.awsSam3Service, {
-          image,
-          instances: chunk,
-          return_polygons: true,
-          decode_batch: 32,
-          polygon_resolution: 2048,
-          score_threshold: 0.5,
-        });
-      } catch (error) {
-        return this.buildConceptCandidateFallbackResult(
-          asset.id,
-          imageBuffer,
-          refinementCandidates,
-          originalCandidateCount,
-          prompts.length,
-          responseInstanceCount,
-          error instanceof Error ? error.message : 'SAM3 instance refinement request failed.',
-          vegetationCandidates
-        );
+    for (const chunk of chunkItems(scaledPrompts, SAM3_BATCH_V2_INSTANCE_REFINEMENT_CHUNK_SIZE)) {
+      let completeResult: Awaited<
+        ReturnType<NonNullable<AwsSam3Like['refineInstances']>>
+      > | undefined;
+
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        let result: Awaited<ReturnType<NonNullable<AwsSam3Like['refineInstances']>>>;
+        try {
+          result = await refineInstances.call(this.awsSam3Service, {
+            image,
+            instances: chunk,
+            return_polygons: true,
+            decode_batch: 32,
+            polygon_resolution: 2048,
+            score_threshold: 0.5,
+          });
+        } catch (error) {
+          return this.buildConceptCandidateFallbackResult(
+            asset.id,
+            imageBuffer,
+            refinementCandidates,
+            originalCandidateCount,
+            prompts.length,
+            responseInstanceCount,
+            error instanceof Error ? error.message : 'SAM3 instance refinement request failed.',
+            vegetationCandidates
+          );
+        }
+
+        if (!result.success || !result.response) {
+          return this.buildConceptCandidateFallbackResult(
+            asset.id,
+            imageBuffer,
+            refinementCandidates,
+            originalCandidateCount,
+            prompts.length,
+            responseInstanceCount,
+            result.error || 'SAM3 instance refinement returned no response.',
+            vegetationCandidates
+          );
+        }
+
+        if (hasCompleteInstanceRefinementResponse(chunk, result.response.instances)) {
+          completeResult = result;
+          break;
+        }
       }
 
-      if (!result.success || !result.response) {
-        return this.buildConceptCandidateFallbackResult(
-          asset.id,
-          imageBuffer,
-          refinementCandidates,
-          originalCandidateCount,
-          prompts.length,
-          responseInstanceCount,
-          result.error || 'SAM3 instance refinement returned no response.',
-          vegetationCandidates
-        );
+      if (!completeResult?.response) {
+        incompleteChunks += 1;
+        chunk.forEach((prompt) => incompletePromptIds.add(prompt.id));
+        continue;
       }
 
-      responseInstanceCount += result.response.instances.length;
-      for (const instance of result.response.instances) {
-        responseById.set(instance.id, instance);
+      responseInstanceCount += completeResult.response.instances.length;
+      for (const instance of completeResult.response.instances) {
+        if (candidateById.has(instance.id)) {
+          responseById.set(instance.id, instance);
+        }
       }
     }
 
     let rejectedInstances = 0;
-    const refinedDetections = prompts.flatMap((prompt) => {
-      const response = responseById.get(prompt.id);
+    let refinedInstances = 0;
+    const detections = prompts.flatMap((prompt) => {
       const sourceCandidate = candidateById.get(prompt.id);
-      if (!response?.polygon || !sourceCandidate) {
+      if (!sourceCandidate) {
+        return [];
+      }
+
+      if (incompletePromptIds.has(prompt.id)) {
+        return [mapConceptDetectionToAssetDetection(sourceCandidate)];
+      }
+
+      const response = responseById.get(prompt.id);
+      if (!response?.polygon) {
         rejectedInstances += 1;
         return [];
       }
 
+      const bbox = scaleBboxToOriginal(
+        response.bbox_from_mask ?? polygonBounds(response.polygon),
+        resized.scaling.scaleFactor
+      );
       const score = conceptDetectionScore(sourceCandidate);
+      refinedInstances += 1;
       return [{
-        bbox: response.bbox_from_mask ?? polygonBounds(response.polygon),
-        polygon: response.polygon,
+        bbox,
+        polygon: scalePolygonToOriginal(
+          response.polygon,
+          bbox,
+          resized.scaling.scaleFactor
+        ),
         confidence: score,
         similarity:
           typeof sourceCandidate.similarity === 'number'
@@ -2918,21 +3019,32 @@ export class Sam3BatchV2Service {
       ? await this.applyVegetationMaskHygiene(
           asset.id,
           imageBuffer,
-          refinedDetections,
+          detections,
           vegetationCandidates.imageWidth,
           vegetationCandidates.imageHeight,
           vegetationCandidates.threshold
         )
       : undefined;
+    const incompleteCandidateCount = incompletePromptIds.size;
+    const backendWarning = incompleteChunks > 0
+      ? `SAM3 instance refinement returned incomplete responses for ${asset.id}; ` +
+        `saved ${incompleteCandidateCount} candidate(s) from ${incompleteChunks} chunk(s) ` +
+        'as unrefined pending review items after retry.'
+      : undefined;
+
+    if (backendWarning) {
+      console.warn(`[SAM3 V2] ${backendWarning}`);
+    }
 
     return {
-      detections: maskHygiene?.detections ?? refinedDetections,
+      detections: maskHygiene?.detections ?? detections,
       candidateCount: originalCandidateCount,
       refinementBoxCount: prompts.length,
       refinementDetectionCount: responseInstanceCount,
       refineSentInstances: prompts.length,
-      refineRefinedInstances: refinedDetections.length,
+      refineRefinedInstances: refinedInstances,
       refineRejectedInstances: rejectedInstances,
+      refineIncompleteChunks: incompleteChunks,
       vegetationThreshold: vegetationCandidates?.threshold,
       vegetationGatedCandidates: vegetationCandidates?.gatedCount,
       vegetationRecenteredCandidates: vegetationCandidates?.recenteredCount,
@@ -2941,6 +3053,8 @@ export class Sam3BatchV2Service {
       maskGreenFractionP10: maskHygiene?.p10,
       maskGreenFractionMedian: maskHygiene?.median,
       maskGreenFractionP90: maskHygiene?.p90,
+      usedCandidateFallback: incompleteChunks > 0,
+      backendWarning,
     };
   }
 

--- a/tests/unit/sam3-batch-v2.test.ts
+++ b/tests/unit/sam3-batch-v2.test.ts
@@ -9,13 +9,20 @@ import {
   getBatchV2MaxTargetCandidates,
   getBatchV2MinTargetCandidates,
   getGpuAdmissionCropCount,
+  resolveBatchV2CandidateBudget,
+  resolveBatchV2RefineMode,
+  resolveBatchV2RetrievalBackend,
   resolveBatchV2VegetationPrior,
   resolveBatchV2ReviewProfileForMode,
   Sam3BatchV2Service,
 } from '@/lib/services/sam3-batch-v2';
+import { awsSam3Service } from '@/lib/services/aws-sam3';
 
 describe('sam3-batch-v2', () => {
   const originalFetch = global.fetch;
+  const originalRefineMode = process.env.SAM3_REFINE_MODE;
+  const originalCandidateBudget = process.env.SAM3_CANDIDATE_BUDGET;
+  const originalRetrievalBackend = process.env.SAM3_RETRIEVAL_BACKEND;
   const makeConceptDetection = (index: number, similarity = 0.82) => ({
     bbox: [index * 10, 10, index * 10 + 6, 18] as [number, number, number, number],
     confidence: similarity,
@@ -53,6 +60,9 @@ describe('sam3-batch-v2', () => {
   };
 
   beforeEach(() => {
+    process.env.SAM3_REFINE_MODE = 'concept';
+    delete process.env.SAM3_CANDIDATE_BUDGET;
+    delete process.env.SAM3_RETRIEVAL_BACKEND;
     global.fetch = vi.fn().mockImplementation(async () =>
       new Response(Buffer.from('image-bytes'), {
         status: 200,
@@ -65,6 +75,12 @@ describe('sam3-batch-v2', () => {
   });
 
   afterEach(() => {
+    if (originalRefineMode == null) delete process.env.SAM3_REFINE_MODE;
+    else process.env.SAM3_REFINE_MODE = originalRefineMode;
+    if (originalCandidateBudget == null) delete process.env.SAM3_CANDIDATE_BUDGET;
+    else process.env.SAM3_CANDIDATE_BUDGET = originalCandidateBudget;
+    if (originalRetrievalBackend == null) delete process.env.SAM3_RETRIEVAL_BACKEND;
+    else process.env.SAM3_RETRIEVAL_BACKEND = originalRetrievalBackend;
     global.fetch = originalFetch;
     vi.restoreAllMocks();
   });
@@ -190,6 +206,310 @@ describe('sam3-batch-v2', () => {
     expect(resolveBatchV2VegetationPrior(undefined, undefined)).toBe(true);
     expect(resolveBatchV2VegetationPrior(false, undefined)).toBe(false);
     expect(resolveBatchV2VegetationPrior(true, 'false')).toBe(false);
+  });
+
+  it('defaults instance mode to a 400-candidate satellite-retrieval budget', () => {
+    delete process.env.SAM3_REFINE_MODE;
+
+    expect(resolveBatchV2RefineMode()).toBe('instances');
+    expect(resolveBatchV2CandidateBudget()).toBe(400);
+    expect(resolveBatchV2RetrievalBackend()).toBe('dinov3_vitl16_sat');
+    expect(buildBatchV2ConceptApplyOptions('high_recall')).toMatchObject({
+      topK: 400,
+      sizeFilterMinRatio: 0.2,
+      sizeFilterMaxRatio: 2.5,
+      embeddingBackend: 'dinov3_vitl16_sat',
+    });
+    expect(getBatchV2MinTargetCandidates('high_recall')).toBe(400);
+    expect(getBatchV2MaxTargetCandidates('high_recall')).toBe(400);
+  });
+
+  it('maps instance refinement by id, drops null masks, and chunks requests at 200', async () => {
+    process.env.SAM3_REFINE_MODE = 'instances';
+    const candidates = Array.from({ length: 401 }, (_, index) =>
+      makeConceptDetection(index, 0.7 + index / 10_000)
+    );
+    const refineInstances = vi.fn().mockImplementation(async ({ instances }) => ({
+      success: true,
+      response: {
+        instances: [...instances].reverse().map((instance: any, responseIndex: number) => ({
+          id: instance.id,
+          polygon: instance.id.includes(':0,10,6,18:')
+            ? null
+            : [[10_000 + responseIndex, 20], [10_001 + responseIndex, 20], [10_001 + responseIndex, 21]],
+          bbox_from_mask: instance.id.includes(':0,10,6,18:')
+            ? null
+            : [10_000 + responseIndex, 20, 10_001 + responseIndex, 21],
+          predicted_iou: 0.9,
+          score: 0.9,
+        })),
+        image_size: [5000, 3000],
+      },
+    }));
+    const service = new Sam3BatchV2Service({
+      prisma: {} as never,
+      awsSam3Service: {
+        refreshStatus: vi.fn().mockResolvedValue({
+          modelLoaded: true,
+          instanceState: 'ready',
+          ipAddress: '127.0.0.1',
+        }),
+        isReady: vi.fn().mockReturnValue(true),
+        refineInstances,
+      } as any,
+      acquireGpuLock: vi.fn(),
+      refreshGpuLock: vi.fn(),
+      releaseGpuLock: vi.fn(),
+      sleep: vi.fn(),
+      now: () => new Date('2026-07-17T00:00:00.000Z'),
+    });
+
+    const result = await (service as any).refineConceptDetectionsWithBoxPrompts(
+      { id: 'asset-instance-map', imageWidth: 5000, imageHeight: 3000 },
+      Buffer.from('original-resolution-image'),
+      'Pine Sapling',
+      candidates,
+      { enabled: false, exemplarGreenMedian: 0.8, exemplarDiameter: 8 },
+      400
+    );
+
+    expect(refineInstances).toHaveBeenCalledTimes(3);
+    expect(refineInstances.mock.calls.map(([request]) => request.instances.length)).toEqual([
+      200,
+      200,
+      1,
+    ]);
+    expect(refineInstances.mock.calls[0][0]).toMatchObject({
+      image: Buffer.from('original-resolution-image').toString('base64'),
+      return_polygons: true,
+      decode_batch: 32,
+      polygon_resolution: 2048,
+      score_threshold: 0.5,
+    });
+    expect(refineInstances.mock.calls[0][0].instances[0]).toMatchObject({
+      box: [0, 10, 6, 18],
+      positive_points: [[3, 14]],
+    });
+    expect(result).toMatchObject({
+      refinementMode: 'instances',
+      candidateBudget: 400,
+      candidateCount: 401,
+      refineSentInstances: 401,
+      refineRefinedInstances: 400,
+      refineRejectedInstances: 1,
+    });
+    expect(result.detections).toHaveLength(400);
+    const mappedSecondCandidate = result.detections.find(
+      (detection: any) => detection.similarity === candidates[1].similarity
+    );
+    expect(mappedSecondCandidate).toMatchObject({
+      confidence: candidates[1].similarity,
+      similarity: candidates[1].similarity,
+    });
+    expect(mappedSecondCandidate.bbox[0]).toBeGreaterThan(9_000);
+  });
+
+  it('keeps the flag-off concept refinement request on the legacy segment path', async () => {
+    process.env.SAM3_REFINE_MODE = 'concept';
+    const segment = vi.fn().mockResolvedValue({
+      success: true,
+      response: {
+        detections: [{
+          bbox: [20, 25, 40, 45],
+          confidence: 0.91,
+          polygon: [[20, 25], [40, 25], [40, 45], [20, 45]],
+        }],
+        count: 1,
+      },
+    });
+    const refineInstances = vi.fn();
+    const service = new Sam3BatchV2Service({
+      prisma: {} as never,
+      awsSam3Service: {
+        refreshStatus: vi.fn().mockResolvedValue({
+          modelLoaded: true,
+          instanceState: 'ready',
+          ipAddress: '127.0.0.1',
+        }),
+        isReady: vi.fn().mockReturnValue(true),
+        resizeImage: vi.fn().mockResolvedValue({
+          buffer: Buffer.from('legacy-resized-image'),
+          scaling: { scaleFactor: 1 },
+        }),
+        segment,
+        refineInstances,
+      } as any,
+      acquireGpuLock: vi.fn(),
+      refreshGpuLock: vi.fn(),
+      releaseGpuLock: vi.fn(),
+      sleep: vi.fn(),
+      now: () => new Date('2026-07-17T00:00:00.000Z'),
+    });
+
+    await (service as any).refineConceptDetectionsWithBoxPrompts(
+      { id: 'asset-legacy' },
+      Buffer.from('legacy-original-image'),
+      'Pine Sapling',
+      [{
+        bbox: [20, 25, 40, 45],
+        confidence: 0.82,
+        similarity: 0.82,
+        class_name: 'pine sapling',
+      }],
+      { enabled: false, exemplarGreenMedian: 0.8 }
+    );
+
+    expect(segment).toHaveBeenCalledWith({
+      image: Buffer.from('legacy-resized-image').toString('base64'),
+      boxes: [{ x1: 20, y1: 25, x2: 40, y2: 45 }],
+      className: 'Pine Sapling',
+      returnPolygons: true,
+    });
+    expect(refineInstances).not.toHaveBeenCalled();
+  });
+
+  it('truncates equal-score instance candidates deterministically at the configured budget', async () => {
+    process.env.SAM3_REFINE_MODE = 'instances';
+    process.env.SAM3_CANDIDATE_BUDGET = '400';
+    const candidates = Array.from({ length: 425 }, (_, index) =>
+      makeConceptDetection(index, 0.84)
+    );
+    const applyConceptExemplar = vi.fn();
+    const service = new Sam3BatchV2Service({
+      prisma: {} as never,
+      awsSam3Service: { applyConceptExemplar } as any,
+      acquireGpuLock: vi.fn(),
+      refreshGpuLock: vi.fn(),
+      releaseGpuLock: vi.fn(),
+      sleep: vi.fn(),
+      now: () => new Date('2026-07-17T00:00:00.000Z'),
+    });
+    const run = async (detections: typeof candidates) => {
+      applyConceptExemplar.mockResolvedValueOnce({
+        success: true,
+        data: { detections, processingTimeMs: 1 },
+      });
+      return (service as any).getConceptCandidatesFromEnsemble({
+        asset: { id: 'asset-budget' },
+        imageBuffer: Buffer.from('image'),
+        exemplars: [{ exemplarId: 'exemplar-1' }],
+        primaryOptions: buildBatchV2ConceptApplyOptions('high_recall'),
+        reviewProfile: 'high_recall',
+        failureCode: 'TEST_FAILED',
+      });
+    };
+
+    const forward = await run(candidates);
+    const reversed = await run([...candidates].reverse());
+
+    expect(forward.detections).toHaveLength(400);
+    expect(reversed.detections.map((detection: any) => detection.bbox)).toEqual(
+      forward.detections.map((detection: any) => detection.bbox)
+    );
+  });
+
+  it('retries a 400 retrieval-backend mismatch with dinov2 and returns a stage-log warning', async () => {
+    const image = await makeVegetationImage(10, 10, []);
+    const singleton = awsSam3Service as any;
+    const previous = {
+      configured: singleton.configured,
+      instanceIp: singleton.instanceIp,
+      instanceState: singleton.instanceState,
+    };
+    singleton.configured = true;
+    singleton.instanceIp = '127.0.0.1';
+    singleton.instanceState = 'ready';
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('backend mismatch', { status: 400 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        results: [{ detections: [] }],
+        processing_time_ms: 4,
+      }), { status: 200, headers: { 'content-type': 'application/json' } })) as typeof fetch;
+
+    try {
+      const result = await awsSam3Service.applyConceptExemplar({
+        exemplarId: 'dinov2-exemplar',
+        imageBuffer: image,
+        options: {
+          returnPolygons: true,
+          embeddingBackend: 'dinov3_vitl16_sat',
+        },
+      });
+
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      const firstPayload = JSON.parse((global.fetch as any).mock.calls[0][1].body);
+      const secondPayload = JSON.parse((global.fetch as any).mock.calls[1][1].body);
+      expect(firstPayload.embedding_backend).toBe('dinov3_vitl16_sat');
+      expect(secondPayload.embedding_backend).toBe('dinov2_vits14');
+      expect(result).toMatchObject({
+        success: true,
+        data: {
+          backendFallback: true,
+          embeddingBackend: 'dinov2_vits14',
+          backendWarning: expect.stringContaining('retried with dinov2_vits14'),
+        },
+      });
+    } finally {
+      singleton.configured = previous.configured;
+      singleton.instanceIp = previous.instanceIp;
+      singleton.instanceState = previous.instanceState;
+    }
+  });
+
+  it('posts the refine-instances contract to the primary SAM3 port', async () => {
+    const singleton = awsSam3Service as any;
+    const previous = {
+      configured: singleton.configured,
+      instanceIp: singleton.instanceIp,
+      instanceState: singleton.instanceState,
+    };
+    singleton.configured = true;
+    singleton.instanceIp = '127.0.0.1';
+    singleton.instanceState = 'ready';
+    global.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      instances: [{
+        id: 'candidate-1',
+        polygon: [[1, 2], [3, 2], [3, 4]],
+        bbox_from_mask: [1, 2, 3, 4],
+        predicted_iou: 0.91,
+        score: 0.88,
+      }],
+      image_size: [100, 80],
+    }), { status: 200, headers: { 'content-type': 'application/json' } })) as typeof fetch;
+
+    try {
+      const request = {
+        image: 'base64-image',
+        instances: [{
+          id: 'candidate-1',
+          box: [1, 2, 3, 4] as [number, number, number, number],
+          positive_points: [[2, 3]] as [number, number][],
+          negative_points: [[20, 30]] as [number, number][],
+        }],
+        return_polygons: true as const,
+        decode_batch: 32,
+        polygon_resolution: 2048,
+        score_threshold: 0.5,
+      };
+      const result = await awsSam3Service.refineInstances(request);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://127.0.0.1:8000/refine_instances',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify(request),
+        })
+      );
+      expect(result).toMatchObject({
+        success: true,
+        response: { instances: [{ id: 'candidate-1' }], image_size: [100, 80] },
+      });
+    } finally {
+      singleton.configured = previous.configured;
+      singleton.instanceIp = previous.instanceIp;
+      singleton.instanceState = previous.instanceState;
+    }
   });
 
   it('gates dirt candidates, recentres a green candidate, and post-gates a dirt mask', async () => {

--- a/tests/unit/sam3-batch-v2.test.ts
+++ b/tests/unit/sam3-batch-v2.test.ts
@@ -229,6 +229,10 @@ describe('sam3-batch-v2', () => {
     const candidates = Array.from({ length: 401 }, (_, index) =>
       makeConceptDetection(index, 0.7 + index / 10_000)
     );
+    const resizeImage = vi.fn().mockResolvedValue({
+      buffer: Buffer.from('resized-2048-image'),
+      scaling: { scaleFactor: 0.5 },
+    });
     const refineInstances = vi.fn().mockImplementation(async ({ instances }) => ({
       success: true,
       response: {
@@ -255,6 +259,7 @@ describe('sam3-batch-v2', () => {
           ipAddress: '127.0.0.1',
         }),
         isReady: vi.fn().mockReturnValue(true),
+        resizeImage,
         refineInstances,
       } as any,
       acquireGpuLock: vi.fn(),
@@ -280,16 +285,18 @@ describe('sam3-batch-v2', () => {
       1,
     ]);
     expect(refineInstances.mock.calls[0][0]).toMatchObject({
-      image: Buffer.from('original-resolution-image').toString('base64'),
+      image: Buffer.from('resized-2048-image').toString('base64'),
       return_polygons: true,
       decode_batch: 32,
       polygon_resolution: 2048,
       score_threshold: 0.5,
     });
     expect(refineInstances.mock.calls[0][0].instances[0]).toMatchObject({
-      box: [0, 10, 6, 18],
-      positive_points: [[3, 14]],
+      box: [0, 5, 3, 9],
+      positive_points: [[2, 7]],
     });
+    expect(resizeImage).toHaveBeenCalledOnce();
+    expect(resizeImage).toHaveBeenCalledWith(Buffer.from('original-resolution-image'));
     expect(result).toMatchObject({
       refinementMode: 'instances',
       candidateBudget: 400,
@@ -306,7 +313,269 @@ describe('sam3-batch-v2', () => {
       confidence: candidates[1].similarity,
       similarity: candidates[1].similarity,
     });
-    expect(mappedSecondCandidate.bbox[0]).toBeGreaterThan(9_000);
+    expect(mappedSecondCandidate.bbox[0]).toBeGreaterThan(18_000);
+  });
+
+  it('retries a chunk with a missing id, then preserves the whole chunk as unrefined', async () => {
+    process.env.SAM3_REFINE_MODE = 'instances';
+    const candidates = [makeConceptDetection(0), makeConceptDetection(1)];
+    const refineInstances = vi.fn().mockImplementation(async ({ instances }) => ({
+      success: true,
+      response: {
+        instances: [{
+          id: instances[0].id,
+          polygon: [[0, 5], [3, 5], [3, 9]],
+          bbox_from_mask: [0, 5, 3, 9],
+          predicted_iou: 0.9,
+          score: 0.9,
+        }],
+        image_size: [2048, 1024],
+      },
+    }));
+    const resizeImage = vi.fn().mockResolvedValue({
+      buffer: Buffer.from('resized-image'),
+      scaling: { scaleFactor: 0.5 },
+    });
+    const service = new Sam3BatchV2Service({
+      prisma: {} as never,
+      awsSam3Service: {
+        refreshStatus: vi.fn().mockResolvedValue({
+          modelLoaded: true,
+          instanceState: 'ready',
+          ipAddress: '127.0.0.1',
+        }),
+        isReady: vi.fn().mockReturnValue(true),
+        resizeImage,
+        refineInstances,
+      } as any,
+      acquireGpuLock: vi.fn(),
+      refreshGpuLock: vi.fn(),
+      releaseGpuLock: vi.fn(),
+      sleep: vi.fn(),
+      now: () => new Date('2026-07-17T00:00:00.000Z'),
+    });
+
+    const result = await (service as any).refineConceptDetectionsWithBoxPrompts(
+      { id: 'asset-missing' },
+      Buffer.from('original-image'),
+      'Pine Sapling',
+      candidates,
+      { enabled: false, exemplarGreenMedian: 0.8 }
+    );
+
+    expect(refineInstances).toHaveBeenCalledTimes(2);
+    expect(resizeImage).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({
+      detections: candidates.map((candidate) => ({
+        bbox: candidate.bbox,
+        polygon: candidate.polygon,
+        confidence: candidate.similarity,
+        similarity: candidate.similarity,
+      })),
+      refineRefinedInstances: 0,
+      refineRejectedInstances: 0,
+      refineIncompleteChunks: 1,
+      usedCandidateFallback: true,
+      backendWarning: expect.stringContaining('saved 2 candidate(s) from 1 chunk(s)'),
+    });
+  });
+
+  it('retries a chunk with a duplicate id, then preserves the whole chunk as unrefined', async () => {
+    process.env.SAM3_REFINE_MODE = 'instances';
+    const candidates = [makeConceptDetection(0), makeConceptDetection(1)];
+    const refineInstances = vi.fn().mockImplementation(async ({ instances }) => {
+      const responseFor = (instance: any) => ({
+        id: instance.id,
+        polygon: [[0, 5], [3, 5], [3, 9]],
+        bbox_from_mask: [0, 5, 3, 9],
+        predicted_iou: 0.9,
+        score: 0.9,
+      });
+      return {
+        success: true,
+        response: {
+          instances: [
+            responseFor(instances[0]),
+            responseFor(instances[0]),
+            responseFor(instances[1]),
+          ],
+          image_size: [2048, 1024],
+        },
+      };
+    });
+    const service = new Sam3BatchV2Service({
+      prisma: {} as never,
+      awsSam3Service: {
+        refreshStatus: vi.fn().mockResolvedValue({
+          modelLoaded: true,
+          instanceState: 'ready',
+          ipAddress: '127.0.0.1',
+        }),
+        isReady: vi.fn().mockReturnValue(true),
+        resizeImage: vi.fn().mockResolvedValue({
+          buffer: Buffer.from('resized-image'),
+          scaling: { scaleFactor: 0.5 },
+        }),
+        refineInstances,
+      } as any,
+      acquireGpuLock: vi.fn(),
+      refreshGpuLock: vi.fn(),
+      releaseGpuLock: vi.fn(),
+      sleep: vi.fn(),
+      now: () => new Date('2026-07-17T00:00:00.000Z'),
+    });
+
+    const result = await (service as any).refineConceptDetectionsWithBoxPrompts(
+      { id: 'asset-duplicate' },
+      Buffer.from('original-image'),
+      'Pine Sapling',
+      candidates,
+      { enabled: false, exemplarGreenMedian: 0.8 }
+    );
+
+    expect(refineInstances).toHaveBeenCalledTimes(2);
+    expect(result.detections.map((detection: any) => detection.bbox)).toEqual(
+      candidates.map((candidate) => candidate.bbox)
+    );
+    expect(result).toMatchObject({
+      refineRefinedInstances: 0,
+      refineRejectedInstances: 0,
+      refineIncompleteChunks: 1,
+      usedCandidateFallback: true,
+    });
+  });
+
+  it('counts an explicit null polygon as a rejection without chunk fallback', async () => {
+    process.env.SAM3_REFINE_MODE = 'instances';
+    const candidates = [makeConceptDetection(0), makeConceptDetection(1)];
+    const refineInstances = vi.fn().mockImplementation(async ({ instances }) => ({
+      success: true,
+      response: {
+        instances: [
+          {
+            id: instances[0].id,
+            polygon: null,
+            bbox_from_mask: null,
+            predicted_iou: 0.4,
+            score: 0.4,
+          },
+          {
+            id: instances[1].id,
+            polygon: [[5, 5], [8, 5], [8, 9], [5, 9]],
+            bbox_from_mask: [5, 5, 8, 9],
+            predicted_iou: 0.9,
+            score: 0.9,
+          },
+        ],
+        image_size: [2048, 1024],
+      },
+    }));
+    const service = new Sam3BatchV2Service({
+      prisma: {} as never,
+      awsSam3Service: {
+        refreshStatus: vi.fn().mockResolvedValue({
+          modelLoaded: true,
+          instanceState: 'ready',
+          ipAddress: '127.0.0.1',
+        }),
+        isReady: vi.fn().mockReturnValue(true),
+        resizeImage: vi.fn().mockResolvedValue({
+          buffer: Buffer.from('resized-image'),
+          scaling: { scaleFactor: 0.5 },
+        }),
+        refineInstances,
+      } as any,
+      acquireGpuLock: vi.fn(),
+      refreshGpuLock: vi.fn(),
+      releaseGpuLock: vi.fn(),
+      sleep: vi.fn(),
+      now: () => new Date('2026-07-17T00:00:00.000Z'),
+    });
+
+    const result = await (service as any).refineConceptDetectionsWithBoxPrompts(
+      { id: 'asset-null' },
+      Buffer.from('original-image'),
+      'Pine Sapling',
+      candidates,
+      { enabled: false, exemplarGreenMedian: 0.8 }
+    );
+
+    expect(refineInstances).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({
+      detections: [{
+        bbox: [10, 10, 16, 18],
+        polygon: [[10, 10], [16, 10], [16, 18], [10, 18]],
+        confidence: candidates[1].similarity,
+        similarity: candidates[1].similarity,
+      }],
+      refineRefinedInstances: 1,
+      refineRejectedInstances: 1,
+      refineIncompleteChunks: 0,
+      usedCandidateFallback: false,
+    });
+  });
+
+  it('records incomplete refinement chunks on the per-asset stage log entry', async () => {
+    const stageLog: any[] = [];
+    const service = new Sam3BatchV2Service({
+      prisma: {} as never,
+      awsSam3Service: {} as never,
+      acquireGpuLock: vi.fn(),
+      refreshGpuLock: vi.fn(),
+      releaseGpuLock: vi.fn(),
+      sleep: vi.fn(),
+      now: () => new Date('2026-07-17T00:00:00.000Z'),
+    });
+    vi.spyOn(service as any, 'appendStageLog').mockImplementation(
+      async (_batchJobId: string, entries: any[], entry: any) => {
+        entries.push({ ...entry, timestamp: '2026-07-17T00:00:00.000Z' });
+      }
+    );
+    vi.spyOn(service as any, 'runVisualCropMatch').mockResolvedValue({
+      assetId: 'asset-stage-log',
+      detections: [],
+      outcome: 'zero_detections',
+      refinementMode: 'instances',
+      refineSentInstances: 2,
+      refineRefinedInstances: 0,
+      refineRejectedInstances: 0,
+      refineIncompleteChunks: 1,
+    });
+    vi.spyOn(service as any, 'persistAssetResult').mockResolvedValue(undefined);
+
+    await (service as any).runAndPersistBatch(
+      { updateProgress: vi.fn().mockResolvedValue(undefined) },
+      {
+        batchJobId: 'batch-stage-log',
+        parentBatchJobId: null,
+        mode: 'visual_crop_match',
+        weedType: 'Pine Sapling',
+        sourceAssetId: 'asset-stage-log',
+        exemplarCrops: [],
+        operatorCropCount: 0,
+        assets: [{
+          id: 'asset-stage-log',
+          storageUrl: 'http://localhost/asset-stage-log.jpg',
+          s3Key: null,
+          s3Bucket: null,
+          storageType: 'local',
+          imageWidth: 100,
+          imageHeight: 100,
+        }],
+        missingAssetIds: [],
+      },
+      0,
+      stageLog
+    );
+
+    expect(stageLog).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        stage: 'run_sam3',
+        status: 'completed',
+        assetId: 'asset-stage-log',
+        refineIncompleteChunks: 1,
+      }),
+    ]));
   });
 
   it('keeps the flag-off concept refinement request on the legacy segment path', async () => {
@@ -366,6 +635,63 @@ describe('sam3-batch-v2', () => {
       returnPolygons: true,
     });
     expect(refineInstances).not.toHaveBeenCalled();
+  });
+
+  it('keeps the flag-off concept apply request byte-identical to the legacy payload', async () => {
+    process.env.SAM3_REFINE_MODE = 'concept';
+    process.env.SAM3_RETRIEVAL_BACKEND = 'dinov3_vitl16_sat';
+    const image = await makeVegetationImage(10, 10, []);
+    const singleton = awsSam3Service as any;
+    const previous = {
+      configured: singleton.configured,
+      instanceIp: singleton.instanceIp,
+      instanceState: singleton.instanceState,
+    };
+    singleton.configured = true;
+    singleton.instanceIp = '127.0.0.1';
+    singleton.instanceState = 'ready';
+    global.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      results: [{ detections: [] }],
+      processing_time_ms: 4,
+    }), { status: 200, headers: { 'content-type': 'application/json' } })) as typeof fetch;
+
+    try {
+      const options = buildBatchV2ConceptApplyOptions('high_recall');
+      await awsSam3Service.applyConceptExemplar({
+        exemplarId: 'legacy-exemplar',
+        imageBuffer: image,
+        imageId: 'legacy-image',
+        options,
+      });
+
+      expect(resolveBatchV2RetrievalBackend()).toBeUndefined();
+      expect(options).toEqual({
+        returnPolygons: true,
+        similarityThreshold: 0.75,
+        topK: 180,
+        minBoxSize: 16,
+        maxBoxSize: 600,
+        nmsThreshold: 0.5,
+      });
+      expect(global.fetch).toHaveBeenCalledOnce();
+      const requestBody = (global.fetch as any).mock.calls[0][1].body;
+      const payload = JSON.parse(requestBody);
+      expect(requestBody).toBe(JSON.stringify({
+        exemplar_id: 'legacy-exemplar',
+        images: [payload.images[0]],
+        return_polygons: true,
+        image_ids: ['legacy-image'],
+        similarity_threshold: 0.75,
+        top_k: 180,
+        min_box_size: 16,
+        max_box_size: 600,
+        nms_threshold: 0.5,
+      }));
+    } finally {
+      singleton.configured = previous.configured;
+      singleton.instanceIp = previous.instanceIp;
+      singleton.instanceState = previous.instanceState;
+    }
   });
 
   it('truncates equal-score instance candidates deterministically at the configured budget', async () => {


### PR DESCRIPTION
## Summary
Client half of the evidence-backed pipeline overhaul (pairs with SAM3AWS PR #6; evidence + spec in `~/agridrone-pr2b-spec.md`).

Behind `SAM3_REFINE_MODE=instances` (default; `concept` = byte-identical legacy rollback, test-asserted):
- Refinement calls **`/refine_instances`** per-instance (candidate box + greenest-blob positive point + neighbour-centre negatives) and maps results by echoed id — **the 0.10-IoU re-association is deleted from this path**; provenance is 1:1 by construction.
- **Candidate budget 400** (configurable) with ranked truncation; widened server size-filter ratios (0.2×/2.5×); **DINOv3-satellite retrieval** requested with graceful DINOv2 fallback on backend-affinity 400s.
- Response-completeness validation: missing/duplicate ids → one retry → whole-chunk unrefined fallback (counted, never silent); explicit null polygons counted as rejections.
- Payloads use the existing 2048 resize path (prompts scaled out, coordinates scaled back) — original-resolution bodies measured as 16× heavier for zero mask fidelity.
- Vegetation gates, re-centring, mask gates, polygon dedup (#220) unchanged and still active around the new path.

## Review trail
Independent cold review: 2 P1 + 1 P2, all addressed (rollback backend leak, silent candidate loss on partial responses, payload size).

## Verification
148/148 unit tests (20 files), lint clean.

## Deploy
Requires SAM3AWS PR #6 deployed to the GPU instance first; then the post-deploy acceptance canary per spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)