### PR TITLE
Adaptive vegetation gate + candidates_only apply path

### DIFF
--- a/lib/services/aws-sam3.ts
+++ b/lib/services/aws-sam3.ts
@@ -318,6 +318,7 @@ export interface SAM3ConceptApplyOptions {
   sizeFilterMinRatio?: number;
   sizeFilterMaxRatio?: number;
   embeddingBackend?: string;
+  candidatesOnly?: boolean;
 }
 
 export interface SAM3ConceptApplyResponse {
@@ -1789,6 +1790,9 @@ class AWSSAM3Service {
       }
       if (request.options?.embeddingBackend) {
         payload.embedding_backend = request.options.embeddingBackend;
+      }
+      if (request.options?.candidatesOnly === true) {
+        payload.candidates_only = true;
       }
 
       const sendRequest = (embeddingBackend = request.options?.embeddingBackend) =>

--- a/lib/services/sam3-batch-v2.ts
+++ b/lib/services/sam3-batch-v2.ts
@@ -40,13 +40,35 @@ export const SAM3_BATCH_V2_GPU_LOCK_RETRY_INTERVAL_MS = 5000;
 export const SAM3_BATCH_V2_GPU_LOCK_RETRY_TIMEOUT_MS = 60000;
 export const SAM3_BATCH_V2_GPU_MEMORY_THRESHOLD_MB = 12 * 1024;
 export const SAM3_BATCH_V2_MODEL_OVERHEAD_MB = 4096;
-export const SAM3_BATCH_V2_VEGETATION_FLOOR = 0.15;
+export const SAM3_VEGETATION_DISABLE_BELOW = 0.05;
+export const SAM3_VEGETATION_CLAMP = [0.05, 0.4] as const;
 export const SAM3_BATCH_V2_VEGETATION_ALARM_MEDIAN = 0.3;
 export const SAM3_BATCH_V2_INSTANCE_REFINEMENT_CHUNK_SIZE = 200;
 export const SAM3_BATCH_V2_DEFAULT_CANDIDATE_BUDGET = 400;
 export const SAM3_BATCH_V2_DEFAULT_RETRIEVAL_BACKEND = 'dinov3_vitl16_sat';
 
 export type Sam3BatchV2RefineMode = 'instances' | 'concept';
+export type Sam3BatchV2VegetationMode = 'active' | 'disabled_low_exemplar_green';
+
+export function resolveBatchV2VegetationGate(exemplarGreenMedian: number): {
+  mode: Sam3BatchV2VegetationMode;
+  threshold: number | null;
+} {
+  if (exemplarGreenMedian < SAM3_VEGETATION_DISABLE_BELOW) {
+    return {
+      mode: 'disabled_low_exemplar_green',
+      threshold: null,
+    };
+  }
+
+  return {
+    mode: 'active',
+    threshold: Math.min(
+      SAM3_VEGETATION_CLAMP[1],
+      Math.max(SAM3_VEGETATION_CLAMP[0], 0.5 * exemplarGreenMedian)
+    ),
+  };
+}
 
 export function resolveBatchV2RefineMode(
   value: string | undefined = process.env.SAM3_REFINE_MODE
@@ -205,6 +227,7 @@ export function buildBatchV2ConceptApplyOptions(
           sizeFilterMinRatio: 0.2,
           sizeFilterMaxRatio: 2.5,
           embeddingBackend: resolveBatchV2RetrievalBackend(refineMode),
+          candidatesOnly: true,
         }
       : {}),
   };
@@ -234,6 +257,7 @@ export function buildBatchV2ConceptFallbackApplyOptions(
           sizeFilterMinRatio: 0.2,
           sizeFilterMaxRatio: 2.5,
           embeddingBackend: resolveBatchV2RetrievalBackend(refineMode),
+          candidatesOnly: true,
         }
       : {}),
   };
@@ -337,7 +361,8 @@ export interface Sam3BatchV2StageLogEntry {
   refineIncompleteChunks?: number;
   vegetationPrior?: boolean;
   exemplarGreenMedian?: number;
-  vegetationThreshold?: number;
+  vegetationMode?: Sam3BatchV2VegetationMode;
+  vegetationThreshold?: number | null;
   vegetationGatedCandidates?: number;
   vegetationRecenteredCandidates?: number;
   vegetationGatedMasks?: number;
@@ -551,6 +576,8 @@ interface PreparedBatchContext {
   operatorCropCount: number;
   vegetationPrior: boolean;
   exemplarGreenMedian: number;
+  vegetationMode?: Sam3BatchV2VegetationMode;
+  vegetationThreshold: number | null;
   exemplarDiameter: number;
 }
 
@@ -577,7 +604,8 @@ interface AssetInferenceResult {
   refineRefinedInstances?: number;
   refineRejectedInstances?: number;
   refineIncompleteChunks?: number;
-  vegetationThreshold?: number;
+  vegetationMode?: Sam3BatchV2VegetationMode;
+  vegetationThreshold?: number | null;
   vegetationGatedCandidates?: number;
   vegetationRecenteredCandidates?: number;
   vegetationGatedMasks?: number;
@@ -598,7 +626,8 @@ interface ConceptRefinementResult {
   refineRefinedInstances?: number;
   refineRejectedInstances?: number;
   refineIncompleteChunks?: number;
-  vegetationThreshold?: number;
+  vegetationMode?: Sam3BatchV2VegetationMode;
+  vegetationThreshold?: number | null;
   vegetationGatedCandidates?: number;
   vegetationRecenteredCandidates?: number;
   vegetationGatedMasks?: number;
@@ -614,6 +643,35 @@ interface VegetationPriorContext {
   enabled: boolean;
   exemplarGreenMedian: number;
   exemplarDiameter?: number;
+  mode?: Sam3BatchV2VegetationMode;
+  threshold?: number | null;
+}
+
+function normalizeVegetationPriorContext(
+  vegetation?: VegetationPriorContext
+): VegetationPriorContext | undefined {
+  if (!vegetation) return undefined;
+  if (!vegetation.enabled && !vegetation.mode) {
+    return { ...vegetation, threshold: null };
+  }
+
+  const gate = vegetation.mode
+    ? {
+        mode: vegetation.mode,
+        threshold:
+          vegetation.mode === 'disabled_low_exemplar_green'
+            ? null
+            : vegetation.threshold ??
+              resolveBatchV2VegetationGate(vegetation.exemplarGreenMedian).threshold,
+      }
+    : resolveBatchV2VegetationGate(vegetation.exemplarGreenMedian);
+
+  return {
+    ...vegetation,
+    enabled: vegetation.enabled && gate.mode === 'active',
+    mode: gate.mode,
+    threshold: gate.threshold,
+  };
 }
 
 interface VegetationCandidateResult {
@@ -1356,7 +1414,7 @@ export class Sam3BatchV2Service {
   private async applyVegetationPriorToCandidates(
     imageBuffer: Buffer,
     candidates: SAM3ConceptDetection[],
-    exemplarGreenMedian: number
+    threshold: number
   ): Promise<VegetationCandidateResult> {
     const metadata = await sharp(imageBuffer).metadata();
     const imageWidth = metadata.width ?? 0;
@@ -1369,10 +1427,6 @@ export class Sam3BatchV2Service {
       );
     }
 
-    const threshold = Math.max(
-      SAM3_BATCH_V2_VEGETATION_FLOOR,
-      0.5 * exemplarGreenMedian
-    );
     const surviving: SAM3ConceptDetection[] = [];
     const promptPoints = new Map<SAM3ConceptDetection, [number, number]>();
     let recenteredCount = 0;
@@ -1748,6 +1802,15 @@ export class Sam3BatchV2Service {
           data.exemplarSourceHeight
         )
       : 0;
+    const vegetationGate = vegetationPrior
+      ? resolveBatchV2VegetationGate(exemplarGreenMedian)
+      : undefined;
+    if (vegetationGate?.mode === 'disabled_low_exemplar_green') {
+      console.info(
+        `vegetation gate disabled: exemplar median green=${exemplarGreenMedian} ` +
+          `< ${SAM3_VEGETATION_DISABLE_BELOW}`
+      );
+    }
     const normalizedCrops = normalizeExemplarCrops(data.exemplarCrops);
     let exemplarCrops = normalizedCrops;
     let visualCropSource: Sam3BatchV2StageLogEntry['visualCropSource'] | undefined =
@@ -1803,7 +1866,14 @@ export class Sam3BatchV2Service {
       operatorCropCount: data.mode === 'visual_crop_match' ? normalizedCrops.length : 0,
       modeUsed: data.mode === 'visual_crop_match' ? 'visual_crops' : 'concept_propagation',
       visualCropSource,
-      ...(vegetationPrior ? { vegetationPrior, exemplarGreenMedian } : {}),
+      ...(vegetationPrior
+        ? {
+            vegetationPrior,
+            exemplarGreenMedian,
+            vegetationMode: vegetationGate?.mode,
+            vegetationThreshold: vegetationGate?.threshold,
+          }
+        : {}),
       durationMs: this.now().getTime() - startedAt,
     });
 
@@ -1827,6 +1897,8 @@ export class Sam3BatchV2Service {
       operatorCropCount: data.mode === 'visual_crop_match' ? normalizedCrops.length : 0,
       vegetationPrior,
       exemplarGreenMedian,
+      vegetationMode: vegetationGate?.mode,
+      vegetationThreshold: vegetationGate?.threshold ?? null,
       exemplarDiameter: medianBoxDiameter(data.exemplars),
     };
   }
@@ -2145,9 +2217,12 @@ export class Sam3BatchV2Service {
             conceptExemplars,
             prepared.weedType,
             {
-              enabled: prepared.vegetationPrior,
+              enabled:
+                prepared.vegetationPrior && prepared.vegetationMode === 'active',
               exemplarGreenMedian: prepared.exemplarGreenMedian,
               exemplarDiameter: prepared.exemplarDiameter,
+              mode: prepared.vegetationMode,
+              threshold: prepared.vegetationThreshold,
             }
           );
         }
@@ -2183,6 +2258,7 @@ export class Sam3BatchV2Service {
           refineRefinedInstances: result.refineRefinedInstances,
           refineRejectedInstances: result.refineRejectedInstances,
           refineIncompleteChunks: result.refineIncompleteChunks,
+          vegetationMode: result.vegetationMode,
           vegetationThreshold: result.vegetationThreshold,
           vegetationGatedCandidates: result.vegetationGatedCandidates,
           vegetationRecenteredCandidates: result.vegetationRecenteredCandidates,
@@ -2425,6 +2501,7 @@ export class Sam3BatchV2Service {
       refineRefinedInstances: refinement.refineRefinedInstances,
       refineRejectedInstances: refinement.refineRejectedInstances,
       refineIncompleteChunks: refinement.refineIncompleteChunks,
+      vegetationMode: refinement.vegetationMode,
       vegetationThreshold: refinement.vegetationThreshold,
       vegetationGatedCandidates: refinement.vegetationGatedCandidates,
       vegetationRecenteredCandidates: refinement.vegetationRecenteredCandidates,
@@ -2538,6 +2615,7 @@ export class Sam3BatchV2Service {
       refineRefinedInstances: refinement.refineRefinedInstances,
       refineRejectedInstances: refinement.refineRejectedInstances,
       refineIncompleteChunks: refinement.refineIncompleteChunks,
+      vegetationMode: refinement.vegetationMode,
       vegetationThreshold: refinement.vegetationThreshold,
       vegetationGatedCandidates: refinement.vegetationGatedCandidates,
       vegetationRecenteredCandidates: refinement.vegetationRecenteredCandidates,
@@ -2761,24 +2839,42 @@ export class Sam3BatchV2Service {
     candidateBudget?: number
   ): Promise<ConceptRefinementResult> {
     const refinementMode = resolveBatchV2RefineMode();
+    const normalizedVegetation = normalizeVegetationPriorContext(vegetation);
     const result = refinementMode === 'instances'
       ? await this.refineConceptDetectionsWithInstances(
           asset,
           imageBuffer,
           candidates,
-          vegetation
+          normalizedVegetation
         )
       : await this.refineConceptDetectionsWithLegacyBoxPrompts(
           asset,
           imageBuffer,
           className,
           candidates,
-          vegetation
+          normalizedVegetation
         );
+
+    const disabledLowGreen =
+      normalizedVegetation?.mode === 'disabled_low_exemplar_green';
 
     return {
       ...result,
       refinementMode,
+      ...(normalizedVegetation?.mode
+        ? {
+            vegetationMode: normalizedVegetation.mode,
+            vegetationThreshold: normalizedVegetation.threshold ?? null,
+          }
+        : {}),
+      ...(disabledLowGreen
+        ? {
+            vegetationGatedCandidates: 0,
+            vegetationRecenteredCandidates: 0,
+            vegetationGatedMasks: 0,
+            vegetationDeduplicatedMasks: 0,
+          }
+        : {}),
       candidateBudget: candidateBudget ?? (
         refinementMode === 'instances'
           ? resolveBatchV2CandidateBudget()
@@ -2819,7 +2915,7 @@ export class Sam3BatchV2Service {
       ? await this.applyVegetationPriorToCandidates(
           imageBuffer,
           candidates,
-          vegetation.exemplarGreenMedian
+          vegetation.threshold as number
         )
       : undefined;
     const refinementCandidates = vegetationCandidates?.candidates ?? candidates;
@@ -3079,7 +3175,7 @@ export class Sam3BatchV2Service {
       ? await this.applyVegetationPriorToCandidates(
           imageBuffer,
           candidates,
-          vegetation.exemplarGreenMedian
+          vegetation.threshold as number
         )
       : undefined;
     const refinementCandidates = vegetationCandidates?.candidates ?? candidates;

--- a/tests/unit/sam3-batch-v2.test.ts
+++ b/tests/unit/sam3-batch-v2.test.ts
@@ -12,6 +12,7 @@ import {
   resolveBatchV2CandidateBudget,
   resolveBatchV2RefineMode,
   resolveBatchV2RetrievalBackend,
+  resolveBatchV2VegetationGate,
   resolveBatchV2VegetationPrior,
   resolveBatchV2ReviewProfileForMode,
   Sam3BatchV2Service,
@@ -208,6 +209,25 @@ describe('sam3-batch-v2', () => {
     expect(resolveBatchV2VegetationPrior(true, 'false')).toBe(false);
   });
 
+  it('disables or clamps the adaptive vegetation gate from exemplar green', () => {
+    expect(resolveBatchV2VegetationGate(0)).toEqual({
+      mode: 'disabled_low_exemplar_green',
+      threshold: null,
+    });
+    expect(resolveBatchV2VegetationGate(0.6)).toEqual({
+      mode: 'active',
+      threshold: 0.3,
+    });
+    expect(resolveBatchV2VegetationGate(0.9)).toEqual({
+      mode: 'active',
+      threshold: 0.4,
+    });
+    expect(resolveBatchV2VegetationGate(0.12)).toEqual({
+      mode: 'active',
+      threshold: 0.06,
+    });
+  });
+
   it('defaults instance mode to a 400-candidate satellite-retrieval budget', () => {
     delete process.env.SAM3_REFINE_MODE;
 
@@ -219,6 +239,7 @@ describe('sam3-batch-v2', () => {
       sizeFilterMinRatio: 0.2,
       sizeFilterMaxRatio: 2.5,
       embeddingBackend: 'dinov3_vitl16_sat',
+      candidatesOnly: true,
     });
     expect(getBatchV2MinTargetCandidates('high_recall')).toBe(400);
     expect(getBatchV2MaxTargetCandidates('high_recall')).toBe(400);
@@ -676,6 +697,7 @@ describe('sam3-batch-v2', () => {
       expect(global.fetch).toHaveBeenCalledOnce();
       const requestBody = (global.fetch as any).mock.calls[0][1].body;
       const payload = JSON.parse(requestBody);
+      expect(payload).not.toHaveProperty('candidates_only');
       expect(requestBody).toBe(JSON.stringify({
         exemplar_id: 'legacy-exemplar',
         images: [payload.images[0]],
@@ -687,6 +709,40 @@ describe('sam3-batch-v2', () => {
         max_box_size: 600,
         nms_threshold: 0.5,
       }));
+    } finally {
+      singleton.configured = previous.configured;
+      singleton.instanceIp = previous.instanceIp;
+      singleton.instanceState = previous.instanceState;
+    }
+  });
+
+  it('sends candidates_only only for instance-mode concept apply requests', async () => {
+    process.env.SAM3_REFINE_MODE = 'instances';
+    const image = await makeVegetationImage(10, 10, []);
+    const singleton = awsSam3Service as any;
+    const previous = {
+      configured: singleton.configured,
+      instanceIp: singleton.instanceIp,
+      instanceState: singleton.instanceState,
+    };
+    singleton.configured = true;
+    singleton.instanceIp = '127.0.0.1';
+    singleton.instanceState = 'ready';
+    global.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      results: [{ detections: [] }],
+      processing_time_ms: 4,
+    }), { status: 200, headers: { 'content-type': 'application/json' } })) as typeof fetch;
+
+    try {
+      await awsSam3Service.applyConceptExemplar({
+        exemplarId: 'candidate-exemplar',
+        imageBuffer: image,
+        imageId: 'candidate-image',
+        options: buildBatchV2ConceptApplyOptions('high_recall'),
+      });
+
+      const payload = JSON.parse((global.fetch as any).mock.calls[0][1].body);
+      expect(payload.candidates_only).toBe(true);
     } finally {
       singleton.configured = previous.configured;
       singleton.instanceIp = previous.instanceIp;
@@ -733,6 +789,56 @@ describe('sam3-batch-v2', () => {
       forward.detections.map((detection: any) => detection.bbox)
     );
   });
+
+  it.each([
+    { refineMode: 'instances', expectedWarmups: 1 },
+    { refineMode: 'concept', expectedWarmups: 1 },
+  ] as const)(
+    'calls legacy concept warmup $expectedWarmups time(s) in $refineMode mode',
+    async ({ refineMode, expectedWarmups }) => {
+      process.env.SAM3_REFINE_MODE = refineMode;
+      const warmupConceptService = vi.fn().mockResolvedValue({
+        success: true,
+        data: { sam3Loaded: true, dinoLoaded: true },
+      });
+      const service = new Sam3BatchV2Service({
+        prisma: {
+          batchJob: {
+            update: vi.fn().mockResolvedValue(undefined),
+          },
+        } as never,
+        awsSam3Service: { warmupConceptService } as never,
+        acquireGpuLock: vi.fn(),
+        refreshGpuLock: vi.fn(),
+        releaseGpuLock: vi.fn(),
+        sleep: vi.fn(),
+        now: () => new Date('2026-07-21T00:00:00.000Z'),
+      });
+      vi.spyOn(service as any, 'appendStageLog').mockResolvedValue(undefined);
+      const createConceptExemplarEnsemble = vi
+        .spyOn(service as any, 'createConceptExemplarEnsemble')
+        .mockResolvedValue([{ exemplarId: 'exemplar-1', sourceBoxIndex: 0 }]);
+
+      const result = await (service as any).runAndPersistBatch(
+        { updateProgress: vi.fn().mockResolvedValue(undefined) },
+        {
+          batchJobId: `batch-warmup-${refineMode}`,
+          parentBatchJobId: null,
+          mode: 'concept_propagation',
+          weedType: 'Lantana',
+          sourceAssetId: 'asset-source',
+          assets: [],
+          missingAssetIds: [],
+        },
+        0,
+        []
+      );
+
+      expect(result).toEqual([]);
+      expect(warmupConceptService).toHaveBeenCalledTimes(expectedWarmups);
+      expect(createConceptExemplarEnsemble).toHaveBeenCalledOnce();
+    }
+  );
 
   it('retries a 400 retrieval-backend mismatch with dinov2 and returns a stage-log warning', async () => {
     const image = await makeVegetationImage(10, 10, []);
@@ -915,6 +1021,7 @@ describe('sam3-batch-v2', () => {
       candidateCount: 2,
       refinementBoxCount: 1,
       refinementDetectionCount: 2,
+      vegetationMode: 'active',
       vegetationThreshold: 0.4,
       vegetationGatedCandidates: 1,
       vegetationRecenteredCandidates: 1,
@@ -924,6 +1031,72 @@ describe('sam3-batch-v2', () => {
     });
     expect(result.detections).toHaveLength(1);
     expect(result.detections[0].polygon).toEqual([[16, 0], [40, 0], [40, 40], [16, 40]]);
+  });
+
+  it('disables all vegetation processing for low-green exemplars without dropping candidates', async () => {
+    const candidates = [
+      { bbox: [0, 0, 20, 20], confidence: 0.8, similarity: 0.8, class_name: 'lantana' },
+      { bbox: [30, 0, 50, 20], confidence: 0.7, similarity: 0.7, class_name: 'lantana' },
+    ];
+    const segment = vi.fn().mockResolvedValue({
+      success: true,
+      response: {
+        detections: candidates.map((candidate) => ({
+          bbox: candidate.bbox,
+          confidence: candidate.confidence,
+          polygon: [
+            [candidate.bbox[0], candidate.bbox[1]],
+            [candidate.bbox[2], candidate.bbox[1]],
+            [candidate.bbox[2], candidate.bbox[3]],
+            [candidate.bbox[0], candidate.bbox[3]],
+          ],
+        })),
+        count: candidates.length,
+      },
+    });
+    const service = new Sam3BatchV2Service({
+      prisma: {} as never,
+      awsSam3Service: {
+        refreshStatus: vi.fn().mockResolvedValue({
+          modelLoaded: true,
+          instanceState: 'ready',
+          ipAddress: '127.0.0.1',
+        }),
+        isReady: vi.fn().mockReturnValue(true),
+        resizeImage: vi.fn().mockImplementation(async (buffer: Buffer) => ({
+          buffer,
+          scaling: { scaleFactor: 1 },
+        })),
+        segment,
+      } as any,
+      acquireGpuLock: vi.fn(),
+      refreshGpuLock: vi.fn(),
+      releaseGpuLock: vi.fn(),
+      sleep: vi.fn(),
+      now: () => new Date('2026-07-21T00:00:00.000Z'),
+    });
+
+    const result = await (service as any).refineConceptDetectionsWithBoxPrompts(
+      { id: 'asset-low-exemplar-green', imageWidth: 60, imageHeight: 20 },
+      Buffer.from('not-an-image-because-vegetation-processing-must-not-run'),
+      'Lantana',
+      candidates,
+      { enabled: true, exemplarGreenMedian: 0 }
+    );
+
+    expect(segment.mock.calls[0][0].boxes).toEqual([
+      { x1: 0, y1: 0, x2: 20, y2: 20 },
+      { x1: 30, y1: 0, x2: 50, y2: 20 },
+    ]);
+    expect(result.detections).toHaveLength(2);
+    expect(result).toMatchObject({
+      vegetationMode: 'disabled_low_exemplar_green',
+      vegetationThreshold: null,
+      vegetationGatedCandidates: 0,
+      vegetationRecenteredCandidates: 0,
+      vegetationGatedMasks: 0,
+      vegetationDeduplicatedMasks: 0,
+    });
   });
 
   it('deduplicates overlapping green masks and keeps the higher-confidence detection', async () => {
@@ -1108,12 +1281,100 @@ describe('sam3-batch-v2', () => {
     );
 
     expect(prepared.exemplarGreenMedian).toBe(1);
+    expect(prepared.vegetationMode).toBe('active');
+    expect(prepared.vegetationThreshold).toBe(0.4);
     expect(persistedStageLog).toEqual(expect.arrayContaining([
       expect.objectContaining({
         stage: 'prepare',
         status: 'completed',
         vegetationPrior: true,
         exemplarGreenMedian: 1,
+        vegetationMode: 'active',
+        vegetationThreshold: 0.4,
+      }),
+    ]));
+  });
+
+  it('logs once and records disabled telemetry when exemplar greens are below 0.05', async () => {
+    const image = await makeVegetationImage(30, 10, [
+      { left: 20, top: 0, width: 1, height: 1 },
+    ]);
+    global.fetch = vi.fn().mockResolvedValue(new Response(image, {
+      status: 200,
+      headers: {
+        'content-type': 'image/png',
+        'content-length': String(image.length),
+      },
+    })) as typeof fetch;
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    let persistedStageLog: unknown[] = [];
+    const service = new Sam3BatchV2Service({
+      prisma: {
+        batchJob: {
+          findUnique: vi.fn().mockResolvedValue({
+            parentBatchJobId: null,
+            sourceAssetId: 'asset-source-low-green',
+          }),
+          update: vi.fn().mockImplementation(async ({ data }) => {
+            if (data.stageLog) persistedStageLog = data.stageLog;
+          }),
+        },
+        asset: {
+          findMany: vi.fn().mockResolvedValue([{
+            id: 'asset-source-low-green',
+            storageUrl: 'http://localhost/source-low-green.png',
+            s3Key: null,
+            s3Bucket: null,
+            storageType: 'local',
+            imageWidth: 30,
+            imageHeight: 10,
+          }]),
+          findUnique: vi.fn(),
+        },
+      } as any,
+      awsSam3Service: {} as never,
+      acquireGpuLock: vi.fn(),
+      refreshGpuLock: vi.fn(),
+      releaseGpuLock: vi.fn(),
+      sleep: vi.fn(),
+      now: () => new Date('2026-07-21T00:00:00.000Z'),
+    });
+
+    const prepared = await (service as any).prepareBatch(
+      {
+        batchJobId: 'batch-low-green-calibration',
+        projectId: 'project-1',
+        weedType: 'Lantana',
+        mode: 'concept_propagation',
+        exemplars: [
+          { x1: 0, y1: 0, x2: 10, y2: 10 },
+          { x1: 10, y1: 0, x2: 20, y2: 10 },
+          { x1: 20, y1: 0, x2: 30, y2: 10 },
+        ],
+        exemplarSourceWidth: 30,
+        exemplarSourceHeight: 10,
+        sourceAssetId: 'asset-source-low-green',
+        assetIds: ['asset-source-low-green'],
+        vegetationPrior: true,
+      },
+      0,
+      []
+    );
+
+    expect(prepared.exemplarGreenMedian).toBe(0);
+    expect(prepared.vegetationMode).toBe('disabled_low_exemplar_green');
+    expect(prepared.vegetationThreshold).toBeNull();
+    expect(info).toHaveBeenCalledTimes(1);
+    expect(info).toHaveBeenCalledWith(
+      'vegetation gate disabled: exemplar median green=0 < 0.05'
+    );
+    expect(persistedStageLog).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        stage: 'prepare',
+        status: 'completed',
+        exemplarGreenMedian: 0,
+        vegetationMode: 'disabled_low_exemplar_green',
+        vegetationThreshold: null,
       }),
     ]));
   });


### PR DESCRIPTION
## Summary
- Vegetation gate fully exemplar-calibrated: auto-disables when exemplar median green < 0.05 (Lantana ExG ≈ 0), else 0.5×median clamped [0.05, 0.4]. Removes the 0.15 absolute floor that cost 0.54 recall on the Lantana human-label bench (gate ON 0.006 vs OFF 0.546).
- Telemetry: `vegetationMode` (`active` | `disabled_low_exemplar_green`) + effective threshold.
- Instances mode sends `candidates_only=true` on apply_exemplar — server skips redundant SAM3 refine+NMS (client re-refines via /refine_instances). Concept-mode payload untouched for rollback parity.

## Test plan
- `npx vitest run` — 154/154 pass, incl. new gate acceptance cases (0.0→disabled, 0.6→0.3, 0.9→0.4 clamp, 0.12→0.06 no floor) and candidates_only wiring (instances-only, absent in concept mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpR9N8CwVKJpZUjxvfjEZy