### PR TITLE
Rapid Map: integrate flat-map-runner quality improvements (auto UTM, ASSET_SET, COG, honest counters)

### DIFF
--- a/Dockerfile.rapid-map-worker
+++ b/Dockerfile.rapid-map-worker
@@ -22,7 +22,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ARG FLAT_MAP_RUNNER_REPO=https://github.com/nationaldronesau/flat-map-runner.git
-ARG FLAT_MAP_RUNNER_REF=707ab72ffe90632f257fcdcaac9f357dba193b0b
+# TODO: update to merge commit once PR #1 merges
+ARG FLAT_MAP_RUNNER_REF=9cf7e77ee23a5df2e75b00c00475960412d9a9bb
 
 RUN git clone --depth 1 "${FLAT_MAP_RUNNER_REPO}" "${FLAT_MAP_RUNNER_DIR}" \
     && cd "${FLAT_MAP_RUNNER_DIR}" \

--- a/Dockerfile.rapid-map-worker
+++ b/Dockerfile.rapid-map-worker
@@ -22,8 +22,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ARG FLAT_MAP_RUNNER_REPO=https://github.com/nationaldronesau/flat-map-runner.git
-# TODO: update to merge commit once PR #1 merges
-ARG FLAT_MAP_RUNNER_REF=9cf7e77ee23a5df2e75b00c00475960412d9a9bb
+ARG FLAT_MAP_RUNNER_REF=f81a6c8a1f815a6d824a31e7053d6a556fad9a95
 
 RUN git clone --depth 1 "${FLAT_MAP_RUNNER_REPO}" "${FLAT_MAP_RUNNER_DIR}" \
     && cd "${FLAT_MAP_RUNNER_DIR}" \

--- a/Dockerfile.rapid-map-worker
+++ b/Dockerfile.rapid-map-worker
@@ -1,0 +1,60 @@
+FROM node:20-bookworm-slim
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV FLAT_MAP_RUNNER_DIR=/opt/flat-map-runner
+ENV FLAT_MAP_PYTHON=/opt/flatmap-venv/bin/python
+ENV RAPID_MAP_RUNNER_COMMAND=/opt/flatmap-venv/bin/python
+ENV RAPID_MAP_RUNNER_ARGS='["/app/scripts/run-rapid-map-flatmap.py"]'
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      gdal-bin \
+      git \
+      libgdal-dev \
+      python3 \
+      python3-venv \
+      python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG FLAT_MAP_RUNNER_REPO=https://github.com/nationaldronesau/flat-map-runner.git
+ARG FLAT_MAP_RUNNER_REF=707ab72ffe90632f257fcdcaac9f357dba193b0b
+
+RUN git clone --depth 1 "${FLAT_MAP_RUNNER_REPO}" "${FLAT_MAP_RUNNER_DIR}" \
+    && cd "${FLAT_MAP_RUNNER_DIR}" \
+    && git fetch --depth 1 origin "${FLAT_MAP_RUNNER_REF}" \
+    && git checkout "${FLAT_MAP_RUNNER_REF}" \
+    && python3 -m venv /opt/flatmap-venv \
+    && /opt/flatmap-venv/bin/pip install --no-cache-dir --upgrade pip \
+    && /opt/flatmap-venv/bin/pip install --no-cache-dir \
+      awscli \
+      numpy \
+      opencv-python-headless \
+      pillow \
+      pyproj \
+      rasterio
+
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+COPY prisma ./prisma/
+RUN npx prisma generate
+
+COPY tsconfig.json ./tsconfig.json
+COPY lib ./lib
+COPY workers ./workers
+COPY scripts ./scripts
+
+RUN groupadd --system --gid 1001 nodejs \
+    && useradd --system --uid 1001 --gid nodejs rapidmap \
+    && mkdir -p /app/tmp \
+    && chmod +x /app/scripts/run-rapid-map-flatmap.py \
+    && chown -R rapidmap:nodejs /app /app/tmp
+
+USER rapidmap
+
+CMD ["npm", "run", "worker:rapid-map"]

--- a/app/api/projects/[id]/rapid-map-runs/[runId]/route.ts
+++ b/app/api/projects/[id]/rapid-map-runs/[runId]/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/db";
+import { checkProjectAccess, getAuthenticatedUser } from "@/lib/auth/api-auth";
+
+function serializeRapidMapRun<T extends { createdAt: Date; updatedAt: Date; startedAt: Date | null; completedAt: Date | null }>(
+  run: T
+) {
+  return {
+    ...run,
+    createdAt: run.createdAt.toISOString(),
+    updatedAt: run.updatedAt.toISOString(),
+    startedAt: run.startedAt?.toISOString() ?? null,
+    completedAt: run.completedAt?.toISOString() ?? null,
+  };
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string; runId: string }> }
+) {
+  try {
+    const auth = await getAuthenticatedUser();
+    if (!auth.authenticated || !auth.userId) {
+      return NextResponse.json({ error: auth.error || "Unauthorized" }, { status: 401 });
+    }
+
+    const { id: projectId, runId } = await params;
+    const access = await checkProjectAccess(projectId);
+    if (!access.hasAccess || !access.teamId) {
+      return NextResponse.json({ error: access.error || "Access denied" }, { status: 403 });
+    }
+
+    const run = await prisma.rapidMapRun.findFirst({
+      where: {
+        id: runId,
+        projectId,
+        teamId: access.teamId,
+      },
+      include: {
+        orthomosaic: {
+          select: {
+            id: true,
+            name: true,
+            status: true,
+            tilesetPath: true,
+            s3TilesetKey: true,
+            bounds: true,
+            centerLat: true,
+            centerLon: true,
+          },
+        },
+      },
+    });
+
+    if (!run) {
+      return NextResponse.json({ error: "Rapid Map run not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ run: serializeRapidMapRun(run) });
+  } catch (error) {
+    console.error("Failed to fetch rapid map run:", error);
+    return NextResponse.json({ error: "Failed to fetch rapid map run" }, { status: 500 });
+  }
+}

--- a/app/api/projects/[id]/rapid-map-runs/route.ts
+++ b/app/api/projects/[id]/rapid-map-runs/route.ts
@@ -1,0 +1,290 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  Prisma,
+  RapidMapPreset,
+  RapidMapRunStatus,
+  RapidMapSourceType,
+} from "@prisma/client";
+import { z } from "zod";
+import prisma from "@/lib/db";
+import { checkProjectAccess, getAuthenticatedUser } from "@/lib/auth/api-auth";
+import { enqueueRapidMapRun } from "@/lib/queue/rapid-map-queue";
+import { S3Service } from "@/lib/services/s3";
+
+const createRapidMapRunSchema = z.object({
+  name: z.string().trim().min(1).max(160).optional(),
+  description: z.string().trim().max(2000).optional(),
+  sourceType: z
+    .nativeEnum(RapidMapSourceType)
+    .optional()
+    .default(RapidMapSourceType.S3_PREFIX),
+  sourcePath: z.string().trim().min(1).max(4000),
+  sourceAssetIds: z.array(z.string().min(1)).max(5000).optional(),
+  preset: z
+    .nativeEnum(RapidMapPreset)
+    .optional()
+    .default(RapidMapPreset.INITIAL_TRIAL),
+});
+
+function presetConfig(preset: RapidMapPreset): Prisma.InputJsonObject {
+  switch (preset) {
+    case RapidMapPreset.SHARPER_REVIEW:
+      return {
+        pixelSizeM: 0.2,
+        featherPx: 24,
+        maxSourcePx: 1536,
+        nadirPitchToleranceDeg: 15,
+        targetEpsg: "EPSG:32756",
+      };
+    case RapidMapPreset.COVERAGE_CHECK:
+      return {
+        pixelSizeM: 0.5,
+        featherPx: 16,
+        maxSourcePx: 768,
+        nadirPitchToleranceDeg: 20,
+        targetEpsg: "EPSG:32756",
+      };
+    case RapidMapPreset.INITIAL_TRIAL:
+    default:
+      return {
+        pixelSizeM: 0.3,
+        featherPx: 32,
+        maxSourcePx: 1024,
+        nadirPitchToleranceDeg: 15,
+        targetEpsg: "EPSG:32756",
+      };
+  }
+}
+
+function processingLog(
+  stage: string,
+  message: string,
+  details?: Prisma.InputJsonObject
+): Prisma.InputJsonObject {
+  return {
+    stage,
+    message,
+    timestamp: new Date().toISOString(),
+    ...(details ? { details } : {}),
+  };
+}
+
+function buildOutputPrefix(projectId: string, runId: string): string {
+  return `${S3Service.environmentSegment}/${projectId}/rapid-maps/${runId}`;
+}
+
+function serializeRapidMapRun<T extends { createdAt: Date; updatedAt: Date; startedAt: Date | null; completedAt: Date | null }>(
+  run: T
+) {
+  return {
+    ...run,
+    createdAt: run.createdAt.toISOString(),
+    updatedAt: run.updatedAt.toISOString(),
+    startedAt: run.startedAt?.toISOString() ?? null,
+    completedAt: run.completedAt?.toISOString() ?? null,
+  };
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const auth = await getAuthenticatedUser();
+    if (!auth.authenticated || !auth.userId) {
+      return NextResponse.json({ error: auth.error || "Unauthorized" }, { status: 401 });
+    }
+
+    const { id: projectId } = await params;
+    const access = await checkProjectAccess(projectId);
+    if (!access.hasAccess || !access.teamId) {
+      return NextResponse.json({ error: access.error || "Access denied" }, { status: 403 });
+    }
+
+    const status = request.nextUrl.searchParams.get("status");
+    const limit = Math.max(1, Math.min(100, Number(request.nextUrl.searchParams.get("limit") || "20")));
+    const offset = Math.max(0, Number(request.nextUrl.searchParams.get("offset") || "0"));
+
+    const where: Prisma.RapidMapRunWhereInput = {
+      teamId: access.teamId,
+      projectId,
+    };
+
+    if (status && Object.values(RapidMapRunStatus).includes(status as RapidMapRunStatus)) {
+      where.status = status as RapidMapRunStatus;
+    }
+
+    const [runs, total] = await Promise.all([
+      prisma.rapidMapRun.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+        take: limit,
+        skip: offset,
+        include: {
+          orthomosaic: {
+            select: {
+              id: true,
+              name: true,
+              status: true,
+              tilesetPath: true,
+              s3TilesetKey: true,
+            },
+          },
+        },
+      }),
+      prisma.rapidMapRun.count({ where }),
+    ]);
+
+    return NextResponse.json({
+      runs: runs.map((run) => serializeRapidMapRun(run)),
+      total,
+      limit,
+      offset,
+    });
+  } catch (error) {
+    console.error("Failed to list rapid map runs:", error);
+    return NextResponse.json({ error: "Failed to list rapid map runs" }, { status: 500 });
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const auth = await getAuthenticatedUser();
+    if (!auth.authenticated || !auth.userId) {
+      return NextResponse.json({ error: auth.error || "Unauthorized" }, { status: 401 });
+    }
+
+    const { id: projectId } = await params;
+    const access = await checkProjectAccess(projectId);
+    if (!access.hasAccess || !access.teamId) {
+      return NextResponse.json({ error: access.error || "Access denied" }, { status: 403 });
+    }
+
+    const payload = createRapidMapRunSchema.safeParse(await request.json().catch(() => ({})));
+    if (!payload.success) {
+      return NextResponse.json(
+        { error: "Invalid request body", details: payload.error.flatten() },
+        { status: 400 }
+      );
+    }
+
+    const runName =
+      payload.data.name ||
+      `Rapid Map - ${new Date().toLocaleDateString("en-AU", {
+        day: "2-digit",
+        month: "short",
+        year: "numeric",
+      })}`;
+
+    let run = await prisma.rapidMapRun.create({
+      data: {
+        teamId: access.teamId,
+        projectId,
+        createdById: auth.userId,
+        name: runName,
+        description: payload.data.description,
+        sourceType: payload.data.sourceType,
+        sourcePath: payload.data.sourcePath,
+        sourceAssetIds: payload.data.sourceAssetIds
+          ? (payload.data.sourceAssetIds as Prisma.InputJsonArray)
+          : Prisma.DbNull,
+        preset: payload.data.preset,
+        status: RapidMapRunStatus.QUEUED,
+        progress: 0,
+        config: {
+          preset: payload.data.preset,
+          sourceType: payload.data.sourceType,
+          runner: "flat-map-runner",
+          outputPrefixPattern: "{env}/{projectId}/rapid-maps/{runId}",
+          ...presetConfig(payload.data.preset),
+        },
+        outputS3Prefix: "",
+        outputBucket: S3Service.bucketName,
+        processingLog: processingLog(
+          "RECORDED",
+          "Rapid Map run recorded. Background processing is waiting to start."
+        ),
+      },
+    });
+
+    const outputS3Prefix = buildOutputPrefix(projectId, run.id);
+    run = await prisma.rapidMapRun.update({
+      where: { id: run.id },
+      data: { outputS3Prefix },
+    });
+
+    await prisma.auditLog.create({
+      data: {
+        action: "CREATE",
+        entityType: "RapidMapRun",
+        entityId: run.id,
+        userId: auth.userId,
+        beforeState: Prisma.JsonNull,
+        afterState: {
+          status: run.status,
+          projectId,
+          sourceType: payload.data.sourceType,
+          sourcePath: payload.data.sourcePath,
+          preset: payload.data.preset,
+          outputS3Prefix,
+        } as Prisma.InputJsonValue,
+      },
+    });
+
+    let queued = false;
+    let queueError: string | null = null;
+
+    try {
+      const queueJobId = await enqueueRapidMapRun({
+        runId: run.id,
+        projectId,
+        teamId: access.teamId,
+      });
+
+      queued = true;
+      run = await prisma.rapidMapRun.update({
+        where: { id: run.id },
+        data: {
+          queueJobId,
+          processingLog: processingLog(
+            "QUEUED",
+            "Rapid Map processing has been queued."
+          ),
+        },
+      });
+    } catch (error) {
+      queueError =
+        error instanceof Error
+          ? error.message
+          : "Rapid Map processing could not be queued.";
+
+      run = await prisma.rapidMapRun.update({
+        where: { id: run.id },
+        data: {
+          errorMessage: queueError,
+          processingLog: processingLog(
+            "QUEUE_UNAVAILABLE",
+            "Rapid Map run was recorded, but the processing queue is not available yet.",
+            { error: queueError }
+          ),
+        },
+      });
+    }
+
+    return NextResponse.json(
+      {
+        success: true,
+        queued,
+        queueError,
+        run: serializeRapidMapRun(run),
+      },
+      { status: 202 }
+    );
+  } catch (error) {
+    console.error("Failed to create rapid map run:", error);
+    return NextResponse.json({ error: "Failed to create rapid map run" }, { status: 500 });
+  }
+}

--- a/app/api/projects/[id]/rapid-map-runs/route.ts
+++ b/app/api/projects/[id]/rapid-map-runs/route.ts
@@ -61,6 +61,7 @@ function presetConfig(preset: RapidMapPreset): Prisma.InputJsonObject {
         maxSourcePx: 1536,
         nadirPitchToleranceDeg: 15,
         targetEpsg: "auto",
+        dem: "auto",
         blend: "center",
         cog: true,
       };
@@ -71,6 +72,7 @@ function presetConfig(preset: RapidMapPreset): Prisma.InputJsonObject {
         maxSourcePx: 768,
         nadirPitchToleranceDeg: 20,
         targetEpsg: "auto",
+        dem: "auto",
         blend: "center",
         cog: true,
       };
@@ -82,6 +84,7 @@ function presetConfig(preset: RapidMapPreset): Prisma.InputJsonObject {
         maxSourcePx: 1024,
         nadirPitchToleranceDeg: 15,
         targetEpsg: "auto",
+        dem: "auto",
         blend: "center",
         cog: true,
       };

--- a/app/api/projects/[id]/rapid-map-runs/route.ts
+++ b/app/api/projects/[id]/rapid-map-runs/route.ts
@@ -13,6 +13,7 @@ import {
   RapidMapAssetSetValidationError,
   resolveRapidMapAssetSet,
 } from "@/lib/services/rapid-map-asset-source";
+import { assertRapidMapProjectS3Prefix } from "@/lib/services/rapid-map-source-path";
 import { S3Service } from "@/lib/services/s3";
 
 const createRapidMapRunSchema = z
@@ -213,6 +214,22 @@ export async function POST(
         { error: "Invalid request body", details: payload.error.flatten() },
         { status: 400 }
       );
+    }
+
+    if (payload.data.sourceType === RapidMapSourceType.S3_PREFIX) {
+      try {
+        assertRapidMapProjectS3Prefix(payload.data.sourcePath!, projectId);
+      } catch (error) {
+        return NextResponse.json(
+          {
+            error:
+              error instanceof Error
+                ? error.message
+                : "Rapid Map S3 source prefix is invalid.",
+          },
+          { status: 400 }
+        );
+      }
     }
 
     if (payload.data.sourceType === RapidMapSourceType.ASSET_SET) {

--- a/app/api/projects/[id]/rapid-map-runs/route.ts
+++ b/app/api/projects/[id]/rapid-map-runs/route.ts
@@ -9,22 +9,47 @@ import { z } from "zod";
 import prisma from "@/lib/db";
 import { checkProjectAccess, getAuthenticatedUser } from "@/lib/auth/api-auth";
 import { enqueueRapidMapRun } from "@/lib/queue/rapid-map-queue";
+import {
+  RapidMapAssetSetValidationError,
+  resolveRapidMapAssetSet,
+} from "@/lib/services/rapid-map-asset-source";
 import { S3Service } from "@/lib/services/s3";
 
-const createRapidMapRunSchema = z.object({
-  name: z.string().trim().min(1).max(160).optional(),
-  description: z.string().trim().max(2000).optional(),
-  sourceType: z
-    .nativeEnum(RapidMapSourceType)
-    .optional()
-    .default(RapidMapSourceType.S3_PREFIX),
-  sourcePath: z.string().trim().min(1).max(4000),
-  sourceAssetIds: z.array(z.string().min(1)).max(5000).optional(),
-  preset: z
-    .nativeEnum(RapidMapPreset)
-    .optional()
-    .default(RapidMapPreset.INITIAL_TRIAL),
-});
+const createRapidMapRunSchema = z
+  .object({
+    name: z.string().trim().min(1).max(160).optional(),
+    description: z.string().trim().max(2000).optional(),
+    sourceType: z
+      .nativeEnum(RapidMapSourceType)
+      .optional()
+      .default(RapidMapSourceType.S3_PREFIX),
+    sourcePath: z.string().trim().min(1).max(4000).optional(),
+    sourceAssetIds: z.array(z.string().min(1)).max(5000).optional(),
+    preset: z
+      .nativeEnum(RapidMapPreset)
+      .optional()
+      .default(RapidMapPreset.INITIAL_TRIAL),
+  })
+  .superRefine((value, context) => {
+    if (value.sourceType === RapidMapSourceType.ASSET_SET) {
+      if (!value.sourceAssetIds?.length) {
+        context.addIssue({
+          code: "custom",
+          path: ["sourceAssetIds"],
+          message: "ASSET_SET requires source asset ids.",
+        });
+      }
+      return;
+    }
+
+    if (!value.sourcePath) {
+      context.addIssue({
+        code: "custom",
+        path: ["sourcePath"],
+        message: `${value.sourceType} requires a source path.`,
+      });
+    }
+  });
 
 function presetConfig(preset: RapidMapPreset): Prisma.InputJsonObject {
   switch (preset) {
@@ -34,7 +59,9 @@ function presetConfig(preset: RapidMapPreset): Prisma.InputJsonObject {
         featherPx: 24,
         maxSourcePx: 1536,
         nadirPitchToleranceDeg: 15,
-        targetEpsg: "EPSG:32756",
+        targetEpsg: "auto",
+        blend: "center",
+        cog: true,
       };
     case RapidMapPreset.COVERAGE_CHECK:
       return {
@@ -42,7 +69,9 @@ function presetConfig(preset: RapidMapPreset): Prisma.InputJsonObject {
         featherPx: 16,
         maxSourcePx: 768,
         nadirPitchToleranceDeg: 20,
-        targetEpsg: "EPSG:32756",
+        targetEpsg: "auto",
+        blend: "center",
+        cog: true,
       };
     case RapidMapPreset.INITIAL_TRIAL:
     default:
@@ -51,7 +80,9 @@ function presetConfig(preset: RapidMapPreset): Prisma.InputJsonObject {
         featherPx: 32,
         maxSourcePx: 1024,
         nadirPitchToleranceDeg: 15,
-        targetEpsg: "EPSG:32756",
+        targetEpsg: "auto",
+        blend: "center",
+        cog: true,
       };
   }
 }
@@ -67,6 +98,19 @@ function processingLog(
     timestamp: new Date().toISOString(),
     ...(details ? { details } : {}),
   };
+}
+
+function appendProcessingLog(
+  current: Prisma.JsonValue | null,
+  entry: Prisma.InputJsonObject
+): Prisma.InputJsonArray {
+  const existing = Array.isArray(current)
+    ? (current.filter(Boolean) as Prisma.InputJsonArray)
+    : current && typeof current === "object"
+      ? [current as Prisma.InputJsonObject]
+      : [];
+
+  return [...existing, entry];
 }
 
 function buildOutputPrefix(projectId: string, runId: string): string {
@@ -171,6 +215,13 @@ export async function POST(
       );
     }
 
+    if (payload.data.sourceType === RapidMapSourceType.ASSET_SET) {
+      await resolveRapidMapAssetSet(
+        access.teamId,
+        payload.data.sourceAssetIds || []
+      );
+    }
+
     const runName =
       payload.data.name ||
       `Rapid Map - ${new Date().toLocaleDateString("en-AU", {
@@ -187,7 +238,7 @@ export async function POST(
         name: runName,
         description: payload.data.description,
         sourceType: payload.data.sourceType,
-        sourcePath: payload.data.sourcePath,
+        sourcePath: payload.data.sourcePath ?? null,
         sourceAssetIds: payload.data.sourceAssetIds
           ? (payload.data.sourceAssetIds as Prisma.InputJsonArray)
           : Prisma.DbNull,
@@ -227,7 +278,7 @@ export async function POST(
           status: run.status,
           projectId,
           sourceType: payload.data.sourceType,
-          sourcePath: payload.data.sourcePath,
+          sourcePath: payload.data.sourcePath ?? null,
           preset: payload.data.preset,
           outputS3Prefix,
         } as Prisma.InputJsonValue,
@@ -249,9 +300,9 @@ export async function POST(
         where: { id: run.id },
         data: {
           queueJobId,
-          processingLog: processingLog(
-            "QUEUED",
-            "Rapid Map processing has been queued."
+          processingLog: appendProcessingLog(
+            run.processingLog,
+            processingLog("QUEUED", "Rapid Map processing has been queued.")
           ),
         },
       });
@@ -265,10 +316,13 @@ export async function POST(
         where: { id: run.id },
         data: {
           errorMessage: queueError,
-          processingLog: processingLog(
-            "QUEUE_UNAVAILABLE",
-            "Rapid Map run was recorded, but the processing queue is not available yet.",
-            { error: queueError }
+          processingLog: appendProcessingLog(
+            run.processingLog,
+            processingLog(
+              "QUEUE_UNAVAILABLE",
+              "Rapid Map run was recorded, but the processing queue is not available yet.",
+              { error: queueError }
+            )
           ),
         },
       });
@@ -284,6 +338,10 @@ export async function POST(
       { status: 202 }
     );
   } catch (error) {
+    if (error instanceof RapidMapAssetSetValidationError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
     console.error("Failed to create rapid map run:", error);
     return NextResponse.json({ error: "Failed to create rapid map run" }, { status: 500 });
   }

--- a/app/orthomosaics/page.tsx
+++ b/app/orthomosaics/page.tsx
@@ -8,7 +8,18 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { MapPin, Calendar, Mountain, AlertCircle, CheckCircle, Clock, Loader2 } from 'lucide-react';
+import {
+  AlertCircle,
+  Calendar,
+  CheckCircle,
+  Clock,
+  Loader2,
+  MapPin,
+  Mountain,
+  Server,
+  ShieldCheck,
+  SlidersHorizontal,
+} from 'lucide-react';
 import { formatBytes, formatDate } from '@/lib/utils';
 import { OrthomosaicUploader } from '@/components/OrthomosaicUploader';
 
@@ -38,6 +49,26 @@ interface Project {
   location: string | null;
 }
 
+interface RapidMapRun {
+  id: string;
+  name: string;
+  sourceType: 'S3_PREFIX' | 'ASSET_SET' | 'PROCESSING_NODE_PATH';
+  sourcePath: string | null;
+  preset: 'INITIAL_TRIAL' | 'SHARPER_REVIEW' | 'COVERAGE_CHECK';
+  status: 'QUEUED' | 'PROCESSING' | 'COMPLETED' | 'FAILED' | 'CANCELLED';
+  progress: number;
+  errorMessage: string | null;
+  sourceImageCount: number | null;
+  renderedImageCount: number | null;
+  excludedImageCount: number | null;
+  createdAt: string;
+  orthomosaic: {
+    id: string;
+    name: string;
+    status: string;
+  } | null;
+}
+
 export default function OrthomosaicsPage() {
   const [orthomosaics, setOrthomosaics] = useState<Orthomosaic[]>([]);
   const [projects, setProjects] = useState<Project[]>([]);
@@ -50,11 +81,51 @@ export default function OrthomosaicsPage() {
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [orthomosaicsError, setOrthomosaicsError] = useState<string | null>(null);
   const [projectsError, setProjectsError] = useState<string | null>(null);
+  const [rapidMapProjectId, setRapidMapProjectId] = useState<string>('');
+  const [rapidMapSourceType, setRapidMapSourceType] = useState<string>('S3_PREFIX');
+  const [rapidMapSource, setRapidMapSource] = useState<string>('');
+  const [rapidMapPreset, setRapidMapPreset] = useState<string>('INITIAL_TRIAL');
+  const [rapidMapRuns, setRapidMapRuns] = useState<RapidMapRun[]>([]);
+  const [rapidMapRunsLoading, setRapidMapRunsLoading] = useState<boolean>(false);
+  const [rapidMapSubmitting, setRapidMapSubmitting] = useState<boolean>(false);
+  const [rapidMapError, setRapidMapError] = useState<string | null>(null);
+  const [rapidMapSuccess, setRapidMapSuccess] = useState<string | null>(null);
 
   useEffect(() => {
     fetchOrthomosaics();
     fetchProjects();
   }, []);
+
+  useEffect(() => {
+    if (projects.length > 0 && !rapidMapProjectId) {
+      setRapidMapProjectId(projects[0].id);
+    }
+  }, [projects, rapidMapProjectId]);
+
+  useEffect(() => {
+    if (!rapidMapProjectId) {
+      setRapidMapRuns([]);
+      return;
+    }
+
+    fetchRapidMapRuns(rapidMapProjectId);
+  }, [rapidMapProjectId]);
+
+  useEffect(() => {
+    if (!rapidMapProjectId) {
+      return;
+    }
+
+    if (!rapidMapRuns.some((run) => ['QUEUED', 'PROCESSING'].includes(run.status))) {
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      fetchRapidMapRuns(rapidMapProjectId);
+    }, 10000);
+
+    return () => window.clearInterval(interval);
+  }, [rapidMapProjectId, rapidMapRuns]);
 
   const fetchOrthomosaics = async () => {
     try {
@@ -107,6 +178,60 @@ export default function OrthomosaicsPage() {
     setProcessingError(error.message);
   };
 
+  const fetchRapidMapRuns = async (projectId: string) => {
+    try {
+      setRapidMapRunsLoading(true);
+      const response = await fetch(`/api/projects/${projectId}/rapid-map-runs?limit=5`);
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to load Rapid Map runs');
+      }
+
+      setRapidMapRuns(data.runs || []);
+    } catch (error) {
+      console.error('Error fetching Rapid Map runs:', error);
+      setRapidMapError(error instanceof Error ? error.message : 'Failed to load Rapid Map runs');
+    } finally {
+      setRapidMapRunsLoading(false);
+    }
+  };
+
+  const handleRapidMapSubmit = async () => {
+    if (!rapidMapProjectId || !rapidMapSource.trim()) {
+      return;
+    }
+
+    try {
+      setRapidMapSubmitting(true);
+      setRapidMapError(null);
+      setRapidMapSuccess(null);
+
+      const response = await fetch(`/api/projects/${rapidMapProjectId}/rapid-map-runs`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sourceType: rapidMapSourceType,
+          sourcePath: rapidMapSource.trim(),
+          preset: rapidMapPreset,
+        }),
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to queue Rapid Map');
+      }
+
+      setRapidMapSuccess(data.queued ? 'Rapid Map queued.' : 'Rapid Map recorded. Worker queue is not available yet.');
+      setRapidMapSource('');
+      await fetchRapidMapRuns(rapidMapProjectId);
+    } catch (error) {
+      setRapidMapError(error instanceof Error ? error.message : 'Failed to queue Rapid Map');
+    } finally {
+      setRapidMapSubmitting(false);
+    }
+  };
+
   const getStatusIcon = (status: string) => {
     switch (status) {
       case 'COMPLETED':
@@ -130,6 +255,32 @@ export default function OrthomosaicsPage() {
         return 'Processing failed';
       default:
         return 'Waiting to process';
+    }
+  };
+
+  const getRapidMapStatusClass = (status: RapidMapRun['status']) => {
+    switch (status) {
+      case 'COMPLETED':
+        return 'border-green-200 bg-green-50 text-green-700';
+      case 'PROCESSING':
+        return 'border-blue-200 bg-blue-50 text-blue-700';
+      case 'FAILED':
+        return 'border-red-200 bg-red-50 text-red-700';
+      case 'CANCELLED':
+        return 'border-gray-200 bg-gray-50 text-gray-700';
+      default:
+        return 'border-amber-200 bg-amber-50 text-amber-700';
+    }
+  };
+
+  const formatRapidMapPreset = (preset: RapidMapRun['preset'] | string) => {
+    switch (preset) {
+      case 'SHARPER_REVIEW':
+        return 'Sharper review';
+      case 'COVERAGE_CHECK':
+        return 'Coverage check';
+      default:
+        return 'Initial trial';
     }
   };
 
@@ -250,6 +401,183 @@ export default function OrthomosaicsPage() {
                 {successMessage}
               </div>
             )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="mb-8 bg-white shadow-lg border-0 rounded-lg">
+        <CardHeader>
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <CardTitle className="text-xl font-semibold text-gray-900">Generate Rapid Map</CardTitle>
+              <CardDescription className="text-gray-600">
+                Queue a metadata-driven map from uploaded flight imagery for quick review before detection fusion and spray export.
+              </CardDescription>
+            </div>
+            <Server className="h-6 w-6 text-blue-600" />
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-4 lg:grid-cols-[1fr_1fr]">
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="rapidMapProject">Project</Label>
+                <Select value={rapidMapProjectId} onValueChange={setRapidMapProjectId}>
+                  <SelectTrigger id="rapidMapProject">
+                    <SelectValue placeholder="Choose a project" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {projects.map((project) => (
+                      <SelectItem key={project.id} value={project.id}>
+                        {project.name} {project.location && `- ${project.location}`}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="rapidMapSourceType">Source type</Label>
+                  <Select value={rapidMapSourceType} onValueChange={setRapidMapSourceType}>
+                    <SelectTrigger id="rapidMapSourceType">
+                      <SelectValue placeholder="Uploaded images / S3 folder" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="S3_PREFIX">Uploaded images / S3 folder</SelectItem>
+                      <SelectItem value="PROCESSING_NODE_PATH">Processing-node folder</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="rapidMapPreset">Processing preset</Label>
+                  <Select value={rapidMapPreset} onValueChange={setRapidMapPreset}>
+                    <SelectTrigger id="rapidMapPreset">
+                      <SelectValue placeholder="Initial trial - 0.3 m/px" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="INITIAL_TRIAL">Initial trial - 0.3 m/px</SelectItem>
+                      <SelectItem value="SHARPER_REVIEW">Sharper review - 0.2 m/px</SelectItem>
+                      <SelectItem value="COVERAGE_CHECK">Coverage check - faster preview</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="rapidMapSource">Source images</Label>
+                <Input
+                  id="rapidMapSource"
+                  placeholder={
+                    rapidMapSourceType === 'S3_PREFIX'
+                      ? 'S3 prefix or flight session'
+                      : 'Processing-node image folder'
+                  }
+                  value={rapidMapSource}
+                  onChange={(event) => setRapidMapSource(event.target.value)}
+                />
+              </div>
+
+              <div className="grid gap-2 text-sm text-gray-600 md:grid-cols-3">
+                <div className="flex items-center gap-2 rounded-md border border-gray-100 bg-gray-50 px-3 py-2">
+                  <Server className="h-4 w-4 text-blue-600" />
+                  <span>Worker run</span>
+                </div>
+                <div className="flex items-center gap-2 rounded-md border border-gray-100 bg-gray-50 px-3 py-2">
+                  <SlidersHorizontal className="h-4 w-4 text-green-600" />
+                  <span>Map preview</span>
+                </div>
+                <div className="flex items-center gap-2 rounded-md border border-gray-100 bg-gray-50 px-3 py-2">
+                  <ShieldCheck className="h-4 w-4 text-amber-600" />
+                  <span>Review first</span>
+                </div>
+              </div>
+
+              {rapidMapError && (
+                <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+                  {rapidMapError}
+                </div>
+              )}
+
+              {rapidMapSuccess && (
+                <div className="rounded-lg border border-green-200 bg-green-50 p-3 text-sm text-green-800">
+                  {rapidMapSuccess}
+                </div>
+              )}
+
+              <Button
+                className="w-full bg-gradient-to-r from-green-500 to-blue-500 text-white hover:from-green-600 hover:to-blue-600"
+                disabled={!rapidMapProjectId || !rapidMapSource.trim() || rapidMapSubmitting}
+                onClick={handleRapidMapSubmit}
+              >
+                {rapidMapSubmitting ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Queueing Rapid Map...
+                  </>
+                ) : rapidMapProjectId && rapidMapSource.trim() ? (
+                  'Queue Rapid Map'
+                ) : (
+                  'Select project and source'
+                )}
+              </Button>
+            </div>
+
+            <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+              <div className="mb-3 flex items-center justify-between">
+                <p className="text-sm font-medium text-gray-900">Recent Rapid Map runs</p>
+                {rapidMapRunsLoading && (
+                  <Loader2 className="h-4 w-4 animate-spin text-gray-500" />
+                )}
+              </div>
+
+              {!rapidMapProjectId ? (
+                <p className="text-sm text-gray-500">Select a project to see recent runs.</p>
+              ) : rapidMapRuns.length === 0 && !rapidMapRunsLoading ? (
+                <p className="text-sm text-gray-500">No Rapid Map runs yet.</p>
+              ) : (
+                <div className="space-y-3">
+                  {rapidMapRuns.map((run) => (
+                    <div key={run.id} className="rounded-md border border-white bg-white p-3 shadow-sm">
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="text-sm font-medium text-gray-900">{run.name}</p>
+                          <p className="text-xs text-gray-500">
+                            {formatRapidMapPreset(run.preset)} · {run.sourcePath || 'Source pending'}
+                          </p>
+                        </div>
+                        <span className={`rounded-full border px-2 py-1 text-xs font-medium ${getRapidMapStatusClass(run.status)}`}>
+                          {run.status.toLowerCase()}
+                        </span>
+                      </div>
+
+                      <div className="mt-2 h-2 overflow-hidden rounded-full bg-gray-100">
+                        <div
+                          className="h-full rounded-full bg-gradient-to-r from-green-500 to-blue-500"
+                          style={{ width: `${Math.max(0, Math.min(100, run.progress || 0))}%` }}
+                        />
+                      </div>
+
+                      <div className="mt-2 flex items-center justify-between text-xs text-gray-500">
+                        <span>{run.sourceImageCount ?? 0} source images</span>
+                        {run.orthomosaic ? (
+                          <Link href={`/orthomosaics/${run.orthomosaic.id}`} className="font-medium text-blue-600 hover:text-blue-700">
+                            View generated map
+                          </Link>
+                        ) : (
+                          <span>{run.progress || 0}%</span>
+                        )}
+                      </div>
+
+                      {run.errorMessage && (
+                        <p className="mt-2 text-xs text-red-600">{run.errorMessage}</p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
           </div>
         </CardContent>
       </Card>

--- a/docs/RAPID_MAP_AWS_WORKER.md
+++ b/docs/RAPID_MAP_AWS_WORKER.md
@@ -5,7 +5,7 @@ Rapid Map processing runs outside the Next.js web server. The web app creates a
 
 The worker image uses
 [`nationaldronesau/flat-map-runner`](https://github.com/nationaldronesau/flat-map-runner)
-at commit `707ab72ffe90632f257fcdcaac9f357dba193b0b`. That engine is a
+at commit `f81a6c8a1f815a6d824a31e7053d6a556fad9a95`. That engine is a
 metadata-driven rapid map generator using rasterio/GDAL, pyproj, OpenCV, Pillow,
 and numpy. It is not ODM, SfM, or full photogrammetry.
 
@@ -58,6 +58,10 @@ s3://agridrone-ops-production/production/{projectId}/raw-images/{flightSession}/
   DJI_0001.JPG
   DJI_0002.JPG
 ```
+
+The API only accepts S3 prefixes under the selected project's current
+environment path (`{environment}/{projectId}/`) so one project cannot dispatch
+the worker against another project's imagery.
 
 The adapter also accepts:
 

--- a/docs/RAPID_MAP_AWS_WORKER.md
+++ b/docs/RAPID_MAP_AWS_WORKER.md
@@ -1,0 +1,140 @@
+# Rapid Map AWS Worker
+
+Rapid Map processing runs outside the Next.js web server. The web app creates a
+`RapidMapRun`, enqueues `rapid-map-processing`, and the worker consumes that job.
+
+The worker image uses
+[`nationaldronesau/flat-map-runner`](https://github.com/nationaldronesau/flat-map-runner)
+at commit `707ab72ffe90632f257fcdcaac9f357dba193b0b`. That engine is a
+metadata-driven rapid map generator using rasterio/GDAL, pyproj, OpenCV, Pillow,
+and numpy. It is not ODM, SfM, or full photogrammetry.
+
+## Build
+
+```bash
+docker build -f Dockerfile.rapid-map-worker -t agridrone-rapid-map-worker .
+```
+
+## Runtime
+
+```bash
+npm run worker:rapid-map
+```
+
+Required production services:
+
+- RDS/MySQL via `DATABASE_URL`
+- Redis/ElastiCache via `REDIS_URL`
+- S3 via `AWS_REGION` and `AWS_S3_BUCKET`
+- IAM access for S3 read/write
+
+Rapid Map runner configuration:
+
+- `RAPID_MAP_RUNNER_COMMAND`: executable path for the map engine wrapper
+- `RAPID_MAP_RUNNER_ARGS`: optional JSON string array of extra args
+- `RAPID_MAP_RUNNER_TIMEOUT_MS`: optional timeout, default 6 hours
+- `RAPID_MAP_WORKER_CONCURRENCY`: optional concurrency, default 1
+- `RAPID_MAP_KEEP_WORKDIR=1`: keep temp job files for debugging
+
+The default worker image sets:
+
+```bash
+RAPID_MAP_RUNNER_COMMAND=/opt/flatmap-venv/bin/python
+RAPID_MAP_RUNNER_ARGS='["/app/scripts/run-rapid-map-flatmap.py"]'
+FLAT_MAP_RUNNER_DIR=/opt/flat-map-runner
+FLAT_MAP_PYTHON=/opt/flatmap-venv/bin/python
+```
+
+## Source Folder Contract
+
+For the first production path, the source must contain imagery and a
+`metadata.csv` compatible with `flat-map-runner`.
+
+For an S3 source prefix:
+
+```text
+s3://agridrone-ops-production/production/{projectId}/raw-images/{flightSession}/
+  metadata.csv
+  DJI_0001.JPG
+  DJI_0002.JPG
+```
+
+The adapter also accepts:
+
+```text
+...
+  images/
+    DJI_0001.JPG
+    DJI_0002.JPG
+  metadata.csv
+```
+
+`metadata.csv` minimum columns:
+
+```text
+filename,lat,lon,RelativeAltitude,FlightYawDegree
+```
+
+Recommended columns:
+
+```text
+filename,lat,lon,AbsoluteAltitude,RelativeAltitude,FlightYawDegree,GimbalPitchDegree,GimbalRollDegree,ImageWidth,ImageLength
+```
+
+## Runner Contract
+
+The worker calls:
+
+```bash
+$RAPID_MAP_RUNNER_COMMAND --job /tmp/.../rapid-map-job.json --output /tmp/.../output
+```
+
+The runner must write:
+
+```text
+/tmp/.../output/manifest.json
+```
+
+Minimum manifest shape:
+
+```json
+{
+  "version": 1,
+  "summary": {
+    "sourceImageCount": 999,
+    "renderedImageCount": 999,
+    "excludedImageCount": 0,
+    "estimatedErrorMeters": 1.5
+  },
+  "artifacts": [
+    {
+      "path": "rapid-map.tif",
+      "role": "geotiff",
+      "contentType": "image/tiff"
+    },
+    {
+      "path": "preview.png",
+      "role": "preview",
+      "contentType": "image/png"
+    }
+  ],
+  "orthomosaic": {
+    "name": "Rapid Map",
+    "bounds": {
+      "type": "Polygon",
+      "coordinates": []
+    },
+    "centerLat": -27.4698,
+    "centerLon": 153.0251,
+    "resolutionCmPerPixel": 30,
+    "imageCount": 999
+  }
+}
+```
+
+The worker uploads listed artifacts to S3 under the run output prefix, creates
+an `Orthomosaic` when the manifest includes the required map metadata, and marks
+the `RapidMapRun` as `COMPLETED`.
+
+If `RAPID_MAP_RUNNER_COMMAND` is not configured, jobs fail clearly with a
+configuration error instead of silently sitting in the queue.

--- a/lib/queue/rapid-map-queue.ts
+++ b/lib/queue/rapid-map-queue.ts
@@ -29,7 +29,11 @@ export function getRapidMapQueue(): Queue<RapidMapJobData, RapidMapJobResult> {
         connection: createRedisConnection(),
         prefix: QUEUE_PREFIX,
         defaultJobOptions: {
-          attempts: 1,
+          attempts: 2,
+          backoff: {
+            type: "exponential",
+            delay: 60_000,
+          },
           removeOnComplete: {
             age: 24 * 60 * 60,
             count: 200,

--- a/lib/queue/rapid-map-queue.ts
+++ b/lib/queue/rapid-map-queue.ts
@@ -1,0 +1,82 @@
+import { Queue } from "bullmq";
+import { createRedisConnection, QUEUE_PREFIX } from "./redis";
+
+export interface RapidMapJobData {
+  runId: string;
+  projectId: string;
+  teamId: string;
+}
+
+export interface RapidMapJobResult {
+  runId: string;
+  orthomosaicId?: string;
+  sourceImageCount?: number;
+  renderedImageCount?: number;
+  excludedImageCount?: number;
+  artifactCount?: number;
+  storageType: "s3" | "local";
+}
+
+export const RAPID_MAP_QUEUE_NAME = "rapid-map-processing";
+
+let rapidMapQueue: Queue<RapidMapJobData, RapidMapJobResult> | null = null;
+
+export function getRapidMapQueue(): Queue<RapidMapJobData, RapidMapJobResult> {
+  if (!rapidMapQueue) {
+    rapidMapQueue = new Queue<RapidMapJobData, RapidMapJobResult>(
+      RAPID_MAP_QUEUE_NAME,
+      {
+        connection: createRedisConnection(),
+        prefix: QUEUE_PREFIX,
+        defaultJobOptions: {
+          attempts: 1,
+          removeOnComplete: {
+            age: 24 * 60 * 60,
+            count: 200,
+          },
+          removeOnFail: {
+            age: 7 * 24 * 60 * 60,
+          },
+        },
+      }
+    );
+  }
+
+  return rapidMapQueue;
+}
+
+export async function enqueueRapidMapRun(data: RapidMapJobData): Promise<string> {
+  const queue = getRapidMapQueue();
+  const existingJob = await queue.getJob(data.runId);
+
+  if (existingJob) {
+    const state = await existingJob.getState();
+    if (state === "waiting" || state === "active" || state === "delayed") {
+      return existingJob.id || data.runId;
+    }
+
+    try {
+      await existingJob.remove();
+    } catch {
+      // Let the replacement add fail if BullMQ still owns the old record.
+    }
+  }
+
+  const job = await queue.add("process-rapid-map", data, {
+    jobId: data.runId,
+  });
+
+  return job.id || data.runId;
+}
+
+export async function getRapidMapQueueStats() {
+  const queue = getRapidMapQueue();
+  const [waiting, active, completed, failed] = await Promise.all([
+    queue.getWaitingCount(),
+    queue.getActiveCount(),
+    queue.getCompletedCount(),
+    queue.getFailedCount(),
+  ]);
+
+  return { waiting, active, completed, failed };
+}

--- a/lib/services/rapid-map-asset-metadata.ts
+++ b/lib/services/rapid-map-asset-metadata.ts
@@ -1,0 +1,140 @@
+import path from "path";
+
+export const RAPID_MAP_METADATA_COLUMNS = [
+  "filename",
+  "lat",
+  "lon",
+  "AbsoluteAltitude",
+  "RelativeAltitude",
+  "FlightYawDegree",
+  "GimbalYawDegree",
+  "GimbalPitchDegree",
+  "GimbalRollDegree",
+  "ImageWidth",
+  "ImageLength",
+] as const;
+
+export interface RapidMapMetadataAsset {
+  id: string;
+  fileName: string;
+  s3Key: string | null;
+  metadata: unknown;
+  gpsLatitude: number | null;
+  gpsLongitude: number | null;
+  altitude: number | null;
+  gimbalRoll: number | null;
+  gimbalPitch: number | null;
+  gimbalYaw: number | null;
+  imageWidth: number | null;
+  imageHeight: number | null;
+}
+
+export interface ExcludedRapidMapMetadataAsset {
+  id: string;
+  fileName: string;
+  missingFields: Array<"gpsLatitude" | "gpsLongitude" | "altitude">;
+}
+
+export interface RapidMapAssetObject {
+  s3Key: string;
+  filename: string;
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  return undefined;
+}
+
+function metadataNumber(metadata: unknown, keys: string[]): number | undefined {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return undefined;
+  }
+
+  const record = metadata as Record<string, unknown>;
+  for (const key of keys) {
+    const value = finiteNumber(record[key]);
+    if (value !== undefined) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function csvCell(value: string | number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  const text = String(value);
+  if (/[",\r\n]/.test(text)) {
+    return `"${text.replace(/"/g, '""')}"`;
+  }
+
+  return text;
+}
+
+export function buildAssetSetMetadataCsv(assets: RapidMapMetadataAsset[]): {
+  csv: string;
+  assetObjects: RapidMapAssetObject[];
+  excludedAssets: ExcludedRapidMapMetadataAsset[];
+} {
+  const rows: Array<Array<string | number | null | undefined>> = [];
+  const assetObjects: RapidMapAssetObject[] = [];
+  const excludedAssets: ExcludedRapidMapMetadataAsset[] = [];
+
+  for (const asset of assets) {
+    const missingFields: ExcludedRapidMapMetadataAsset["missingFields"] = [];
+    if (finiteNumber(asset.gpsLatitude) === undefined) missingFields.push("gpsLatitude");
+    if (finiteNumber(asset.gpsLongitude) === undefined) missingFields.push("gpsLongitude");
+    if (finiteNumber(asset.altitude) === undefined) missingFields.push("altitude");
+
+    if (missingFields.length > 0) {
+      excludedAssets.push({
+        id: asset.id,
+        fileName: asset.fileName,
+        missingFields,
+      });
+      continue;
+    }
+
+    if (!asset.s3Key) {
+      throw new Error(`Rapid Map asset ${asset.id} (${asset.fileName}) is missing an S3 key.`);
+    }
+
+    const filename = path.basename(asset.s3Key);
+    if (!filename) {
+      throw new Error(`Rapid Map asset ${asset.id} has an invalid S3 key.`);
+    }
+
+    rows.push([
+      filename,
+      asset.gpsLatitude,
+      asset.gpsLongitude,
+      asset.altitude,
+      metadataNumber(asset.metadata, ["RelativeAltitude", "drone-dji:RelativeAltitude"]),
+      metadataNumber(asset.metadata, ["FlightYawDegree", "drone-dji:FlightYawDegree"]),
+      asset.gimbalYaw,
+      asset.gimbalPitch,
+      asset.gimbalRoll,
+      asset.imageWidth,
+      asset.imageHeight,
+    ]);
+    assetObjects.push({ s3Key: asset.s3Key, filename });
+  }
+
+  const csv = [
+    RAPID_MAP_METADATA_COLUMNS.join(","),
+    ...rows.map((row) => row.map(csvCell).join(",")),
+  ].join("\n") + "\n";
+
+  return { csv, assetObjects, excludedAssets };
+}

--- a/lib/services/rapid-map-asset-source.ts
+++ b/lib/services/rapid-map-asset-source.ts
@@ -1,0 +1,105 @@
+import prisma from "@/lib/db";
+import {
+  buildAssetSetMetadataCsv,
+  ExcludedRapidMapMetadataAsset,
+  RapidMapAssetObject,
+} from "@/lib/services/rapid-map-asset-metadata";
+
+export class RapidMapAssetSetValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RapidMapAssetSetValidationError";
+  }
+}
+
+export interface ResolvedRapidMapAssetSet {
+  sourceAssetIds: string[];
+  assetObjects: RapidMapAssetObject[];
+  metadataCsv: string;
+  excludedAssets: ExcludedRapidMapMetadataAsset[];
+}
+
+export async function resolveRapidMapAssetSet(
+  teamId: string,
+  requestedAssetIds: string[]
+): Promise<ResolvedRapidMapAssetSet> {
+  const sourceAssetIds = [...new Set(requestedAssetIds)];
+  if (sourceAssetIds.length === 0) {
+    throw new RapidMapAssetSetValidationError("Rapid Map run is missing source asset ids.");
+  }
+
+  const assets = await prisma.asset.findMany({
+    where: {
+      id: { in: sourceAssetIds },
+      project: { teamId },
+    },
+    select: {
+      id: true,
+      fileName: true,
+      s3Key: true,
+      metadata: true,
+      gpsLatitude: true,
+      gpsLongitude: true,
+      altitude: true,
+      gimbalRoll: true,
+      gimbalPitch: true,
+      gimbalYaw: true,
+      imageWidth: true,
+      imageHeight: true,
+    },
+  });
+
+  const assetById = new Map(assets.map((asset) => [asset.id, asset]));
+  const unavailableIds = sourceAssetIds.filter((id) => !assetById.has(id));
+  if (unavailableIds.length > 0) {
+    throw new RapidMapAssetSetValidationError(
+      `Rapid Map asset ids are not available to this team: ${unavailableIds.join(", ")}`
+    );
+  }
+
+  const orderedAssets = sourceAssetIds.map((id) => assetById.get(id)!);
+  let metadata;
+  try {
+    metadata = buildAssetSetMetadataCsv(orderedAssets);
+  } catch (error) {
+    throw new RapidMapAssetSetValidationError(
+      error instanceof Error ? error.message : "Rapid Map asset metadata is invalid."
+    );
+  }
+
+  if (metadata.assetObjects.length < 3) {
+    const excluded = metadata.excludedAssets
+      .map(
+        (asset) =>
+          `${asset.id} (${asset.fileName}): ${asset.missingFields.join(", ")}`
+      )
+      .join("; ");
+    throw new RapidMapAssetSetValidationError(
+      `ASSET_SET requires at least 3 assets with GPS latitude, GPS longitude, and altitude. Missing metadata: ${excluded || "no eligible assets"}`
+    );
+  }
+
+  const filenameCounts = new Map<string, number>();
+  for (const asset of metadata.assetObjects) {
+    filenameCounts.set(asset.filename, (filenameCounts.get(asset.filename) || 0) + 1);
+  }
+  const duplicateFilenames = [...filenameCounts.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([filename]) => filename);
+  if (duplicateFilenames.length > 0) {
+    throw new RapidMapAssetSetValidationError(
+      `ASSET_SET contains duplicate image filenames: ${duplicateFilenames.join(", ")}`
+    );
+  }
+
+  const assetIdByS3Key = new Map(
+    orderedAssets.map((asset) => [asset.s3Key, asset.id])
+  );
+
+  return {
+    sourceAssetIds: metadata.assetObjects.map((asset) => assetIdByS3Key.get(asset.s3Key)!),
+    assetObjects: metadata.assetObjects,
+    metadataCsv: metadata.csv,
+    excludedAssets: metadata.excludedAssets,
+  };
+}

--- a/lib/services/rapid-map-runner.ts
+++ b/lib/services/rapid-map-runner.ts
@@ -1,9 +1,6 @@
-import { execFile } from "child_process";
+import { spawn } from "child_process";
 import { access, readFile } from "fs/promises";
 import path from "path";
-import { promisify } from "util";
-
-const execFileAsync = promisify(execFile);
 
 const DEFAULT_RUNNER_TIMEOUT_MS = 6 * 60 * 60 * 1000;
 const RUNNER_MAX_BUFFER = 20 * 1024 * 1024;
@@ -32,6 +29,12 @@ export interface RapidMapRunnerSummary {
   rasterWidth?: number;
   rasterHeight?: number;
   bounds?: unknown;
+  gpsOutlierCount?: number;
+  pitchFilteredCount?: number;
+  elapsedSeconds?: number;
+  targetEpsg?: string;
+  blend?: string;
+  skipped?: unknown[];
 }
 
 export interface RapidMapRunnerOrthomosaic {
@@ -65,6 +68,7 @@ export interface RapidMapRunnerRequest {
   runId: string;
   jobFilePath: string;
   outputDirectory: string;
+  reportProgress?: (progress: number) => Promise<void> | void;
 }
 
 export class RapidMapRunnerNotConfiguredError extends Error {
@@ -107,6 +111,122 @@ async function readRunnerManifest(outputDirectory: string): Promise<RapidMapRunn
   return manifest;
 }
 
+function runRunnerProcess(
+  command: string,
+  args: string[],
+  request: RapidMapRunnerRequest,
+  timeout: number
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        RAPID_MAP_RUN_ID: request.runId,
+        RAPID_MAP_JOB_FILE: request.jobFilePath,
+        RAPID_MAP_OUTPUT_DIR: request.outputDirectory,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let stdoutLineBuffer = "";
+    let progress = 30;
+    let progressUpdates = Promise.resolve();
+    let terminationError: Error | undefined;
+
+    const terminate = (error: Error) => {
+      if (!terminationError) {
+        terminationError = error;
+        child.kill("SIGKILL");
+      }
+    };
+
+    const capture = (chunk: Buffer, chunks: Buffer[], stream: "stdout" | "stderr") => {
+      if (stream === "stdout") {
+        stdoutBytes += chunk.length;
+        if (stdoutBytes > RUNNER_MAX_BUFFER) {
+          terminate(new Error("Rapid Map runner stdout exceeded the 20 MB output limit."));
+          return;
+        }
+      } else {
+        stderrBytes += chunk.length;
+        if (stderrBytes > RUNNER_MAX_BUFFER) {
+          terminate(new Error("Rapid Map runner stderr exceeded the 20 MB output limit."));
+          return;
+        }
+      }
+
+      chunks.push(chunk);
+    };
+
+    const reportStageLines = (chunk: Buffer) => {
+      stdoutLineBuffer += chunk.toString("utf8");
+      const lines = stdoutLineBuffer.split(/\r?\n/);
+      stdoutLineBuffer = lines.pop() || "";
+
+      for (const line of lines) {
+        if (!line.trimStart().startsWith("+ ")) {
+          continue;
+        }
+
+        progress = Math.min(68, progress + 5);
+        const stageProgress = progress;
+        progressUpdates = progressUpdates.then(async () => {
+          await request.reportProgress?.(stageProgress);
+        });
+      }
+    };
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      capture(chunk, stdoutChunks, "stdout");
+      reportStageLines(chunk);
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      capture(chunk, stderrChunks, "stderr");
+    });
+
+    const timeoutHandle = setTimeout(() => {
+      terminate(new Error(`Rapid Map runner timed out after ${timeout} ms.`));
+    }, timeout);
+
+    child.once("error", (error) => {
+      clearTimeout(timeoutHandle);
+      reject(error);
+    });
+
+    child.once("close", (code, signal) => {
+      clearTimeout(timeoutHandle);
+      void progressUpdates.then(
+        () => {
+          if (terminationError) {
+            reject(terminationError);
+            return;
+          }
+
+          if (code !== 0) {
+            const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
+            const stdout = Buffer.concat(stdoutChunks).toString("utf8").trim();
+            const detail = stderr || stdout;
+            reject(
+              new Error(
+                `Rapid Map runner exited with code ${code ?? "null"}${signal ? ` (${signal})` : ""}${detail ? `: ${detail}` : ""}`
+              )
+            );
+            return;
+          }
+
+          resolve();
+        },
+        reject
+      );
+    });
+  });
+}
+
 export async function runRapidMapRunner(
   request: RapidMapRunnerRequest
 ): Promise<RapidMapRunnerManifest> {
@@ -124,17 +244,7 @@ export async function runRapidMapRunner(
     request.outputDirectory,
   ];
 
-  await execFileAsync(command, args, {
-    cwd: process.cwd(),
-    env: {
-      ...process.env,
-      RAPID_MAP_RUN_ID: request.runId,
-      RAPID_MAP_JOB_FILE: request.jobFilePath,
-      RAPID_MAP_OUTPUT_DIR: request.outputDirectory,
-    },
-    maxBuffer: RUNNER_MAX_BUFFER,
-    timeout,
-  });
+  await runRunnerProcess(command, args, request, timeout);
 
   return readRunnerManifest(request.outputDirectory);
 }

--- a/lib/services/rapid-map-runner.ts
+++ b/lib/services/rapid-map-runner.ts
@@ -1,0 +1,140 @@
+import { execFile } from "child_process";
+import { access, readFile } from "fs/promises";
+import path from "path";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_RUNNER_TIMEOUT_MS = 6 * 60 * 60 * 1000;
+const RUNNER_MAX_BUFFER = 20 * 1024 * 1024;
+
+export type RapidMapArtifactRole =
+  | "geotiff"
+  | "preview"
+  | "overlay"
+  | "metadata"
+  | "summary"
+  | "tiles"
+  | "other";
+
+export interface RapidMapRunnerArtifact {
+  path: string;
+  role?: RapidMapArtifactRole;
+  contentType?: string;
+  targetKey?: string;
+}
+
+export interface RapidMapRunnerSummary {
+  sourceImageCount?: number;
+  renderedImageCount?: number;
+  excludedImageCount?: number;
+  estimatedErrorMeters?: number;
+  rasterWidth?: number;
+  rasterHeight?: number;
+  bounds?: unknown;
+}
+
+export interface RapidMapRunnerOrthomosaic {
+  name?: string;
+  description?: string;
+  bounds?: unknown;
+  centerLat?: number;
+  centerLon?: number;
+  resolutionCmPerPixel?: number;
+  areaHectares?: number;
+  imageCount?: number;
+  rasterWidth?: number;
+  rasterHeight?: number;
+  minZoom?: number;
+  maxZoom?: number;
+  captureDate?: string;
+  crs?: unknown;
+  affineTransform?: unknown;
+  nodataValues?: unknown;
+  bandMetadata?: unknown;
+}
+
+export interface RapidMapRunnerManifest {
+  version?: number;
+  summary?: RapidMapRunnerSummary;
+  artifacts?: RapidMapRunnerArtifact[];
+  orthomosaic?: RapidMapRunnerOrthomosaic;
+}
+
+export interface RapidMapRunnerRequest {
+  runId: string;
+  jobFilePath: string;
+  outputDirectory: string;
+}
+
+export class RapidMapRunnerNotConfiguredError extends Error {
+  constructor() {
+    super(
+      "Rapid Map runner is not configured. Set RAPID_MAP_RUNNER_COMMAND on the rapid-map worker container."
+    );
+    this.name = "RapidMapRunnerNotConfiguredError";
+  }
+}
+
+function parseRunnerArgs(): string[] {
+  const rawArgs = process.env.RAPID_MAP_RUNNER_ARGS;
+  if (!rawArgs) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(rawArgs);
+    if (Array.isArray(parsed) && parsed.every((value) => typeof value === "string")) {
+      return parsed;
+    }
+  } catch {
+    // Fall through to the clear configuration error below.
+  }
+
+  throw new Error("RAPID_MAP_RUNNER_ARGS must be a JSON string array.");
+}
+
+async function readRunnerManifest(outputDirectory: string): Promise<RapidMapRunnerManifest> {
+  const manifestPath = path.join(outputDirectory, "manifest.json");
+  await access(manifestPath);
+
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as RapidMapRunnerManifest;
+
+  if (!manifest || typeof manifest !== "object") {
+    throw new Error("Rapid Map runner manifest is invalid.");
+  }
+
+  return manifest;
+}
+
+export async function runRapidMapRunner(
+  request: RapidMapRunnerRequest
+): Promise<RapidMapRunnerManifest> {
+  const command = process.env.RAPID_MAP_RUNNER_COMMAND;
+  if (!command) {
+    throw new RapidMapRunnerNotConfiguredError();
+  }
+
+  const timeout = Number(process.env.RAPID_MAP_RUNNER_TIMEOUT_MS || DEFAULT_RUNNER_TIMEOUT_MS);
+  const args = [
+    ...parseRunnerArgs(),
+    "--job",
+    request.jobFilePath,
+    "--output",
+    request.outputDirectory,
+  ];
+
+  await execFileAsync(command, args, {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      RAPID_MAP_RUN_ID: request.runId,
+      RAPID_MAP_JOB_FILE: request.jobFilePath,
+      RAPID_MAP_OUTPUT_DIR: request.outputDirectory,
+    },
+    maxBuffer: RUNNER_MAX_BUFFER,
+    timeout,
+  });
+
+  return readRunnerManifest(request.outputDirectory);
+}

--- a/lib/services/rapid-map-source-path.ts
+++ b/lib/services/rapid-map-source-path.ts
@@ -1,0 +1,15 @@
+import { assertValidS3Key, S3Service } from "@/lib/services/s3";
+
+export function assertRapidMapProjectS3Prefix(
+  sourcePath: string,
+  projectId: string
+): void {
+  assertValidS3Key(sourcePath, "Rapid Map source prefix");
+
+  const projectPrefix = `${S3Service.environmentSegment}/${projectId}/`;
+  if (!sourcePath.startsWith(projectPrefix)) {
+    throw new Error(
+      `Rapid Map S3 source must be under the current project prefix: ${projectPrefix}`
+    );
+  }
+}

--- a/lib/services/rapid-map.ts
+++ b/lib/services/rapid-map.ts
@@ -13,6 +13,11 @@ import { Prisma, RapidMapRunStatus } from "@prisma/client";
 import type { RapidMapSourceType } from "@prisma/client";
 import prisma from "@/lib/db";
 import type { RapidMapJobResult } from "@/lib/queue/rapid-map-queue";
+import { resolveRapidMapAssetSet } from "@/lib/services/rapid-map-asset-source";
+import type {
+  ExcludedRapidMapMetadataAsset,
+  RapidMapAssetObject,
+} from "@/lib/services/rapid-map-asset-metadata";
 import { S3Service, assertValidS3Key, s3Client } from "@/lib/services/s3";
 import {
   RapidMapRunnerArtifact,
@@ -45,6 +50,9 @@ interface RapidMapSourceSpec {
   sourcePath: string | null;
   sourceBucket?: string;
   sourceAssetIds: string[];
+  assetObjects?: RapidMapAssetObject[];
+  excludedAssets?: ExcludedRapidMapMetadataAsset[];
+  metadataCsv?: string;
   estimatedSourceImageCount?: number;
 }
 
@@ -135,6 +143,7 @@ function isImageKey(key: string): boolean {
 }
 
 async function buildSourceSpec(run: {
+  teamId: string;
   sourceType: RapidMapSourceType;
   sourcePath: string | null;
   sourceAssetIds: Prisma.JsonValue | null;
@@ -159,15 +168,17 @@ async function buildSourceSpec(run: {
 
   if (run.sourceType === "ASSET_SET") {
     const sourceAssetIds = parseSourceAssetIds(run.sourceAssetIds);
-    if (sourceAssetIds.length === 0) {
-      throw new Error("Rapid Map run is missing source asset ids.");
-    }
+    const resolved = await resolveRapidMapAssetSet(run.teamId, sourceAssetIds);
 
     return {
       type: run.sourceType,
       sourcePath: run.sourcePath,
-      sourceAssetIds,
-      estimatedSourceImageCount: sourceAssetIds.length,
+      sourceBucket: S3Service.bucketName,
+      sourceAssetIds: resolved.sourceAssetIds,
+      assetObjects: resolved.assetObjects,
+      excludedAssets: resolved.excludedAssets,
+      metadataCsv: resolved.metadataCsv,
+      estimatedSourceImageCount: resolved.assetObjects.length,
     };
   }
 
@@ -374,6 +385,21 @@ async function writeRunnerJobFile(options: {
   outputDirectory: string;
 }) {
   const jobFilePath = path.join(options.outputDirectory, "rapid-map-job.json");
+  const { metadataCsv, ...source } = options.source;
+  let jobSource: Omit<RapidMapSourceSpec, "metadataCsv"> & {
+    metadataCsvPath?: string;
+  } = source;
+
+  if (source.type === "ASSET_SET") {
+    if (!metadataCsv || !source.assetObjects?.length) {
+      throw new Error("ASSET_SET job is missing asset objects or metadata CSV content.");
+    }
+
+    const metadataCsvPath = path.join(path.dirname(options.outputDirectory), "metadata.csv");
+    await writeFile(metadataCsvPath, metadataCsv, "utf8");
+    jobSource = { ...source, metadataCsvPath };
+  }
+
   const jobSpec = {
     version: 1,
     runId: options.run.id,
@@ -383,7 +409,7 @@ async function writeRunnerJobFile(options: {
     description: options.run.description,
     preset: options.run.preset,
     config: options.run.config || {},
-    source: options.source,
+    source: jobSource,
     output: {
       bucket: options.run.outputBucket || S3Service.bucketName,
       prefix: options.outputS3Prefix,
@@ -393,7 +419,7 @@ async function writeRunnerJobFile(options: {
   };
 
   await writeFile(jobFilePath, JSON.stringify(jobSpec, null, 2));
-  return jobFilePath;
+  return { jobFilePath, jobSource };
 }
 
 function numberOrUndefined(value: unknown): number | undefined {
@@ -483,7 +509,7 @@ export async function processRapidMapRun(
     const outputDirectory = path.join(workDirectory, "output");
     await mkdir(outputDirectory, { recursive: true });
 
-    const jobFilePath = await writeRunnerJobFile({
+    const { jobFilePath, jobSource } = await writeRunnerJobFile({
       run,
       source,
       outputS3Prefix,
@@ -499,7 +525,7 @@ export async function processRapidMapRun(
           worker: {
             jobFilePath,
             outputDirectory,
-            source,
+            source: jobSource,
           },
         }),
       },
@@ -511,6 +537,8 @@ export async function processRapidMapRun(
       runId,
       jobFilePath,
       outputDirectory,
+      reportProgress: (progress) =>
+        setProgress(runId, progress, options.reportProgress),
     });
     await setProgress(runId, 70, options.reportProgress);
 

--- a/lib/services/rapid-map.ts
+++ b/lib/services/rapid-map.ts
@@ -14,6 +14,7 @@ import type { RapidMapSourceType } from "@prisma/client";
 import prisma from "@/lib/db";
 import type { RapidMapJobResult } from "@/lib/queue/rapid-map-queue";
 import { resolveRapidMapAssetSet } from "@/lib/services/rapid-map-asset-source";
+import { assertRapidMapProjectS3Prefix } from "@/lib/services/rapid-map-source-path";
 import type {
   ExcludedRapidMapMetadataAsset,
   RapidMapAssetObject,
@@ -144,6 +145,7 @@ function isImageKey(key: string): boolean {
 
 async function buildSourceSpec(run: {
   teamId: string;
+  projectId: string;
   sourceType: RapidMapSourceType;
   sourcePath: string | null;
   sourceAssetIds: Prisma.JsonValue | null;
@@ -153,7 +155,7 @@ async function buildSourceSpec(run: {
       throw new Error("Rapid Map run is missing an S3 source prefix.");
     }
 
-    assertValidS3Key(run.sourcePath, "Rapid Map source prefix");
+    assertRapidMapProjectS3Prefix(run.sourcePath, run.projectId);
     const objects = await S3Service.listObjects(run.sourcePath, 1000);
     const imageCount = objects.filter(isImageKey).length;
 

--- a/lib/services/rapid-map.ts
+++ b/lib/services/rapid-map.ts
@@ -1,0 +1,598 @@
+import { createReadStream } from "fs";
+import {
+  mkdir,
+  mkdtemp,
+  rm,
+  stat,
+  writeFile,
+} from "fs/promises";
+import os from "os";
+import path from "path";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { Prisma, RapidMapRunStatus } from "@prisma/client";
+import type { RapidMapSourceType } from "@prisma/client";
+import prisma from "@/lib/db";
+import type { RapidMapJobResult } from "@/lib/queue/rapid-map-queue";
+import { S3Service, assertValidS3Key, s3Client } from "@/lib/services/s3";
+import {
+  RapidMapRunnerArtifact,
+  RapidMapRunnerManifest,
+  RapidMapRunnerNotConfiguredError,
+  runRapidMapRunner,
+} from "@/lib/services/rapid-map-runner";
+
+type RapidMapLogEntry = {
+  stage: string;
+  message: string;
+  timestamp: string;
+  details?: Prisma.InputJsonObject;
+};
+
+type RapidMapProgressReporter = (progress: number) => Promise<void> | void;
+
+export interface ProcessRapidMapRunOptions {
+  reportProgress?: RapidMapProgressReporter;
+}
+
+type UploadedRapidMapArtifact = RapidMapRunnerArtifact & {
+  s3Key: string;
+  bucket: string;
+  fileSize: number;
+};
+
+interface RapidMapSourceSpec {
+  type: RapidMapSourceType;
+  sourcePath: string | null;
+  sourceBucket?: string;
+  sourceAssetIds: string[];
+  estimatedSourceImageCount?: number;
+}
+
+const IMAGE_EXTENSIONS = new Set([
+  ".jpg",
+  ".jpeg",
+  ".tif",
+  ".tiff",
+  ".png",
+  ".dng",
+]);
+
+function buildLogEntry(
+  stage: string,
+  message: string,
+  details?: Prisma.InputJsonObject
+): RapidMapLogEntry {
+  return {
+    stage,
+    message,
+    timestamp: new Date().toISOString(),
+    ...(details ? { details } : {}),
+  };
+}
+
+function normalizeProcessingLog(value: Prisma.JsonValue | null): Prisma.InputJsonArray {
+  if (Array.isArray(value)) {
+    return value.filter((entry) => Boolean(entry)) as Prisma.InputJsonArray;
+  }
+
+  if (value && typeof value === "object") {
+    return [value as Prisma.InputJsonObject];
+  }
+
+  return [];
+}
+
+async function appendRunLog(
+  runId: string,
+  entry: RapidMapLogEntry
+): Promise<Prisma.InputJsonArray> {
+  const run = await prisma.rapidMapRun.findUnique({
+    where: { id: runId },
+    select: { processingLog: true },
+  });
+
+  return [...normalizeProcessingLog(run?.processingLog ?? null), entry];
+}
+
+async function updateRunState(
+  runId: string,
+  data: Prisma.RapidMapRunUpdateInput,
+  logEntry: RapidMapLogEntry
+) {
+  const processingLog = await appendRunLog(runId, logEntry);
+  return prisma.rapidMapRun.update({
+    where: { id: runId },
+    data: {
+      ...data,
+      processingLog,
+    },
+  });
+}
+
+async function setProgress(
+  runId: string,
+  progress: number,
+  reportProgress?: RapidMapProgressReporter
+) {
+  await prisma.rapidMapRun.update({
+    where: { id: runId },
+    data: { progress },
+  });
+
+  await reportProgress?.(progress);
+}
+
+function parseSourceAssetIds(value: Prisma.JsonValue | null): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function isImageKey(key: string): boolean {
+  return IMAGE_EXTENSIONS.has(path.extname(key).toLowerCase());
+}
+
+async function buildSourceSpec(run: {
+  sourceType: RapidMapSourceType;
+  sourcePath: string | null;
+  sourceAssetIds: Prisma.JsonValue | null;
+}): Promise<RapidMapSourceSpec> {
+  if (run.sourceType === "S3_PREFIX") {
+    if (!run.sourcePath) {
+      throw new Error("Rapid Map run is missing an S3 source prefix.");
+    }
+
+    assertValidS3Key(run.sourcePath, "Rapid Map source prefix");
+    const objects = await S3Service.listObjects(run.sourcePath, 1000);
+    const imageCount = objects.filter(isImageKey).length;
+
+    return {
+      type: run.sourceType,
+      sourcePath: run.sourcePath,
+      sourceBucket: S3Service.bucketName,
+      sourceAssetIds: [],
+      estimatedSourceImageCount: imageCount,
+    };
+  }
+
+  if (run.sourceType === "ASSET_SET") {
+    const sourceAssetIds = parseSourceAssetIds(run.sourceAssetIds);
+    if (sourceAssetIds.length === 0) {
+      throw new Error("Rapid Map run is missing source asset ids.");
+    }
+
+    return {
+      type: run.sourceType,
+      sourcePath: run.sourcePath,
+      sourceAssetIds,
+      estimatedSourceImageCount: sourceAssetIds.length,
+    };
+  }
+
+  if (!run.sourcePath) {
+    throw new Error("Rapid Map run is missing a processing-node source path.");
+  }
+
+  return {
+    type: run.sourceType,
+    sourcePath: run.sourcePath,
+    sourceAssetIds: [],
+  };
+}
+
+function safeRelativeArtifactPath(value: string): string {
+  const normalized = value.replace(/\\/g, "/").replace(/^\/+/, "");
+  const parts = normalized.split("/").filter(Boolean);
+
+  if (parts.length === 0 || parts.some((part) => part === "." || part === "..")) {
+    throw new Error(`Invalid Rapid Map artifact path: ${value}`);
+  }
+
+  return parts.join("/");
+}
+
+function contentTypeForArtifact(filePath: string, artifact: RapidMapRunnerArtifact): string {
+  if (artifact.contentType) {
+    return artifact.contentType;
+  }
+
+  const extension = path.extname(filePath).toLowerCase();
+  if (extension === ".png") return "image/png";
+  if (extension === ".jpg" || extension === ".jpeg") return "image/jpeg";
+  if (extension === ".json") return "application/json";
+  if (extension === ".csv") return "text/csv; charset=utf-8";
+  if (extension === ".tif" || extension === ".tiff") return "image/tiff";
+  return "application/octet-stream";
+}
+
+async function uploadArtifactFile(options: {
+  artifact: RapidMapRunnerArtifact;
+  outputDirectory: string;
+  outputS3Prefix: string;
+  bucket: string;
+}): Promise<UploadedRapidMapArtifact> {
+  const relativePath = safeRelativeArtifactPath(options.artifact.path);
+  const sourcePath = path.resolve(options.outputDirectory, relativePath);
+  const outputRoot = path.resolve(options.outputDirectory);
+
+  if (!sourcePath.startsWith(`${outputRoot}${path.sep}`) && sourcePath !== outputRoot) {
+    throw new Error(`Rapid Map artifact escapes output directory: ${options.artifact.path}`);
+  }
+
+  const artifactStat = await stat(sourcePath);
+  const targetRelativePath = safeRelativeArtifactPath(
+    options.artifact.targetKey || relativePath
+  );
+  const s3Key = `${options.outputS3Prefix}/${targetRelativePath}`;
+  assertValidS3Key(s3Key, "Rapid Map artifact key");
+
+  await s3Client.send(
+    new PutObjectCommand({
+      Bucket: options.bucket,
+      Key: s3Key,
+      Body: createReadStream(sourcePath),
+      ContentType: contentTypeForArtifact(sourcePath, options.artifact),
+    })
+  );
+
+  return {
+    ...options.artifact,
+    path: relativePath,
+    targetKey: targetRelativePath,
+    s3Key,
+    bucket: options.bucket,
+    fileSize: artifactStat.size,
+  };
+}
+
+async function uploadArtifacts(options: {
+  manifest: RapidMapRunnerManifest;
+  outputDirectory: string;
+  outputS3Prefix: string;
+  bucket: string;
+}): Promise<UploadedRapidMapArtifact[]> {
+  const artifacts = options.manifest.artifacts || [];
+
+  return Promise.all(
+    artifacts.map((artifact) =>
+      uploadArtifactFile({
+        artifact,
+        outputDirectory: options.outputDirectory,
+        outputS3Prefix: options.outputS3Prefix,
+        bucket: options.bucket,
+      })
+    )
+  );
+}
+
+function asJsonValue(value: unknown): Prisma.InputJsonValue {
+  return JSON.parse(JSON.stringify(value)) as Prisma.InputJsonValue;
+}
+
+function toOptionalDate(value: string | undefined): Date | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+function pickOrthomosaicArtifact(
+  artifacts: UploadedRapidMapArtifact[]
+): UploadedRapidMapArtifact | undefined {
+  return (
+    artifacts.find((artifact) => artifact.role === "geotiff") ||
+    artifacts.find((artifact) => {
+      const extension = path.extname(artifact.path).toLowerCase();
+      return extension === ".tif" || extension === ".tiff";
+    })
+  );
+}
+
+async function createOrthomosaicFromManifest(options: {
+  runId: string;
+  projectId: string;
+  manifest: RapidMapRunnerManifest;
+  artifacts: UploadedRapidMapArtifact[];
+}): Promise<string | undefined> {
+  const orthomosaic = options.manifest.orthomosaic;
+  const artifact = pickOrthomosaicArtifact(options.artifacts);
+
+  if (!orthomosaic || !artifact) {
+    return undefined;
+  }
+
+  if (
+    typeof orthomosaic.centerLat !== "number" ||
+    typeof orthomosaic.centerLon !== "number" ||
+    !orthomosaic.bounds
+  ) {
+    throw new Error(
+      "Rapid Map manifest includes an orthomosaic but is missing bounds or center coordinates."
+    );
+  }
+
+  const created = await prisma.orthomosaic.create({
+    data: {
+      projectId: options.projectId,
+      name: orthomosaic.name || `Rapid Map ${options.runId.slice(0, 8)}`,
+      description: orthomosaic.description || "Generated by Rapid Map processing",
+      originalFile: artifact.s3Key,
+      fileSize: BigInt(artifact.fileSize),
+      s3Key: artifact.s3Key,
+      s3Bucket: artifact.bucket,
+      storageType: "s3",
+      bounds: asJsonValue(orthomosaic.bounds),
+      centerLat: orthomosaic.centerLat,
+      centerLon: orthomosaic.centerLon,
+      minZoom: orthomosaic.minZoom ?? 10,
+      maxZoom: orthomosaic.maxZoom ?? 22,
+      captureDate: toOptionalDate(orthomosaic.captureDate),
+      resolution: orthomosaic.resolutionCmPerPixel,
+      area: orthomosaic.areaHectares,
+      imageCount: orthomosaic.imageCount,
+      status: "COMPLETED",
+      processingLog: [
+        buildLogEntry("RAPID_MAP_LINKED", "Orthomosaic created from Rapid Map run", {
+          rapidMapRunId: options.runId,
+          artifactKey: artifact.s3Key,
+        }),
+      ],
+    },
+  });
+
+  return created.id;
+}
+
+function buildOutputS3Prefix(run: {
+  outputS3Prefix: string | null;
+  projectId: string;
+  id: string;
+}): string {
+  return (
+    run.outputS3Prefix ||
+    `${S3Service.environmentSegment}/${run.projectId}/rapid-maps/${run.id}`
+  );
+}
+
+async function writeRunnerJobFile(options: {
+  run: {
+    id: string;
+    teamId: string;
+    projectId: string;
+    name: string;
+    description: string | null;
+    preset: string;
+    config: Prisma.JsonValue | null;
+    outputBucket: string | null;
+  };
+  source: RapidMapSourceSpec;
+  outputS3Prefix: string;
+  outputDirectory: string;
+}) {
+  const jobFilePath = path.join(options.outputDirectory, "rapid-map-job.json");
+  const jobSpec = {
+    version: 1,
+    runId: options.run.id,
+    teamId: options.run.teamId,
+    projectId: options.run.projectId,
+    name: options.run.name,
+    description: options.run.description,
+    preset: options.run.preset,
+    config: options.run.config || {},
+    source: options.source,
+    output: {
+      bucket: options.run.outputBucket || S3Service.bucketName,
+      prefix: options.outputS3Prefix,
+      directory: options.outputDirectory,
+      manifestPath: path.join(options.outputDirectory, "manifest.json"),
+    },
+  };
+
+  await writeFile(jobFilePath, JSON.stringify(jobSpec, null, 2));
+  return jobFilePath;
+}
+
+function numberOrUndefined(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function buildCompletionSummary(
+  manifest: RapidMapRunnerManifest,
+  artifacts: UploadedRapidMapArtifact[]
+): Prisma.InputJsonObject {
+  return {
+    ...(manifest.summary ? (asJsonValue(manifest.summary) as Prisma.InputJsonObject) : {}),
+    artifactCount: artifacts.length,
+    artifactsUploadedAt: new Date().toISOString(),
+  };
+}
+
+export async function processRapidMapRun(
+  runId: string,
+  options: ProcessRapidMapRunOptions = {}
+): Promise<RapidMapJobResult> {
+  const run = await prisma.rapidMapRun.findUnique({
+    where: { id: runId },
+    select: {
+      id: true,
+      teamId: true,
+      projectId: true,
+      name: true,
+      description: true,
+      sourceType: true,
+      sourcePath: true,
+      sourceAssetIds: true,
+      preset: true,
+      status: true,
+      config: true,
+      outputS3Prefix: true,
+      outputBucket: true,
+    },
+  });
+
+  if (!run) {
+    throw new Error(`Rapid Map run not found: ${runId}`);
+  }
+
+  if (run.status === RapidMapRunStatus.CANCELLED) {
+    throw new Error(`Rapid Map run is cancelled: ${runId}`);
+  }
+
+  if (run.status === RapidMapRunStatus.COMPLETED) {
+    return {
+      runId,
+      storageType: "s3",
+    };
+  }
+
+  const outputS3Prefix = buildOutputS3Prefix(run);
+  const outputBucket = run.outputBucket || S3Service.bucketName;
+  let workDirectory: string | undefined;
+
+  try {
+    await updateRunState(
+      runId,
+      {
+        status: RapidMapRunStatus.PROCESSING,
+        progress: 5,
+        startedAt: new Date(),
+        completedAt: null,
+        errorMessage: null,
+        outputS3Prefix,
+        outputBucket,
+      },
+      buildLogEntry("PROCESSING_STARTED", "Rapid Map worker started", {
+        outputS3Prefix,
+        outputBucket,
+      })
+    );
+    await options.reportProgress?.(5);
+
+    if (!process.env.RAPID_MAP_RUNNER_COMMAND) {
+      throw new RapidMapRunnerNotConfiguredError();
+    }
+
+    const source = await buildSourceSpec(run);
+    await setProgress(runId, 15, options.reportProgress);
+
+    workDirectory = await mkdtemp(path.join(os.tmpdir(), `rapid-map-${runId}-`));
+    const outputDirectory = path.join(workDirectory, "output");
+    await mkdir(outputDirectory, { recursive: true });
+
+    const jobFilePath = await writeRunnerJobFile({
+      run,
+      source,
+      outputS3Prefix,
+      outputDirectory,
+    });
+
+    await updateRunState(
+      runId,
+      {
+        sourceImageCount: source.estimatedSourceImageCount,
+        config: asJsonValue({
+          ...(run.config && typeof run.config === "object" ? run.config : {}),
+          worker: {
+            jobFilePath,
+            outputDirectory,
+            source,
+          },
+        }),
+      },
+      buildLogEntry("RUNNER_DISPATCHED", "Rapid Map runner command dispatched")
+    );
+    await setProgress(runId, 30, options.reportProgress);
+
+    const manifest = await runRapidMapRunner({
+      runId,
+      jobFilePath,
+      outputDirectory,
+    });
+    await setProgress(runId, 70, options.reportProgress);
+
+    const uploadedArtifacts = await uploadArtifacts({
+      manifest,
+      outputDirectory,
+      outputS3Prefix,
+      bucket: outputBucket,
+    });
+    await setProgress(runId, 85, options.reportProgress);
+
+    const orthomosaicId = await createOrthomosaicFromManifest({
+      runId,
+      projectId: run.projectId,
+      manifest,
+      artifacts: uploadedArtifacts,
+    });
+
+    const summary = manifest.summary || {};
+    const artifactManifest = {
+      version: manifest.version || 1,
+      artifacts: uploadedArtifacts,
+      orthomosaic: manifest.orthomosaic || null,
+    };
+
+    await updateRunState(
+      runId,
+      {
+        status: RapidMapRunStatus.COMPLETED,
+        progress: 100,
+        completedAt: new Date(),
+        orthomosaic: orthomosaicId
+          ? {
+              connect: { id: orthomosaicId },
+            }
+          : undefined,
+        artifactManifest: asJsonValue(artifactManifest),
+        runSummary: buildCompletionSummary(manifest, uploadedArtifacts),
+        sourceImageCount:
+          numberOrUndefined(summary.sourceImageCount) ||
+          source.estimatedSourceImageCount,
+        renderedImageCount: numberOrUndefined(summary.renderedImageCount),
+        excludedImageCount: numberOrUndefined(summary.excludedImageCount),
+        estimatedErrorMeters: numberOrUndefined(summary.estimatedErrorMeters),
+      },
+      buildLogEntry("COMPLETED", "Rapid Map run completed", {
+        artifactCount: uploadedArtifacts.length,
+        orthomosaicId: orthomosaicId || null,
+      })
+    );
+    await options.reportProgress?.(100);
+
+    return {
+      runId,
+      orthomosaicId,
+      sourceImageCount:
+        numberOrUndefined(summary.sourceImageCount) ||
+        source.estimatedSourceImageCount,
+      renderedImageCount: numberOrUndefined(summary.renderedImageCount),
+      excludedImageCount: numberOrUndefined(summary.excludedImageCount),
+      artifactCount: uploadedArtifacts.length,
+      storageType: "s3",
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown Rapid Map error";
+
+    await updateRunState(
+      runId,
+      {
+        status: RapidMapRunStatus.FAILED,
+        completedAt: new Date(),
+        errorMessage: message.slice(0, 1000),
+      },
+      buildLogEntry("FAILED", "Rapid Map run failed", {
+        error: message.slice(0, 1000),
+      })
+    );
+
+    throw error;
+  } finally {
+    if (workDirectory && process.env.RAPID_MAP_KEEP_WORKDIR !== "1") {
+      await rm(workDirectory, { recursive: true, force: true });
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^3.4.15",
         "tsconfig-paths": "4.2.0",
+        "tsx": "^4.21.0",
         "zod": "^4.0.5"
       },
       "devDependencies": {
@@ -80,7 +81,6 @@
         "eslint": "^9",
         "eslint-config-next": "^15.4.11",
         "ts-node": "^10.9.2",
-        "tsx": "^4.21.0",
         "typescript": "^5",
         "vitest": "^3.2.4"
       }
@@ -1857,7 +1857,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1874,7 +1873,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1891,7 +1889,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1908,7 +1905,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1925,7 +1921,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1942,7 +1937,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1959,7 +1953,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1976,7 +1969,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1993,7 +1985,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2010,7 +2001,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2027,7 +2017,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2044,7 +2033,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2061,7 +2049,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2078,7 +2065,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2095,7 +2081,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2112,7 +2097,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2129,7 +2113,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2146,7 +2129,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2163,7 +2145,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2180,7 +2161,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2197,7 +2177,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2214,7 +2193,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2231,7 +2209,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2248,7 +2225,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2265,7 +2241,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2282,7 +2257,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10241,7 +10215,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
       "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -11227,7 +11200,6 @@
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
       "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -13864,7 +13836,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -15135,7 +15106,6 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "worker:inference:dev": "tsx -r tsconfig-paths/register --env-file=.env workers/inference-worker.ts",
     "worker:roboflow-detection": "tsx -r tsconfig-paths/register workers/roboflow-detection-worker.ts",
     "worker:roboflow-detection:dev": "tsx -r tsconfig-paths/register --env-file=.env workers/roboflow-detection-worker.ts",
+    "worker:rapid-map": "tsx -r tsconfig-paths/register workers/rapid-map-worker.ts",
+    "worker:rapid-map:dev": "tsx -r tsconfig-paths/register --env-file=.env workers/rapid-map-worker.ts",
     "worker:yolo-inference": "tsx -r tsconfig-paths/register workers/yolo-inference-worker.ts",
     "worker:yolo-inference:dev": "tsx -r tsconfig-paths/register --env-file=.env workers/yolo-inference-worker.ts",
     "worker:temporal": "tsx -r tsconfig-paths/register workers/temporal-worker.ts",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^3.4.15",
     "tsconfig-paths": "4.2.0",
+    "tsx": "^4.21.0",
     "zod": "^4.0.5"
   },
   "devDependencies": {
@@ -118,7 +119,6 @@
     "eslint": "^9",
     "eslint-config-next": "^15.4.11",
     "ts-node": "^10.9.2",
-    "tsx": "^4.21.0",
     "typescript": "^5",
     "vitest": "^3.2.4"
   }

--- a/prisma/migrations/20260605110000_add_rapid_map_runs/migration.sql
+++ b/prisma/migrations/20260605110000_add_rapid_map_runs/migration.sql
@@ -1,0 +1,58 @@
+-- Add Rapid Map run tracking for metadata-based map generation.
+-- The run stores job/provenance/status separately from the generated Orthomosaic.
+
+CREATE TABLE `RapidMapRun` (
+    `id` VARCHAR(191) NOT NULL,
+    `teamId` VARCHAR(191) NOT NULL,
+    `projectId` VARCHAR(191) NOT NULL,
+    `createdById` VARCHAR(191) NOT NULL,
+    `orthomosaicId` VARCHAR(191) NULL,
+    `name` VARCHAR(191) NOT NULL,
+    `description` TEXT NULL,
+    `sourceType` ENUM('S3_PREFIX', 'ASSET_SET', 'PROCESSING_NODE_PATH') NOT NULL DEFAULT 'S3_PREFIX',
+    `sourcePath` TEXT NULL,
+    `sourceAssetIds` JSON NULL,
+    `preset` ENUM('INITIAL_TRIAL', 'SHARPER_REVIEW', 'COVERAGE_CHECK') NOT NULL DEFAULT 'INITIAL_TRIAL',
+    `status` ENUM('QUEUED', 'PROCESSING', 'COMPLETED', 'FAILED', 'CANCELLED') NOT NULL DEFAULT 'QUEUED',
+    `progress` INTEGER NOT NULL DEFAULT 0,
+    `queueJobId` VARCHAR(191) NULL,
+    `errorMessage` TEXT NULL,
+    `config` JSON NULL,
+    `processingLog` JSON NULL,
+    `artifactManifest` JSON NULL,
+    `runSummary` JSON NULL,
+    `outputS3Prefix` TEXT NULL,
+    `outputBucket` VARCHAR(191) NULL,
+    `sourceImageCount` INTEGER NULL,
+    `renderedImageCount` INTEGER NULL,
+    `excludedImageCount` INTEGER NULL,
+    `estimatedErrorMeters` DOUBLE NULL,
+    `startedAt` DATETIME(3) NULL,
+    `completedAt` DATETIME(3) NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    INDEX `RapidMapRun_teamId_idx`(`teamId`),
+    INDEX `RapidMapRun_projectId_idx`(`projectId`),
+    INDEX `RapidMapRun_createdById_idx`(`createdById`),
+    INDEX `RapidMapRun_orthomosaicId_idx`(`orthomosaicId`),
+    INDEX `RapidMapRun_status_idx`(`status`),
+    INDEX `RapidMapRun_createdAt_idx`(`createdAt`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE `RapidMapRun`
+    ADD CONSTRAINT `RapidMapRun_teamId_fkey`
+    FOREIGN KEY (`teamId`) REFERENCES `Team`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE `RapidMapRun`
+    ADD CONSTRAINT `RapidMapRun_projectId_fkey`
+    FOREIGN KEY (`projectId`) REFERENCES `Project`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE `RapidMapRun`
+    ADD CONSTRAINT `RapidMapRun_createdById_fkey`
+    FOREIGN KEY (`createdById`) REFERENCES `User`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE `RapidMapRun`
+    ADD CONSTRAINT `RapidMapRun_orthomosaicId_fkey`
+    FOREIGN KEY (`orthomosaicId`) REFERENCES `Orthomosaic`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,7 @@ model User {
   sprayPlans             SprayPlan[]
   complianceLayers       ComplianceLayer[]
   temporalRuns           TemporalComparisonRun[]
+  rapidMapRuns           RapidMapRun[]
 }
 
 model Account {
@@ -73,6 +74,7 @@ model Team {
   sprayPlans        SprayPlan[]
   complianceLayers  ComplianceLayer[]
   surveys           Survey[]
+  rapidMapRuns      RapidMapRun[]
   temporalRuns      TemporalComparisonRun[]
 }
 
@@ -126,6 +128,7 @@ model Project {
   assets            Asset[]
   jobs              ProcessingJob[]
   orthomosaics      Orthomosaic[]
+  rapidMapRuns      RapidMapRun[]
   batchJobs         BatchJob[]
   trainingDatasets  TrainingDataset[]
   reviewSessions    ReviewSession[]
@@ -444,9 +447,10 @@ model Orthomosaic {
   processingLog Json?
 
   // Relations
-  project   Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  project      Project       @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  rapidMapRuns RapidMapRun[]
+  createdAt    DateTime      @default(now())
+  updatedAt    DateTime      @updatedAt
 
   @@index([projectId])
   @@index([status])
@@ -457,6 +461,77 @@ enum ProcessingStatus {
   PROCESSING
   COMPLETED
   FAILED
+}
+
+model RapidMapRun {
+  id String @id @default(cuid())
+
+  teamId      String
+  projectId   String
+  createdById String
+
+  orthomosaicId String?
+
+  name        String
+  description String?
+  sourceType  RapidMapSourceType @default(S3_PREFIX)
+  sourcePath  String?
+  sourceAssetIds Json?
+  preset      RapidMapPreset     @default(INITIAL_TRIAL)
+
+  status       RapidMapRunStatus @default(QUEUED)
+  progress     Int               @default(0)
+  queueJobId   String?
+  errorMessage String?
+
+  config           Json?
+  processingLog    Json?
+  artifactManifest Json?
+  runSummary       Json?
+
+  outputS3Prefix       String?
+  outputBucket         String?
+  sourceImageCount     Int?
+  renderedImageCount   Int?
+  excludedImageCount   Int?
+  estimatedErrorMeters Float?
+
+  startedAt   DateTime?
+  completedAt DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  team        Team         @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  project     Project      @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  createdBy   User         @relation(fields: [createdById], references: [id], onDelete: Cascade)
+  orthomosaic Orthomosaic? @relation(fields: [orthomosaicId], references: [id], onDelete: SetNull)
+
+  @@index([teamId])
+  @@index([projectId])
+  @@index([createdById])
+  @@index([orthomosaicId])
+  @@index([status])
+  @@index([createdAt])
+}
+
+enum RapidMapRunStatus {
+  QUEUED
+  PROCESSING
+  COMPLETED
+  FAILED
+  CANCELLED
+}
+
+enum RapidMapSourceType {
+  S3_PREFIX
+  ASSET_SET
+  PROCESSING_NODE_PATH
+}
+
+enum RapidMapPreset {
+  INITIAL_TRIAL
+  SHARPER_REVIEW
+  COVERAGE_CHECK
 }
 
 // ============================================

--- a/scripts/run-rapid-map-flatmap.py
+++ b/scripts/run-rapid-map-flatmap.py
@@ -278,6 +278,7 @@ def build_manifest(output_dir: Path, job: dict[str, Any]) -> dict[str, Any]:
     image_count = summary.get("image_count")
     missing_count = count(summary.get("missing_metadata_images"))
     pitch_filtered_count = count(summary.get("pitch_filtered_images"))
+    source_image_count = count(image_count) + missing_count + pitch_filtered_count
     rendered_count = count(mosaic_manifest.get("rendered_count"))
     skipped_count = count(mosaic_manifest.get("skipped_count"))
     pixel_size = optional_number(mosaic_manifest.get("pixel_size"))
@@ -289,7 +290,7 @@ def build_manifest(output_dir: Path, job: dict[str, Any]) -> dict[str, Any]:
     return {
         "version": 1,
         "summary": {
-            "sourceImageCount": image_count,
+            "sourceImageCount": source_image_count,
             "renderedImageCount": rendered_count,
             "excludedImageCount": missing_count + pitch_filtered_count + skipped_count,
             "gpsOutlierCount": count(mosaic_manifest.get("gps_outlier_count")),

--- a/scripts/run-rapid-map-flatmap.py
+++ b/scripts/run-rapid-map-flatmap.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Adapt AgriDrone Rapid Map jobs to the flat-map-runner CLI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import rasterio
+from rasterio.warp import transform_bounds
+
+
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".tif", ".tiff", ".png", ".dng"}
+ARTIFACTS = [
+    ("flat-footprint-mosaic.tif", "geotiff", "image/tiff", "rapid-map.tif"),
+    ("flat-footprint-mosaic-overlay.png", "overlay", "image/png", "overlay.png"),
+    ("flat-map-footprints.geojson", "metadata", "application/geo+json", "footprints.geojson"),
+    ("flat-map-images.csv", "metadata", "text/csv; charset=utf-8", "images.csv"),
+    ("flat-map-artifacts-input.json", "metadata", "application/json", "runner-input.json"),
+    ("run-summary.json", "summary", "application/json", "run-summary.json"),
+    ("basemap-viewer.html", "other", "text/html; charset=utf-8", "basemap-viewer.html"),
+]
+
+
+def run(command: list[str], cwd: Path | None = None) -> None:
+    print("+", " ".join(str(part) for part in command), flush=True)
+    subprocess.run([str(part) for part in command], cwd=cwd, check=True)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def ensure_directory(path: Path, label: str) -> Path:
+    if not path.exists() or not path.is_dir():
+        raise SystemExit(f"{label} does not exist or is not a directory: {path}")
+    return path
+
+
+def sync_s3_prefix(bucket: str, prefix: str, destination: Path) -> Path:
+    if not shutil.which("aws"):
+        raise SystemExit("AWS CLI is required for S3 Rapid Map sources.")
+
+    destination.mkdir(parents=True, exist_ok=True)
+    run(
+        [
+            "aws",
+            "s3",
+            "sync",
+            f"s3://{bucket}/{prefix.rstrip('/')}",
+            str(destination),
+            "--exclude",
+            "*",
+            "--include",
+            "*.JPG",
+            "--include",
+            "*.JPEG",
+            "--include",
+            "*.jpg",
+            "--include",
+            "*.jpeg",
+            "--include",
+            "*.TIF",
+            "--include",
+            "*.TIFF",
+            "--include",
+            "*.tif",
+            "--include",
+            "*.tiff",
+            "--include",
+            "*.DNG",
+            "--include",
+            "*.dng",
+            "--include",
+            "metadata.csv",
+        ]
+    )
+    return destination
+
+
+def discover_input_paths(source_root: Path) -> tuple[Path, Path]:
+    metadata_candidates = [
+        source_root / "metadata.csv",
+        source_root / "images" / "metadata.csv",
+    ]
+    metadata = next((path for path in metadata_candidates if path.exists()), None)
+    if metadata is None:
+        matches = list(source_root.rglob("metadata.csv"))
+        metadata = matches[0] if matches else None
+
+    if metadata is None:
+        raise SystemExit(f"No metadata.csv found under {source_root}")
+
+    image_dirs = [metadata.parent, source_root / "images", source_root]
+    image_dir = next(
+        (
+            directory
+            for directory in image_dirs
+            if directory.exists()
+            and any(path.suffix.lower() in IMAGE_EXTENSIONS for path in directory.rglob("*"))
+        ),
+        None,
+    )
+
+    if image_dir is None:
+        raise SystemExit(f"No source images found under {source_root}")
+
+    return image_dir, metadata
+
+
+def resolve_source(job: dict[str, Any], workspace: Path) -> tuple[Path, Path]:
+    source = job.get("source") or {}
+    source_type = source.get("type")
+    source_path = source.get("sourcePath")
+
+    if source_type == "S3_PREFIX":
+        bucket = source.get("sourceBucket") or job.get("output", {}).get("bucket")
+        if not bucket or not source_path:
+            raise SystemExit("S3 Rapid Map source requires sourceBucket and sourcePath.")
+        return discover_input_paths(sync_s3_prefix(bucket, source_path, workspace / "input"))
+
+    if source_type == "PROCESSING_NODE_PATH":
+        if not source_path:
+            raise SystemExit("Processing-node Rapid Map source requires sourcePath.")
+        return discover_input_paths(ensure_directory(Path(source_path).expanduser().resolve(), "Source path"))
+
+    raise SystemExit(f"Unsupported Rapid Map source type for flat-map-runner: {source_type}")
+
+
+def number(value: Any, default: float) -> float:
+    if isinstance(value, (int, float)) and math.isfinite(value):
+        return float(value)
+    return default
+
+
+def integer(value: Any, default: int) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and math.isfinite(value):
+        return int(value)
+    return default
+
+
+def config_value(config: dict[str, Any], key: str, default: Any) -> Any:
+    value = config.get(key)
+    if value is not None:
+        return value
+    runner = config.get("runner")
+    if isinstance(runner, dict):
+        return runner.get(key, default)
+    return default
+
+
+def raster_metadata(path: Path) -> dict[str, Any]:
+    with rasterio.open(path) as dataset:
+        bounds = dataset.bounds
+        if dataset.crs:
+            west, south, east, north = transform_bounds(
+                dataset.crs,
+                "EPSG:4326",
+                bounds.left,
+                bounds.bottom,
+                bounds.right,
+                bounds.top,
+                densify_pts=21,
+            )
+            crs = dataset.crs.to_string()
+        else:
+            west, south, east, north = bounds.left, bounds.bottom, bounds.right, bounds.top
+            crs = None
+
+        return {
+            "bounds": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [west, south],
+                        [east, south],
+                        [east, north],
+                        [west, north],
+                        [west, south],
+                    ]
+                ],
+            },
+            "centerLat": (south + north) / 2,
+            "centerLon": (west + east) / 2,
+            "rasterWidth": dataset.width,
+            "rasterHeight": dataset.height,
+            "crs": crs,
+            "affineTransform": list(dataset.transform)[:6],
+            "nodataValues": list(dataset.nodatavals or []),
+        }
+
+
+def build_manifest(output_dir: Path, job: dict[str, Any]) -> dict[str, Any]:
+    summary_path = output_dir / "run-summary.json"
+    summary = load_json(summary_path) if summary_path.exists() else {}
+    mosaic_path = output_dir / "flat-footprint-mosaic.tif"
+    raster = raster_metadata(mosaic_path) if mosaic_path.exists() else {}
+    config = job.get("config") if isinstance(job.get("config"), dict) else {}
+
+    artifacts = []
+    for file_name, role, content_type, target_key in ARTIFACTS:
+        if (output_dir / file_name).exists():
+            artifacts.append(
+                {
+                    "path": file_name,
+                    "role": role,
+                    "contentType": content_type,
+                    "targetKey": target_key,
+                }
+            )
+
+    image_count = summary.get("image_count")
+    missing_count = summary.get("missing_metadata_images")
+    resolution_cm = number(config_value(config, "pixelSizeM", 0.3), 0.3) * 100
+
+    return {
+        "version": 1,
+        "summary": {
+            "sourceImageCount": image_count,
+            "renderedImageCount": image_count,
+            "excludedImageCount": missing_count,
+            "estimatedErrorMeters": config_value(config, "estimatedErrorMeters", None),
+            "rasterWidth": raster.get("rasterWidth"),
+            "rasterHeight": raster.get("rasterHeight"),
+            "bounds": raster.get("bounds"),
+        },
+        "artifacts": artifacts,
+        "orthomosaic": {
+            "name": job.get("name") or f"Rapid Map {job.get('runId', '')[:8]}",
+            "description": job.get("description") or "Generated by Rapid Map processing",
+            "bounds": raster.get("bounds"),
+            "centerLat": raster.get("centerLat"),
+            "centerLon": raster.get("centerLon"),
+            "resolutionCmPerPixel": resolution_cm,
+            "imageCount": image_count,
+            "rasterWidth": raster.get("rasterWidth"),
+            "rasterHeight": raster.get("rasterHeight"),
+            "crs": raster.get("crs"),
+            "affineTransform": raster.get("affineTransform"),
+            "nodataValues": raster.get("nodataValues"),
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run flat-map-runner for an AgriDrone Rapid Map job")
+    parser.add_argument("--job", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    job_path = Path(args.job).resolve()
+    output_dir = Path(args.output).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    workspace = output_dir.parent
+    job = load_json(job_path)
+    config = job.get("config") if isinstance(job.get("config"), dict) else {}
+
+    flat_map_dir = Path(os.environ.get("FLAT_MAP_RUNNER_DIR", "/opt/flat-map-runner")).resolve()
+    flat_map_python = os.environ.get("FLAT_MAP_PYTHON") or os.environ.get("PYTHON", "python3")
+    flat_map_script = flat_map_dir / "scripts" / "run-flat-map-test.py"
+    if not flat_map_script.exists():
+        raise SystemExit(f"flat-map-runner script not found: {flat_map_script}")
+
+    image_dir, metadata_csv = resolve_source(job, workspace)
+    pixel_size = number(config_value(config, "pixelSizeM", 0.3), 0.3)
+    feather_px = integer(config_value(config, "featherPx", 32), 32)
+    max_source_px = integer(config_value(config, "maxSourcePx", 1024), 1024)
+    preview_max_size = integer(config_value(config, "previewMaxSize", 4000), 4000)
+    target_epsg = str(config_value(config, "targetEpsg", "EPSG:32756"))
+    nadir_pitch_tolerance = number(config_value(config, "nadirPitchToleranceDeg", 15), 15)
+
+    command = [
+        flat_map_python,
+        str(flat_map_script),
+        "--images",
+        str(image_dir),
+        "--metadata",
+        str(metadata_csv),
+        "--output-dir",
+        str(output_dir),
+        "--target-epsg",
+        target_epsg,
+        "--pixel-size",
+        str(pixel_size),
+        "--feather-px",
+        str(feather_px),
+        "--max-source-px",
+        str(max_source_px),
+        "--preview-max-size",
+        str(preview_max_size),
+        "--nadir-pitch-tolerance",
+        str(nadir_pitch_tolerance),
+        "--python",
+        flat_map_python,
+    ]
+
+    run(command)
+    (output_dir / "manifest.json").write_text(json.dumps(build_manifest(output_dir, job), indent=2) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-rapid-map-flatmap.py
+++ b/scripts/run-rapid-map-flatmap.py
@@ -43,10 +43,13 @@ def ensure_directory(path: Path, label: str) -> Path:
     return path
 
 
-def sync_s3_prefix(bucket: str, prefix: str, destination: Path) -> Path:
+def require_aws_cli() -> None:
     if not shutil.which("aws"):
         raise SystemExit("AWS CLI is required for S3 Rapid Map sources.")
 
+
+def sync_s3_prefix(bucket: str, prefix: str, destination: Path) -> Path:
+    require_aws_cli()
     destination.mkdir(parents=True, exist_ok=True)
     run(
         [
@@ -81,6 +84,34 @@ def sync_s3_prefix(bucket: str, prefix: str, destination: Path) -> Path:
             "metadata.csv",
         ]
     )
+    return destination
+
+
+def download_asset_set(bucket: str, asset_objects: Any, destination: Path) -> Path:
+    require_aws_cli()
+    if not isinstance(asset_objects, list) or not asset_objects:
+        raise SystemExit("ASSET_SET Rapid Map source requires a non-empty assetObjects array.")
+
+    destination.mkdir(parents=True, exist_ok=True)
+    filenames: set[str] = set()
+    for index, asset_object in enumerate(asset_objects):
+        if not isinstance(asset_object, dict):
+            raise SystemExit(f"ASSET_SET assetObjects[{index}] must be an object.")
+
+        s3_key = asset_object.get("s3Key")
+        filename = asset_object.get("filename")
+        if not isinstance(s3_key, str) or not s3_key.strip():
+            raise SystemExit(f"ASSET_SET assetObjects[{index}] requires s3Key.")
+        if not isinstance(filename, str) or not filename.strip():
+            raise SystemExit(f"ASSET_SET assetObjects[{index}] requires filename.")
+        if Path(filename).name != filename:
+            raise SystemExit(f"ASSET_SET assetObjects[{index}] filename must be a basename.")
+        if filename in filenames:
+            raise SystemExit(f"ASSET_SET contains duplicate filename: {filename}")
+
+        filenames.add(filename)
+        run(["aws", "s3", "cp", f"s3://{bucket}/{s3_key.lstrip('/')}", str(destination / filename)])
+
     return destination
 
 
@@ -125,6 +156,21 @@ def resolve_source(job: dict[str, Any], workspace: Path) -> tuple[Path, Path]:
             raise SystemExit("S3 Rapid Map source requires sourceBucket and sourcePath.")
         return discover_input_paths(sync_s3_prefix(bucket, source_path, workspace / "input"))
 
+    if source_type == "ASSET_SET":
+        bucket = source.get("sourceBucket") or job.get("output", {}).get("bucket")
+        metadata_path = source.get("metadataCsvPath")
+        if not bucket:
+            raise SystemExit("ASSET_SET Rapid Map source requires sourceBucket.")
+        if not isinstance(metadata_path, str) or not metadata_path:
+            raise SystemExit("ASSET_SET Rapid Map source requires metadataCsvPath.")
+
+        metadata_csv = Path(metadata_path).expanduser().resolve()
+        if not metadata_csv.exists() or not metadata_csv.is_file():
+            raise SystemExit(f"ASSET_SET metadata.csv does not exist: {metadata_csv}")
+
+        image_dir = download_asset_set(bucket, source.get("assetObjects"), workspace / "input")
+        return image_dir, metadata_csv
+
     if source_type == "PROCESSING_NODE_PATH":
         if not source_path:
             raise SystemExit("Processing-node Rapid Map source requires sourcePath.")
@@ -145,6 +191,16 @@ def integer(value: Any, default: int) -> int:
     if isinstance(value, float) and math.isfinite(value):
         return int(value)
     return default
+
+
+def optional_number(value: Any) -> float | None:
+    if isinstance(value, (int, float)) and math.isfinite(value):
+        return float(value)
+    return None
+
+
+def count(value: Any) -> int:
+    return integer(value, 0)
 
 
 def config_value(config: dict[str, Any], key: str, default: Any) -> Any:
@@ -201,6 +257,8 @@ def raster_metadata(path: Path) -> dict[str, Any]:
 def build_manifest(output_dir: Path, job: dict[str, Any]) -> dict[str, Any]:
     summary_path = output_dir / "run-summary.json"
     summary = load_json(summary_path) if summary_path.exists() else {}
+    mosaic_manifest_path = output_dir / "flat-footprint-mosaic.manifest.json"
+    mosaic_manifest = load_json(mosaic_manifest_path) if mosaic_manifest_path.exists() else {}
     mosaic_path = output_dir / "flat-footprint-mosaic.tif"
     raster = raster_metadata(mosaic_path) if mosaic_path.exists() else {}
     config = job.get("config") if isinstance(job.get("config"), dict) else {}
@@ -218,15 +276,28 @@ def build_manifest(output_dir: Path, job: dict[str, Any]) -> dict[str, Any]:
             )
 
     image_count = summary.get("image_count")
-    missing_count = summary.get("missing_metadata_images")
-    resolution_cm = number(config_value(config, "pixelSizeM", 0.3), 0.3) * 100
+    missing_count = count(summary.get("missing_metadata_images"))
+    pitch_filtered_count = count(summary.get("pitch_filtered_images"))
+    rendered_count = count(mosaic_manifest.get("rendered_count"))
+    skipped_count = count(mosaic_manifest.get("skipped_count"))
+    pixel_size = optional_number(mosaic_manifest.get("pixel_size"))
+    resolution_cm = pixel_size * 100 if pixel_size is not None else None
+    skipped = mosaic_manifest.get("skipped")
+    if not isinstance(skipped, list):
+        skipped = []
 
     return {
         "version": 1,
         "summary": {
             "sourceImageCount": image_count,
-            "renderedImageCount": image_count,
-            "excludedImageCount": missing_count,
+            "renderedImageCount": rendered_count,
+            "excludedImageCount": missing_count + pitch_filtered_count + skipped_count,
+            "gpsOutlierCount": count(mosaic_manifest.get("gps_outlier_count")),
+            "pitchFilteredCount": pitch_filtered_count,
+            "elapsedSeconds": optional_number(mosaic_manifest.get("elapsed_seconds")),
+            "targetEpsg": summary.get("target_epsg"),
+            "blend": summary.get("blend"),
+            "skipped": skipped[:50],
             "estimatedErrorMeters": config_value(config, "estimatedErrorMeters", None),
             "rasterWidth": raster.get("rasterWidth"),
             "rasterHeight": raster.get("rasterHeight"),
@@ -240,7 +311,7 @@ def build_manifest(output_dir: Path, job: dict[str, Any]) -> dict[str, Any]:
             "centerLat": raster.get("centerLat"),
             "centerLon": raster.get("centerLon"),
             "resolutionCmPerPixel": resolution_cm,
-            "imageCount": image_count,
+            "imageCount": rendered_count,
             "rasterWidth": raster.get("rasterWidth"),
             "rasterHeight": raster.get("rasterHeight"),
             "crs": raster.get("crs"),
@@ -274,8 +345,15 @@ def main() -> int:
     feather_px = integer(config_value(config, "featherPx", 32), 32)
     max_source_px = integer(config_value(config, "maxSourcePx", 1024), 1024)
     preview_max_size = integer(config_value(config, "previewMaxSize", 4000), 4000)
-    target_epsg = str(config_value(config, "targetEpsg", "EPSG:32756"))
+    target_epsg = str(config_value(config, "targetEpsg", "auto"))
     nadir_pitch_tolerance = number(config_value(config, "nadirPitchToleranceDeg", 15), 15)
+    blend = str(config_value(config, "blend", "center"))
+    workers = integer(config_value(config, "workers", 0), 0)
+    max_offset_km = number(config_value(config, "maxOffsetKm", 10), 10)
+    max_raster_px = integer(config_value(config, "maxRasterPx", 250_000_000), 250_000_000)
+    cog = bool(config_value(config, "cog", True))
+    image_orientation_policy = str(config_value(config, "imageOrientationPolicy", "flipv"))
+    yaw_offset_deg = number(config_value(config, "yawOffsetDeg", 0), 0)
 
     command = [
         flat_map_python,
@@ -298,9 +376,24 @@ def main() -> int:
         str(preview_max_size),
         "--nadir-pitch-tolerance",
         str(nadir_pitch_tolerance),
+        "--blend",
+        blend,
+        "--workers",
+        str(workers),
+        "--max-offset-km",
+        str(max_offset_km),
+        "--max-raster-px",
+        str(max_raster_px),
+        "--image-orientation-policy",
+        image_orientation_policy,
+        "--yaw-offset-deg",
+        str(yaw_offset_deg),
         "--python",
         flat_map_python,
     ]
+
+    if cog:
+        command.append("--cog")
 
     run(command)
     (output_dir / "manifest.json").write_text(json.dumps(build_manifest(output_dir, job), indent=2) + "\n")

--- a/scripts/run-rapid-map-flatmap.py
+++ b/scripts/run-rapid-map-flatmap.py
@@ -298,6 +298,8 @@ def build_manifest(output_dir: Path, job: dict[str, Any]) -> dict[str, Any]:
             "elapsedSeconds": optional_number(mosaic_manifest.get("elapsed_seconds")),
             "targetEpsg": summary.get("target_epsg"),
             "blend": summary.get("blend"),
+            "demSource": summary.get("dem_source"),
+            "aglStats": summary.get("agl_stats"),
             "skipped": skipped[:50],
             "estimatedErrorMeters": config_value(config, "estimatedErrorMeters", None),
             "rasterWidth": raster.get("rasterWidth"),
@@ -347,6 +349,7 @@ def main() -> int:
     max_source_px = integer(config_value(config, "maxSourcePx", 1024), 1024)
     preview_max_size = integer(config_value(config, "previewMaxSize", 4000), 4000)
     target_epsg = str(config_value(config, "targetEpsg", "auto"))
+    dem = str(config_value(config, "dem", "auto"))
     nadir_pitch_tolerance = number(config_value(config, "nadirPitchToleranceDeg", 15), 15)
     blend = str(config_value(config, "blend", "center"))
     workers = integer(config_value(config, "workers", 0), 0)
@@ -367,6 +370,8 @@ def main() -> int:
         str(output_dir),
         "--target-epsg",
         target_epsg,
+        "--dem",
+        dem,
         "--pixel-size",
         str(pixel_size),
         "--feather-px",

--- a/tests/unit/rapid-map-asset-metadata.test.ts
+++ b/tests/unit/rapid-map-asset-metadata.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAssetSetMetadataCsv,
+  RapidMapMetadataAsset,
+} from "@/lib/services/rapid-map-asset-metadata";
+
+function asset(
+  overrides: Partial<RapidMapMetadataAsset> & Pick<RapidMapMetadataAsset, "id" | "fileName" | "s3Key">
+): RapidMapMetadataAsset {
+  return {
+    metadata: null,
+    gpsLatitude: -27,
+    gpsLongitude: 153,
+    altitude: 100,
+    gimbalRoll: null,
+    gimbalPitch: null,
+    gimbalYaw: null,
+    imageWidth: null,
+    imageHeight: null,
+    ...overrides,
+  };
+}
+
+describe("buildAssetSetMetadataCsv", () => {
+  it("writes runner-compatible rows and reports assets missing required GPS metadata", () => {
+    const result = buildAssetSetMetadataCsv([
+      asset({
+        id: "asset-1",
+        fileName: "IMG_001.JPG",
+        s3Key: "teams/team-1/IMG_001.JPG",
+        metadata: { RelativeAltitude: 80, FlightYawDegree: 42 },
+        gimbalYaw: 43,
+        gimbalPitch: -90,
+        gimbalRoll: 0,
+        imageWidth: 5472,
+        imageHeight: 3648,
+      }),
+      asset({
+        id: "asset-2",
+        fileName: "IMG_002.JPG",
+        s3Key: "teams/team-1/IMG_002.JPG",
+        gpsLatitude: -27.1,
+        gpsLongitude: 153.1,
+        altitude: 111,
+        gimbalYaw: -178,
+        gimbalPitch: -89.5,
+        gimbalRoll: 0.2,
+        imageWidth: 4000,
+        imageHeight: 3000,
+      }),
+      asset({
+        id: "asset-3",
+        fileName: "IMG_003.JPG",
+        s3Key: "teams/team-1/IMG_003.JPG",
+        gpsLongitude: null,
+      }),
+    ]);
+
+    expect(result.csv).toBe(
+      [
+        "filename,lat,lon,AbsoluteAltitude,RelativeAltitude,FlightYawDegree,GimbalYawDegree,GimbalPitchDegree,GimbalRollDegree,ImageWidth,ImageLength",
+        "IMG_001.JPG,-27,153,100,80,42,43,-90,0,5472,3648",
+        "IMG_002.JPG,-27.1,153.1,111,,,-178,-89.5,0.2,4000,3000",
+        "",
+      ].join("\n")
+    );
+    expect(result.assetObjects).toEqual([
+      { s3Key: "teams/team-1/IMG_001.JPG", filename: "IMG_001.JPG" },
+      { s3Key: "teams/team-1/IMG_002.JPG", filename: "IMG_002.JPG" },
+    ]);
+    expect(result.excludedAssets).toEqual([
+      {
+        id: "asset-3",
+        fileName: "IMG_003.JPG",
+        missingFields: ["gpsLongitude"],
+      },
+    ]);
+  });
+});

--- a/tests/unit/rapid-map-source-path.test.ts
+++ b/tests/unit/rapid-map-source-path.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { assertRapidMapProjectS3Prefix } from "@/lib/services/rapid-map-source-path";
+import { S3Service } from "@/lib/services/s3";
+
+describe("assertRapidMapProjectS3Prefix", () => {
+  const projectId = "project-123";
+  const projectPrefix = `${S3Service.environmentSegment}/${projectId}/`;
+
+  it("accepts source folders within the selected project", () => {
+    expect(() =>
+      assertRapidMapProjectS3Prefix(
+        `${projectPrefix}raw-images/flight-1`,
+        projectId
+      )
+    ).not.toThrow();
+  });
+
+  it("rejects sibling projects and project-id prefix collisions", () => {
+    expect(() =>
+      assertRapidMapProjectS3Prefix(
+        `${S3Service.environmentSegment}/other-project/raw-images/flight-1`,
+        projectId
+      )
+    ).toThrow(/current project prefix/);
+
+    expect(() =>
+      assertRapidMapProjectS3Prefix(
+        `${S3Service.environmentSegment}/${projectId}-other/raw-images/flight-1`,
+        projectId
+      )
+    ).toThrow(/current project prefix/);
+  });
+});

--- a/workers/rapid-map-worker.ts
+++ b/workers/rapid-map-worker.ts
@@ -1,0 +1,71 @@
+import { Job, Worker } from "bullmq";
+import { createRedisConnection, QUEUE_PREFIX } from "../lib/queue/redis";
+import {
+  RAPID_MAP_QUEUE_NAME,
+  RapidMapJobData,
+  RapidMapJobResult,
+} from "../lib/queue/rapid-map-queue";
+import { processRapidMapRun } from "../lib/services/rapid-map";
+
+async function handleRapidMapJob(
+  job: Job<RapidMapJobData>
+): Promise<RapidMapJobResult> {
+  return processRapidMapRun(job.data.runId, {
+    reportProgress: (progress) => job.updateProgress(progress),
+  });
+}
+
+async function startWorker() {
+  console.log("[RapidMapWorker] Starting Rapid Map worker...");
+
+  const redisConnection = createRedisConnection();
+  redisConnection.on("error", (error) => {
+    console.error("[RapidMapWorker] Redis connection error:", error.message);
+  });
+  redisConnection.on("close", () => {
+    console.warn("[RapidMapWorker] Redis connection closed");
+  });
+  redisConnection.on("reconnecting", () => {
+    console.log("[RapidMapWorker] Reconnecting to Redis...");
+  });
+
+  try {
+    await redisConnection.ping();
+    console.log("[RapidMapWorker] Redis connection established");
+  } catch (error) {
+    console.error("[RapidMapWorker] Failed to connect to Redis:", error);
+    process.exit(1);
+  }
+
+  const concurrency = Number(process.env.RAPID_MAP_WORKER_CONCURRENCY || 1);
+  const worker = new Worker<RapidMapJobData, RapidMapJobResult>(
+    RAPID_MAP_QUEUE_NAME,
+    async (job) => handleRapidMapJob(job),
+    {
+      connection: redisConnection,
+      prefix: QUEUE_PREFIX,
+      concurrency,
+    }
+  );
+
+  worker.on("completed", (job, result) => {
+    console.log("[RapidMapWorker] Job completed:", {
+      jobId: job.id,
+      runId: result.runId,
+      orthomosaicId: result.orthomosaicId,
+      artifactCount: result.artifactCount,
+    });
+  });
+
+  worker.on("failed", (job, error) => {
+    console.error(
+      `[RapidMapWorker] Job ${job?.id || "unknown"} failed:`,
+      error.message
+    );
+  });
+}
+
+startWorker().catch((error) => {
+  console.error("[RapidMapWorker] Fatal error:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Integrates the flat-map-runner improvements (nationaldronesau/flat-map-runner#1) into the Rapid Map worker, and completes the ASSET_SET source type. Replaces the stale `codex/rapid-map-worker` branch — this branch is cut from current `main` with the salvaged rapid-map feature cherry-picked on top, then the integration work applied.

flat-map-runner#1 is merged, and `FLAT_MAP_RUNNER_REF` is pinned to merge commit `f81a6c8a1f815a6d824a31e7053d6a556fad9a95`.

### Changes
- **Runner ref + flags**: adapter passes `--blend center`, `--cog`, `--workers`, `--max-offset-km`, `--max-raster-px`, orientation/yaw-offset passthroughs; presets switch to `targetEpsg: "auto"` (derived from image GPS — removes the hardcoded zone-56S assumption).
- **ASSET_SET implemented end-to-end**: `metadata.csv` generated from Asset EXIF fields already in the DB (`lib/services/rapid-map-asset-metadata.ts`, pure + unit-tested), team-scoped asset resolution with cross-tenant guard, fail-fast validation at POST time (400 with per-asset missing-field detail), per-asset S3 download in the adapter with basename/duplicate checks.
- **Honest counters**: `sourceImageCount`, `renderedImageCount`, `excludedImageCount`, GPS outliers, pitch-filtered count, effective resolution, and per-image skip reasons now come from the runner's real manifests; pitch-filtered inputs remain part of the source total.
- **Source isolation**: S3 prefix runs are limited to the selected project's current environment prefix in both the API and worker.
- **Hygiene**: processingLog appends instead of overwriting in the POST route; queue retries (attempts 2, exponential backoff — safe, worker short-circuits COMPLETED runs); runner stdout streamed for stage progress 30→70 with the 20 MB cap and timeout preserved.
- **Worker runtime**: `tsx` is a production dependency so the production-only worker install can start the TypeScript worker.

### Validation
- `npm run lint` — pass (only existing unrelated warnings)
- `npm run test:unit` — 149 tests pass
- `npm run build` — pass
- focused Rapid Map ESLint and unit tests — pass
- `py_compile` clean on the adapter
- synthetic runner smoke independently verified yaw fallback, auto UTM, outlier rejection, center blending, parallel warp, and JPEG-compressed COG output
- production-only dependency install contains runnable `tsx v4.21.0`
- Underlying runner changes validated offline on HQP test-site datasets 015 (999 images) and 016 (874 images) — see flat-map-runner#1 for the evidence table
- Not yet run: Docker image build and dev-stack e2e

Implemented by Codex CLI from a frozen spec; reviewed and verified by Claude, then merge-gate reviewed and corrected by Codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gr7S6StNXBwz3jsvFQ8cBK